### PR TITLE
update form input styles to override native styling

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -432,6 +432,10 @@ h2 {
 }
 
 .form-group input[type="text"], .form-group input[type="date"], .form-group textarea {
+    appearance: none;
+    box-sizing: border-box;
+    min-height: 2.75rem;
+    color: var(--charcoal);
     width: 100%;
     padding: 10px;
     border: 1px solid var(--charcoal);


### PR DESCRIPTION
Adds 4 additional properties to form-group inputs. This fixes the issue of the date picker input appearing larger than other form fields on iOS Safari 26.