### PR TITLE
Add filtering

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -400,6 +400,43 @@ nav a.active {
     gap: 8px;
     flex-shrink: 0;
 }
+.todo-toolbar {
+    display: flex;
+    gap: 24px;
+    margin-bottom: 24px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--pale-gray);
+}
+
+.toolbar-group {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+}
+
+.toolbar-group label {
+    font-family: var(--header-font);
+    font-size: 1.05rem;
+    font-weight: 400;
+    color: var(--charcoal);
+    white-space: nowrap;
+}
+
+.toolbar-group select {
+    appearance: none;
+    box-sizing: border-box;
+    min-height: 2.25rem;
+    color: var(--charcoal);
+    padding: 4px 28px 4px 10px;
+    border: 1px solid var(--pale-gray);
+    background: var(--white);
+    font-family: var(--body-font);
+    font-size: 0.95rem;
+    cursor: pointer;
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23999' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 8px center;
+}
 /**End Todo Page**/
 
 /* Select styling */

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -29,6 +29,24 @@
             <button class="btn-add" id="btn-add-task">Add Task</button>
         </div>
         
+        <div class="todo-toolbar">
+            <div class="toolbar-group">
+                <label for="filter-assignee">Assignee</label>
+                <select id="filter-assignee">
+                    <option value="all">All</option>
+                    <option value="unassigned">Unassigned</option>
+                </select>
+            </div>
+            <div class="toolbar-group">
+                <label for="sort-by">Sort</label>
+                <select id="sort-by">
+                    <option value="due-date">Due Date</option>
+                    <option value="newest">Newest First</option>
+                    <option value="assignee">Assignee</option>
+                </select>
+            </div>
+        </div>
+
         <div class="list-container" id="list-container">
             <div class="loading-state">Loading tasks...</div>
         </div>
@@ -86,6 +104,14 @@
             familyMembers.forEach(m => {
                 select.innerHTML += `<option value="${m.id}">${escapeHtml(m.name)}</option>`;
             });
+
+            const filter = document.getElementById('filter-assignee');
+            const currentValue = filter.value;
+            filter.innerHTML = '<option value="all">All</option><option value="unassigned">Unassigned</option>';
+            familyMembers.forEach(m => {
+                filter.innerHTML += `<option value="${m.id}">${escapeHtml(m.name)}</option>`;
+            });
+            filter.value = currentValue;
         }
 
         function getMemberById(id) {
@@ -126,16 +152,58 @@
             if (!response.ok) throw new Error('Failed to delete todo');
         }
 
+        // Filter & sort
+        function getFilteredSortedTodos() {
+            const filterValue = document.getElementById('filter-assignee').value;
+            const sortValue = document.getElementById('sort-by').value;
+
+            let filtered = todos;
+            if (filterValue === 'unassigned') {
+                filtered = todos.filter(t => !t.assigned_to);
+            } else if (filterValue !== 'all') {
+                const memberId = parseInt(filterValue);
+                filtered = todos.filter(t => t.assigned_to === memberId);
+            }
+
+            const sorted = [...filtered];
+            if (sortValue === 'due-date') {
+                sorted.sort((a, b) => {
+                    if (!a.due_date && !b.due_date) return 0;
+                    if (!a.due_date) return 1;
+                    if (!b.due_date) return -1;
+                    return a.due_date.localeCompare(b.due_date);
+                });
+            } else if (sortValue === 'assignee') {
+                sorted.sort((a, b) => {
+                    const nameA = a.assigned_to ? (getMemberById(a.assigned_to)?.name || '') : '';
+                    const nameB = b.assigned_to ? (getMemberById(b.assigned_to)?.name || '') : '';
+                    if (!nameA && !nameB) return 0;
+                    if (!nameA) return 1;
+                    if (!nameB) return -1;
+                    return nameA.localeCompare(nameB);
+                });
+            }
+            // 'newest' is the default order from the API (created_at DESC)
+
+            return sorted;
+        }
+
         // Render
         function renderTodos() {
             const container = document.getElementById('list-container');
-            
+            const visible = getFilteredSortedTodos();
+
             if (todos.length === 0) {
                 container.innerHTML = '<div class="empty-state">No tasks yet. Click "Add Task" to get started.</div>';
                 return;
             }
 
-            container.innerHTML = todos.map(todo => {
+            if (visible.length === 0) {
+                container.innerHTML = '<div class="empty-state">No tasks match the current filter.</div>';
+                return;
+            }
+
+            container.innerHTML = visible.map(todo => {
                 const dueDateHtml = todo.due_date ? formatDueDate(todo.due_date) : '';
                 const member = todo.assigned_to ? getMemberById(todo.assigned_to) : null;
                 const assigneeHtml = member
@@ -243,6 +311,8 @@
         // Event handlers
         document.getElementById('btn-add-task').addEventListener('click', openAddModal);
         document.getElementById('btn-cancel').addEventListener('click', closeModal);
+        document.getElementById('filter-assignee').addEventListener('change', renderTodos);
+        document.getElementById('sort-by').addEventListener('change', renderTodos);
         
         document.getElementById('modal-overlay').addEventListener('click', (e) => {
             if (e.target.id === 'modal-overlay') closeModal();


### PR DESCRIPTION
This pull request adds filtering and sorting functionality to the Todo page, allowing users to filter tasks by assignee and sort them by due date, newest first, or assignee. The changes include updates to both the UI and the underlying logic to support these features, as well as new styling for the toolbar.

**UI Enhancements:**

* Added a new toolbar (`.todo-toolbar`) above the task list with dropdowns for filtering by assignee (including "All", "Unassigned", and specific family members) and sorting tasks by due date, newest first, or assignee. (`templates/todo.html`, [templates/todo.htmlR32-R49](diffhunk://#diff-04741223287272cf37b220f13ce555af6fa768ba9a9664bed59479964add0c94R32-R49))
* Updated the toolbar and dropdown styles to match the application's design system. (`static/styles.css`, [static/styles.cssR403-R439](diffhunk://#diff-2339bc0791b9baa744347f95fa5d5010d723aba0623fd3b6b22b76a4a1583775R403-R439))

**Filtering and Sorting Logic:**

* Implemented the `getFilteredSortedTodos` function to filter tasks based on the selected assignee and sort them according to the selected criteria. The function handles edge cases such as tasks without due dates or assignees. (`templates/todo.html`, [templates/todo.htmlR155-R206](diffhunk://#diff-04741223287272cf37b220f13ce555af6fa768ba9a9664bed59479964add0c94R155-R206))
* Updated the rendering logic so that only the filtered and sorted tasks are displayed. If no tasks match the current filter, an appropriate empty state message is shown. (`templates/todo.html`, [templates/todo.htmlR155-R206](diffhunk://#diff-04741223287272cf37b220f13ce555af6fa768ba9a9664bed59479964add0c94R155-R206))
* Ensured the assignee filter dropdown is dynamically populated with the latest family members and preserves the user's current selection. (`templates/todo.html`, [templates/todo.htmlR107-R114](diffhunk://#diff-04741223287272cf37b220f13ce555af6fa768ba9a9664bed59479964add0c94R107-R114))

**Event Handling:**

* Added event listeners to the filter and sort dropdowns to re-render the task list whenever the user changes the selection. (`templates/todo.html`, [templates/todo.htmlR314-R315](diffhunk://#diff-04741223287272cf37b220f13ce555af6fa768ba9a9664bed59479964add0c94R314-R315))

This fixes https://github.com/pid1/rally/issues/15