### PR TITLE
Add recurring tasks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY templates/ templates/
 COPY migrate_add_due_date.py migrate_add_due_date.py
 COPY migrate_add_family_members.py migrate_add_family_members.py
 COPY migrate_add_settings.py migrate_add_settings.py
+COPY migrate_add_recurring_todos.py migrate_add_recurring_todos.py
 COPY run_migrations.py run_migrations.py
 COPY entrypoint.sh entrypoint.sh
 

--- a/migrate_add_recurring_todos.py
+++ b/migrate_add_recurring_todos.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Migration to add recurring_todos table and recurring_todo_id column to todos.
+
+Run this once to upgrade existing databases. Safe to run multiple times (idempotent).
+"""
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def migrate():
+    # Get database path from environment or use default
+    db_path = os.environ.get("RALLY_DB_PATH")
+
+    if not db_path:
+        # Try production path first, then development
+        prod_path = Path("/data/rally.db")
+        dev_path = Path(__file__).parent / "rally.db"
+        db_path = str(prod_path) if prod_path.exists() else str(dev_path)
+
+    db_path = Path(db_path)
+
+    if not db_path.exists():
+        print(f"✓ Database not found at {db_path}")
+        print("  No migration needed - database will be created with correct schema on first run.")
+        return True
+
+    print(f"Checking database at {db_path}...")
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    try:
+        # Step 1: Create recurring_todos table if it doesn't exist
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='recurring_todos'"
+        )
+        if cursor.fetchone():
+            print("✓ Migration: recurring_todos table already exists (idempotent check)")
+        else:
+            print("  Creating 'recurring_todos' table...")
+            cursor.execute("""
+                CREATE TABLE recurring_todos (
+                    id INTEGER PRIMARY KEY,
+                    title VARCHAR(200) NOT NULL,
+                    description TEXT,
+                    recurrence_type VARCHAR(20) NOT NULL,
+                    recurrence_day INTEGER,
+                    assigned_to INTEGER,
+                    has_due_date BOOLEAN DEFAULT 0 NOT NULL,
+                    active BOOLEAN DEFAULT 1 NOT NULL,
+                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            print("✓ Migration: recurring_todos table created")
+
+        # Step 2: Add recurring_todo_id column to todos if it doesn't exist
+        cursor.execute("PRAGMA table_info(todos)")
+        columns = [col[1] for col in cursor.fetchall()]
+
+        if "recurring_todo_id" in columns:
+            print("✓ Migration: todos.recurring_todo_id column already exists (idempotent check)")
+        else:
+            print("  Adding 'recurring_todo_id' column to todos table...")
+            cursor.execute("ALTER TABLE todos ADD COLUMN recurring_todo_id INTEGER")
+            print("✓ Migration: todos.recurring_todo_id column added")
+
+        conn.commit()
+        return True
+
+    except sqlite3.Error as e:
+        print(f"✗ Migration failed: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    success = migrate()
+    sys.exit(0 if success else 1)

--- a/run_migrations.py
+++ b/run_migrations.py
@@ -15,6 +15,7 @@ def run_migrations():
         from migrate_add_due_date import migrate as migrate_001_add_due_date
         from migrate_add_family_members import migrate as migrate_002_add_family_members
         from migrate_add_settings import migrate as migrate_003_add_settings
+        from migrate_add_recurring_todos import migrate as migrate_004_add_recurring_todos
     except ImportError as e:
         print(f"✗ Failed to import migrations: {e}")
         return False
@@ -24,6 +25,7 @@ def run_migrations():
         ("001_add_due_date", migrate_001_add_due_date),
         ("002_add_family_members", migrate_002_add_family_members),
         ("003_add_settings", migrate_003_add_settings),
+        ("004_add_recurring_todos", migrate_004_add_recurring_todos),
     ]
 
     print("=" * 60)

--- a/src/rally/main.py
+++ b/src/rally/main.py
@@ -7,7 +7,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from rally.database import init_db
-from rally.routers import dashboard, dinner_planner, family, settings, todos
+from rally.routers import dashboard, dinner_planner, family, recurring_todos, settings, todos
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
@@ -38,6 +38,7 @@ app.include_router(dashboard.router)
 app.include_router(todos.router)
 app.include_router(dinner_planner.router)
 app.include_router(family.router)
+app.include_router(recurring_todos.router)
 app.include_router(settings.router)
 
 

--- a/src/rally/models.py
+++ b/src/rally/models.py
@@ -69,7 +69,25 @@ class Todo(Base):
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     due_date: Mapped[str | None] = mapped_column(String(10), nullable=True)  # YYYY-MM-DD
     assigned_to: Mapped[int | None] = mapped_column(Integer, nullable=True)  # FK to family_members.id
+    recurring_todo_id: Mapped[int | None] = mapped_column(Integer, nullable=True)  # FK to recurring_todos.id
     completed: Mapped[bool] = mapped_column(default=False)
+    created_at: Mapped[datetime] = mapped_column(default=now_utc)
+    updated_at: Mapped[datetime] = mapped_column(default=now_utc, onupdate=now_utc)
+
+
+class RecurringTodo(Base):
+    """Recurring todo template model."""
+
+    __tablename__ = "recurring_todos"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(String(200))
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    recurrence_type: Mapped[str] = mapped_column(String(20))  # daily, weekly, monthly
+    recurrence_day: Mapped[int | None] = mapped_column(Integer, nullable=True)  # 0-6 for weekly, 1-31 for monthly
+    assigned_to: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    has_due_date: Mapped[bool] = mapped_column(default=False)
+    active: Mapped[bool] = mapped_column(default=True)
     created_at: Mapped[datetime] = mapped_column(default=now_utc)
     updated_at: Mapped[datetime] = mapped_column(default=now_utc, onupdate=now_utc)
 

--- a/src/rally/recurrence.py
+++ b/src/rally/recurrence.py
@@ -1,0 +1,84 @@
+"""Recurring todo processing for Rally.
+
+Checks active recurring todo templates and generates todo instances
+when the recurrence is due and no open instance exists.
+"""
+
+import calendar as cal_module
+from datetime import UTC, date, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from rally.models import RecurringTodo, Todo
+from rally.utils.timezone import today_utc
+
+
+def get_last_recurrence_date(rt: RecurringTodo, today: date) -> date:
+    """Get the most recent date this recurrence should have fired."""
+    if rt.recurrence_type == "daily":
+        return today
+    elif rt.recurrence_type == "weekly":
+        day = rt.recurrence_day or 0
+        days_since = (today.weekday() - day) % 7
+        return today - timedelta(days=days_since)
+    elif rt.recurrence_type == "monthly":
+        day = rt.recurrence_day or 1
+        if today.day >= day:
+            clamped = min(day, cal_module.monthrange(today.year, today.month)[1])
+            return today.replace(day=clamped)
+        else:
+            first_of_month = today.replace(day=1)
+            last_month_end = first_of_month - timedelta(days=1)
+            clamped = min(day, cal_module.monthrange(last_month_end.year, last_month_end.month)[1])
+            return last_month_end.replace(day=clamped)
+    return today
+
+
+def process_recurring_todos(db: Session) -> int:
+    """Check all active recurring todos and create instances where due.
+
+    Returns the number of new todos created.
+    """
+    today = today_utc()
+    created_count = 0
+
+    recurring = db.query(RecurringTodo).filter(RecurringTodo.active == True).all()  # noqa: E712
+
+    for rt in recurring:
+        # Skip if there's an open (incomplete) todo for this template
+        open_todo = db.query(Todo).filter(
+            Todo.recurring_todo_id == rt.id,
+            Todo.completed == False,  # noqa: E712
+        ).first()
+        if open_todo:
+            continue
+
+        # Get the most recent recurrence date
+        last_recurrence = get_last_recurrence_date(rt, today)
+
+        # Check if a todo was already created for this recurrence period
+        cutoff = datetime(last_recurrence.year, last_recurrence.month, last_recurrence.day, tzinfo=UTC)
+        existing = db.query(Todo).filter(
+            Todo.recurring_todo_id == rt.id,
+            Todo.created_at >= cutoff,
+        ).first()
+        if existing:
+            continue
+
+        # Create new todo instance
+        due_date = str(last_recurrence) if rt.has_due_date else None
+        new_todo = Todo(
+            title=rt.title,
+            description=rt.description,
+            assigned_to=rt.assigned_to,
+            due_date=due_date,
+            recurring_todo_id=rt.id,
+            completed=False,
+        )
+        db.add(new_todo)
+        created_count += 1
+
+    if created_count > 0:
+        db.commit()
+
+    return created_count

--- a/src/rally/routers/recurring_todos.py
+++ b/src/rally/routers/recurring_todos.py
@@ -1,0 +1,81 @@
+"""Recurring todos router for Rally."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from rally.database import get_db
+from rally.models import RecurringTodo
+from rally.schemas import RecurringTodoCreate, RecurringTodoResponse, RecurringTodoUpdate
+
+router = APIRouter(prefix="/api/recurring-todos", tags=["recurring-todos"])
+
+
+@router.get("", response_model=list[RecurringTodoResponse])
+def list_recurring_todos(db: Session = Depends(get_db)):
+    """List all recurring todo templates."""
+    return db.query(RecurringTodo).order_by(RecurringTodo.created_at.desc()).all()
+
+
+@router.post("", response_model=RecurringTodoResponse, status_code=201)
+def create_recurring_todo(rt: RecurringTodoCreate, db: Session = Depends(get_db)):
+    """Create a new recurring todo template."""
+    db_rt = RecurringTodo(
+        title=rt.title,
+        description=rt.description,
+        recurrence_type=rt.recurrence_type,
+        recurrence_day=rt.recurrence_day,
+        assigned_to=rt.assigned_to,
+        has_due_date=rt.has_due_date,
+    )
+    db.add(db_rt)
+    db.commit()
+    db.refresh(db_rt)
+    return db_rt
+
+
+@router.get("/{rt_id}", response_model=RecurringTodoResponse)
+def get_recurring_todo(rt_id: int, db: Session = Depends(get_db)):
+    """Get a specific recurring todo template."""
+    rt = db.query(RecurringTodo).filter(RecurringTodo.id == rt_id).first()
+    if not rt:
+        raise HTTPException(status_code=404, detail="Recurring todo not found")
+    return rt
+
+
+@router.put("/{rt_id}", response_model=RecurringTodoResponse)
+def update_recurring_todo(rt_id: int, rt: RecurringTodoUpdate, db: Session = Depends(get_db)):
+    """Update a recurring todo template."""
+    db_rt = db.query(RecurringTodo).filter(RecurringTodo.id == rt_id).first()
+    if not db_rt:
+        raise HTTPException(status_code=404, detail="Recurring todo not found")
+
+    if rt.title is not None:
+        db_rt.title = rt.title
+    if rt.description is not None:
+        db_rt.description = rt.description
+    if rt.recurrence_type is not None:
+        db_rt.recurrence_type = rt.recurrence_type
+    if rt.recurrence_day is not None:
+        db_rt.recurrence_day = rt.recurrence_day
+    if rt.assigned_to is not None:
+        db_rt.assigned_to = rt.assigned_to
+    if rt.has_due_date is not None:
+        db_rt.has_due_date = rt.has_due_date
+    if rt.active is not None:
+        db_rt.active = rt.active
+
+    db.commit()
+    db.refresh(db_rt)
+    return db_rt
+
+
+@router.delete("/{rt_id}", status_code=204)
+def delete_recurring_todo(rt_id: int, db: Session = Depends(get_db)):
+    """Delete a recurring todo template."""
+    db_rt = db.query(RecurringTodo).filter(RecurringTodo.id == rt_id).first()
+    if not db_rt:
+        raise HTTPException(status_code=404, detail="Recurring todo not found")
+
+    db.delete(db_rt)
+    db.commit()
+    return None

--- a/src/rally/routers/todos.py
+++ b/src/rally/routers/todos.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from rally.database import get_db
 from rally.models import Todo
+from rally.recurrence import process_recurring_todos
 from rally.schemas import TodoCreate, TodoResponse, TodoUpdate
 from rally.utils.timezone import now_utc
 
@@ -23,6 +24,9 @@ def list_todos(
     By default, completed todos older than 24 hours are hidden.
     Use include_hidden=true to show all todos.
     """
+    # Process any due recurring todos before listing
+    process_recurring_todos(db)
+
     query = db.query(Todo)
 
     if not include_hidden:

--- a/src/rally/schemas.py
+++ b/src/rally/schemas.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
 
-
 # Family Members
 
 
@@ -98,7 +97,43 @@ class TodoUpdate(BaseModel):
 
 class TodoResponse(TodoBase):
     id: int
+    recurring_todo_id: int | None = None
     completed: bool
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# Recurring Todos
+
+
+class RecurringTodoBase(BaseModel):
+    title: str
+    description: str | None = None
+    recurrence_type: str  # daily, weekly, monthly
+    recurrence_day: int | None = None  # 0-6 for weekly, 1-31 for monthly
+    assigned_to: int | None = None
+    has_due_date: bool = False
+
+
+class RecurringTodoCreate(RecurringTodoBase):
+    pass
+
+
+class RecurringTodoUpdate(BaseModel):
+    title: str | None = None
+    description: str | None = None
+    recurrence_type: str | None = None
+    recurrence_day: int | None = None
+    assigned_to: int | None = None
+    has_due_date: bool | None = None
+    active: bool | None = None
+
+
+class RecurringTodoResponse(RecurringTodoBase):
+    id: int
+    active: bool
     created_at: datetime
     updated_at: datetime
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -437,6 +437,54 @@ nav a.active {
     background-repeat: no-repeat;
     background-position: right 8px center;
 }
+.header-actions {
+    display: flex;
+    gap: 12px;
+}
+
+.todo-recurring-icon {
+    flex-shrink: 0;
+    font-size: 1.1rem;
+    color: var(--medium-gray);
+    padding-top: 2px;
+}
+
+.recurring-indicator {
+    font-size: 0.85rem;
+    color: var(--light-gray);
+    margin-left: 4px;
+}
+
+.recurring-template {
+    border-style: dashed;
+}
+
+.recurring-schedule {
+    font-size: 0.85rem;
+    color: var(--medium-gray);
+    font-style: italic;
+    margin-top: 2px;
+}
+
+.recurring-meta {
+    font-size: 0.8rem;
+    color: var(--light-gray);
+    margin-left: 6px;
+}
+
+.recurring-paused {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--light-gray);
+    margin-left: 8px;
+}
+
+.form-group label input[type="checkbox"] {
+    margin-right: 6px;
+    vertical-align: middle;
+}
 /**End Todo Page**/
 
 /* Select styling */

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -26,7 +26,10 @@
     <div class="todo-container">
         <div class="header-container">
             <h2>Tasks</h2>
-            <button class="btn-add" id="btn-add-task">Add Task</button>
+            <div class="header-actions">
+                <button class="btn-add" id="btn-add-recurring">Add Recurring</button>
+                <button class="btn-add" id="btn-add-task">Add Task</button>
+            </div>
         </div>
         
         <div class="todo-toolbar">
@@ -49,6 +52,53 @@
 
         <div class="list-container" id="list-container">
             <div class="loading-state">Loading tasks...</div>
+        </div>
+    </div>
+
+    <!-- Modal for add/edit recurring -->
+    <div class="modal-overlay" id="recurring-modal-overlay">
+        <div class="modal-content">
+            <h3 id="recurring-modal-title">Add Recurring Task</h3>
+            <form id="recurring-form">
+                <input type="hidden" id="recurring-id">
+                <div class="form-group">
+                    <label>Task</label>
+                    <input type="text" id="recurring-title" placeholder="Task title" required>
+                </div>
+                <div class="form-group">
+                    <label>Notes (optional)</label>
+                    <textarea id="recurring-description" placeholder="Additional details" rows="3"></textarea>
+                </div>
+                <div class="form-group">
+                    <label>Recurrence</label>
+                    <select id="recurring-type" required>
+                        <option value="daily">Daily</option>
+                        <option value="weekly">Weekly</option>
+                        <option value="monthly">Monthly</option>
+                    </select>
+                </div>
+                <div class="form-group" id="recurring-day-group" style="display:none;">
+                    <label id="recurring-day-label">Day</label>
+                    <select id="recurring-day"></select>
+                </div>
+                <div class="form-group">
+                    <label>Assigned To (optional)</label>
+                    <select id="recurring-assigned-to">
+                        <option value="">Everyone (family-wide)</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label>
+                        <input type="checkbox" id="recurring-has-due-date">
+                        Set due date on generated tasks
+                    </label>
+                    <small>Due date will match the recurrence day</small>
+                </div>
+                <div class="modal-actions">
+                    <button type="submit" class="btn-primary">Save</button>
+                    <button type="button" class="btn-cancel" id="btn-cancel-recurring">Cancel</button>
+                </div>
+            </form>
         </div>
     </div>
 
@@ -112,6 +162,12 @@
                 filter.innerHTML += `<option value="${m.id}">${escapeHtml(m.name)}</option>`;
             });
             filter.value = currentValue;
+
+            const rSelect = document.getElementById('recurring-assigned-to');
+            rSelect.innerHTML = '<option value="">Everyone (family-wide)</option>';
+            familyMembers.forEach(m => {
+                rSelect.innerHTML += `<option value="${m.id}">${escapeHtml(m.name)}</option>`;
+            });
         }
 
         function getMemberById(id) {
@@ -193,40 +249,71 @@
             const container = document.getElementById('list-container');
             const visible = getFilteredSortedTodos();
 
-            if (todos.length === 0) {
+            if (todos.length === 0 && recurringTodos.length === 0) {
                 container.innerHTML = '<div class="empty-state">No tasks yet. Click "Add Task" to get started.</div>';
                 return;
             }
 
-            if (visible.length === 0) {
-                container.innerHTML = '<div class="empty-state">No tasks match the current filter.</div>';
-                return;
+            let html = '';
+
+            // Render recurring templates first
+            if (recurringTodos.length > 0) {
+                html += recurringTodos.map(rt => {
+                    const member = rt.assigned_to ? getMemberById(rt.assigned_to) : null;
+                    const assigneeHtml = member
+                        ? `<span class="assignee-label">— ${escapeHtml(member.name)}</span>`
+                        : '';
+                    const pausedHtml = !rt.active ? '<span class="recurring-paused">Paused</span>' : '';
+                    const dueBadge = rt.has_due_date ? '<span class="recurring-meta">with due date</span>' : '';
+                    return `
+                        <div class="todo-item recurring-template ${!rt.active ? 'completed' : ''}" data-id="${rt.id}">
+                            <div class="todo-recurring-icon">↻</div>
+                            <div class="todo-content">
+                                <div class="todo-title">${escapeHtml(rt.title)} ${assigneeHtml} ${pausedHtml}</div>
+                                <div class="recurring-schedule">${describeRecurrence(rt)} ${dueBadge}</div>
+                            </div>
+                            <div class="todo-actions">
+                                <button class="btn-edit" onclick="toggleRecurringActive(${rt.id}, ${rt.active})">${rt.active ? 'Pause' : 'Resume'}</button>
+                                <button class="btn-edit" onclick="openEditRecurringModal(${rt.id})">Edit</button>
+                                <button class="btn-delete" onclick="confirmDeleteRecurring(${rt.id})">Delete</button>
+                            </div>
+                        </div>
+                    `;
+                }).join('');
             }
 
-            container.innerHTML = visible.map(todo => {
-                const dueDateHtml = todo.due_date ? formatDueDate(todo.due_date) : '';
-                const member = todo.assigned_to ? getMemberById(todo.assigned_to) : null;
-                const assigneeHtml = member
-                    ? `<span class="assignee-label">— ${escapeHtml(member.name)}</span>`
-                    : '';
-                return `
-                    <div class="todo-item ${todo.completed ? 'completed' : ''}" data-id="${todo.id}">
-                        <div class="todo-checkbox">
-                            <input type="checkbox" ${todo.completed ? 'checked' : ''} 
-                                   onchange="toggleComplete(${todo.id}, this.checked)">
+            // Render todo instances
+            if (visible.length === 0 && recurringTodos.length === 0) {
+                html += '<div class="empty-state">No tasks match the current filter.</div>';
+            } else {
+                html += visible.map(todo => {
+                    const dueDateHtml = todo.due_date ? formatDueDate(todo.due_date) : '';
+                    const member = todo.assigned_to ? getMemberById(todo.assigned_to) : null;
+                    const assigneeHtml = member
+                        ? `<span class="assignee-label">— ${escapeHtml(member.name)}</span>`
+                        : '';
+                    const recurringIcon = todo.recurring_todo_id ? '<span class="recurring-indicator">↻</span>' : '';
+                    return `
+                        <div class="todo-item ${todo.completed ? 'completed' : ''}" data-id="${todo.id}">
+                            <div class="todo-checkbox">
+                                <input type="checkbox" ${todo.completed ? 'checked' : ''} 
+                                       onchange="toggleComplete(${todo.id}, this.checked)">
+                            </div>
+                            <div class="todo-content">
+                                <div class="todo-title">${escapeHtml(todo.title)} ${recurringIcon} ${assigneeHtml}</div>
+                                ${todo.description ? `<div class="todo-description">${escapeHtml(todo.description)}</div>` : ''}
+                                ${dueDateHtml}
+                            </div>
+                            <div class="todo-actions">
+                                <button class="btn-edit" onclick="openEditModal(${todo.id})">Edit</button>
+                                <button class="btn-delete" onclick="confirmDelete(${todo.id})">Delete</button>
+                            </div>
                         </div>
-                        <div class="todo-content">
-                            <div class="todo-title">${escapeHtml(todo.title)} ${assigneeHtml}</div>
-                            ${todo.description ? `<div class="todo-description">${escapeHtml(todo.description)}</div>` : ''}
-                            ${dueDateHtml}
-                        </div>
-                        <div class="todo-actions">
-                            <button class="btn-edit" onclick="openEditModal(${todo.id})">Edit</button>
-                            <button class="btn-delete" onclick="confirmDelete(${todo.id})">Delete</button>
-                        </div>
-                    </div>
-                `;
-            }).join('');
+                    `;
+                }).join('');
+            }
+
+            container.innerHTML = html;
         }
 
         function formatDueDate(dateStr) {
@@ -343,8 +430,164 @@
             }
         });
 
+        // ── Recurring Todos ──
+
+        let recurringTodos = [];
+        let editingRecurringId = null;
+        const DAY_NAMES = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+        async function fetchRecurringTodos() {
+            const response = await fetch('/api/recurring-todos');
+            recurringTodos = await response.json();
+            renderTodos();
+        }
+
+        function describeRecurrence(rt) {
+            if (rt.recurrence_type === 'daily') return 'Daily';
+            if (rt.recurrence_type === 'weekly') return `Weekly on ${DAY_NAMES[rt.recurrence_day] || 'Monday'}`;
+            if (rt.recurrence_type === 'monthly') return `Monthly on the ${ordinal(rt.recurrence_day || 1)}`;
+            return rt.recurrence_type;
+        }
+
+        function ordinal(n) {
+            const s = ['th','st','nd','rd'];
+            const v = n % 100;
+            return n + (s[(v-20)%10] || s[v] || s[0]);
+        }
+
+        // Recurring type / day selector logic
+        function updateDaySelector() {
+            const type = document.getElementById('recurring-type').value;
+            const dayGroup = document.getElementById('recurring-day-group');
+            const daySelect = document.getElementById('recurring-day');
+            const dayLabel = document.getElementById('recurring-day-label');
+
+            if (type === 'daily') {
+                dayGroup.style.display = 'none';
+                return;
+            }
+
+            dayGroup.style.display = '';
+            if (type === 'weekly') {
+                dayLabel.textContent = 'Day of Week';
+                daySelect.innerHTML = DAY_NAMES.map((d, i) =>
+                    `<option value="${i}">${d}</option>`
+                ).join('');
+            } else if (type === 'monthly') {
+                dayLabel.textContent = 'Day of Month';
+                daySelect.innerHTML = Array.from({length: 31}, (_, i) =>
+                    `<option value="${i + 1}">${ordinal(i + 1)}</option>`
+                ).join('');
+            }
+        }
+
+        document.getElementById('recurring-type').addEventListener('change', updateDaySelector);
+
+        function openAddRecurringModal() {
+            editingRecurringId = null;
+            document.getElementById('recurring-modal-title').textContent = 'Add Recurring Task';
+            document.getElementById('recurring-form').reset();
+            document.getElementById('recurring-id').value = '';
+            document.getElementById('recurring-assigned-to').value = '';
+            document.getElementById('recurring-type').value = 'daily';
+            updateDaySelector();
+            document.getElementById('recurring-modal-overlay').style.display = 'flex';
+        }
+
+        function openEditRecurringModal(id) {
+            const rt = recurringTodos.find(r => r.id === id);
+            if (!rt) return;
+
+            editingRecurringId = id;
+            document.getElementById('recurring-modal-title').textContent = 'Edit Recurring Task';
+            document.getElementById('recurring-id').value = id;
+            document.getElementById('recurring-title').value = rt.title;
+            document.getElementById('recurring-description').value = rt.description || '';
+            document.getElementById('recurring-type').value = rt.recurrence_type;
+            updateDaySelector();
+            if (rt.recurrence_day !== null) {
+                document.getElementById('recurring-day').value = rt.recurrence_day;
+            }
+            document.getElementById('recurring-assigned-to').value = rt.assigned_to || '';
+            document.getElementById('recurring-has-due-date').checked = rt.has_due_date;
+            document.getElementById('recurring-modal-overlay').style.display = 'flex';
+        }
+
+        function closeRecurringModal() {
+            document.getElementById('recurring-modal-overlay').style.display = 'none';
+            editingRecurringId = null;
+        }
+
+        async function toggleRecurringActive(id, currentlyActive) {
+            try {
+                await fetch(`/api/recurring-todos/${id}`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ active: !currentlyActive })
+                });
+                await fetchRecurringTodos();
+            } catch (error) {
+                alert('Failed to update recurring task');
+            }
+        }
+
+        async function confirmDeleteRecurring(id) {
+            if (!confirm('Delete this recurring task? Existing generated todos will remain.')) return;
+            try {
+                await fetch(`/api/recurring-todos/${id}`, { method: 'DELETE' });
+                await fetchRecurringTodos();
+            } catch (error) {
+                alert('Failed to delete recurring task');
+            }
+        }
+
+        document.getElementById('btn-add-recurring').addEventListener('click', openAddRecurringModal);
+        document.getElementById('btn-cancel-recurring').addEventListener('click', closeRecurringModal);
+        document.getElementById('recurring-modal-overlay').addEventListener('click', (e) => {
+            if (e.target.id === 'recurring-modal-overlay') closeRecurringModal();
+        });
+
+        document.getElementById('recurring-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+
+            const type = document.getElementById('recurring-type').value;
+            const assignedTo = document.getElementById('recurring-assigned-to').value;
+            const data = {
+                title: document.getElementById('recurring-title').value,
+                description: document.getElementById('recurring-description').value || null,
+                recurrence_type: type,
+                recurrence_day: type !== 'daily' ? parseInt(document.getElementById('recurring-day').value) : null,
+                assigned_to: assignedTo ? parseInt(assignedTo) : null,
+                has_due_date: document.getElementById('recurring-has-due-date').checked,
+            };
+
+            try {
+                if (editingRecurringId) {
+                    await fetch(`/api/recurring-todos/${editingRecurringId}`, {
+                        method: 'PUT',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(data)
+                    });
+                } else {
+                    await fetch('/api/recurring-todos', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(data)
+                    });
+                }
+                closeRecurringModal();
+                await fetchRecurringTodos();
+                await fetchTodos(); // Refresh in case a new instance was generated
+            } catch (error) {
+                alert('Failed to save recurring task');
+            }
+        });
+
         // Initialize
-        fetchFamilyMembers().then(() => fetchTodos());
+        fetchFamilyMembers().then(() => {
+            fetchTodos();
+            fetchRecurringTodos();
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
This pull request introduces recurring todo functionality to the application. It adds support for defining recurring todo templates, automatically generating todo instances based on their recurrence schedule, and provides a full API and UI for managing recurring todos. The migration, backend, and frontend are all updated to support these new features.

**Database and Model Changes**
- Added a new `recurring_todos` table and a `recurring_todo_id` column to the `todos` table via a new migration script, and updated the SQLAlchemy models to include a `RecurringTodo` model and a foreign key on `Todo`. [[1]](diffhunk://#diff-9eb9da6a3750f27559e06f9b68d7e5b857ae8f88126c193b91197b869e2063ccR1-R83) [[2]](diffhunk://#diff-ed091dc7a3e169cb66e4fa163a42b5e43571c4379454ed39ab47b66563067a0aR72-R94) [[3]](diffhunk://#diff-707ad9745ee835447c2bace21cf5c9e18f6dacf34fd4ed2e98dcc17438eede6bR18) [[4]](diffhunk://#diff-707ad9745ee835447c2bace21cf5c9e18f6dacf34fd4ed2e98dcc17438eede6bR28) [[5]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R21)

**Backend Logic and API**
- Implemented recurring todo processing logic in `recurrence.py` to automatically generate todos from active recurring templates when due, and integrated this processing step into the todos listing endpoint. [[1]](diffhunk://#diff-f3ec25027e4a90cc799fb02eb53dcc71e8ec6ecc1cff73d350b1e7fcb8e41ccbR1-R84) [[2]](diffhunk://#diff-1e4a68b477bae1cd45804dc263f51e98f8b4dd406106bd1b58db7768dbcbf890R10) [[3]](diffhunk://#diff-1e4a68b477bae1cd45804dc263f51e98f8b4dd406106bd1b58db7768dbcbf890R27-R29)
- Added a new FastAPI router, `recurring_todos.py`, providing CRUD endpoints for managing recurring todo templates. [[1]](diffhunk://#diff-89a14b72ad9dcffaec14c455d186d0802c5df09a6806871918cb8ba44a71211cR1-R81) [[2]](diffhunk://#diff-39b012200ef2bcd92ffe5ab51a5c2c34f229985ddf480fd3e9b984414215202cL10-R10) [[3]](diffhunk://#diff-39b012200ef2bcd92ffe5ab51a5c2c34f229985ddf480fd3e9b984414215202cR41)

**Schema and Serialization**
- Introduced new Pydantic schemas for recurring todos, and updated the todo response schema to include the `recurring_todo_id` field.

**Frontend and UI Enhancements**
- Updated the tasks page to include UI elements for adding and editing recurring todos, including a modal dialog and new controls, and styled these elements in CSS. [[1]](diffhunk://#diff-04741223287272cf37b220f13ce555af6fa768ba9a9664bed59479964add0c94R29-R33) [[2]](diffhunk://#diff-04741223287272cf37b220f13ce555af6fa768ba9a9664bed59479964add0c94R58-R104) [[3]](diffhunk://#diff-04741223287272cf37b220f13ce555af6fa768ba9a9664bed59479964add0c94R165-R170) [[4]](diffhunk://#diff-2339bc0791b9baa744347f95fa5d5010d723aba0623fd3b6b22b76a4a1583775R440-R487)

These changes collectively enable users to create, manage, and benefit from automatically generated recurring tasks in the application.

This closes https://github.com/pid1/rally/issues/17

