### PR TITLE
Fix mobile styling for task filters

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -423,15 +423,17 @@ nav a.active {
 }
 
 .toolbar-group select {
+    -webkit-appearance: none;
     appearance: none;
     box-sizing: border-box;
     min-height: 2.25rem;
     color: var(--charcoal);
     padding: 4px 28px 4px 10px;
     border: 1px solid var(--pale-gray);
+    border-radius: 0;
     background: var(--white);
     font-family: var(--body-font);
-    font-size: 0.95rem;
+    font-size: 1rem;
     cursor: pointer;
     background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23999' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
@@ -736,6 +738,23 @@ nav a.active {
 
     .card-content p {
         text-align: left;
+    }
+
+    .todo-toolbar {
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .toolbar-group {
+        width: 100%;
+    }
+
+    .toolbar-group select {
+        flex: 1;
+    }
+
+    .header-actions {
+        gap: 8px;
     }
 }
 


### PR DESCRIPTION
This pull request updates the styling for toolbar elements in `static/styles.css` to improve consistency and responsiveness, particularly for select dropdowns and toolbar layouts. The changes focus on refining the appearance of form controls and enhancing the layout for better usability, especially on smaller screens.

**Toolbar and select element styling improvements:**

* Added `-webkit-appearance: none;` and set `border-radius: 0;` to `.toolbar-group select` for a more consistent, flat appearance across browsers. Increased the font size to `1rem` for better readability.

**Responsive layout enhancements:**

* Updated styles for `.todo-toolbar` and related classes to use column flex direction and add spacing (`gap: 10px`), making the toolbar stack vertically on smaller screens. Adjusted `.toolbar-group` and `.toolbar-group select` to ensure full width and flexible sizing in responsive layouts. Also, added a gap to `.header-actions` for improved button spacing.

Fixes https://github.com/pid1/rally/issues/18