### PR TITLE
Refactor styles and replace todo markup

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -165,7 +165,196 @@ nav a.active {
     border: 1px solid var(--charcoal);
     background: var(--white);
 }
+
+.container-empty-state {
+    text-align: center;
+    padding: 64px 32px;
+    color: var(--medium-gray);
+    font-style: italic;
+    border: 1px solid var(--pale-gray);
+}
+
+.container-loading-state {
+    text-align: center;
+    padding: 64px 32px;
+    color: var(--medium-gray);
+    font-style: italic;
+    border: 1px solid var(--pale-gray);
+}
 /** End Container Styling **/
+
+/** Modals **/
+.modal-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background: var(--white);
+    border: 1px solid var(--charcoal);
+    padding: 32px;
+    width: 90%;
+    max-width: 500px;
+}
+
+.modal-content h3 {
+    font-size: 1.3rem;
+    font-family: var(--header-font);
+    margin-bottom: 24px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.modal-actions {
+    display: flex;
+    gap: 12px;
+    margin-top: 24px;
+}
+/** End Modals **/
+
+/** Form Styles **/
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+}
+
+.form-group input[type="text"], .form-group input[type="password"], .form-group input[type="date"], .form-group textarea {
+    appearance: none;
+    box-sizing: border-box;
+    min-height: 2.75rem;
+    color: var(--charcoal);
+    width: 100%;
+    padding: 10px;
+    border: 1px solid var(--charcoal);
+    background: var(--white);
+    font-family: var(--body-font);
+    font-size: 1rem;
+}
+
+.form-group small {
+    display: block;
+    margin-top: 4px;
+    color: var(--medium-gray);
+    font-size: 0.8rem;
+    font-style: italic;
+}
+
+.form-group textarea {
+    resize: vertical;
+    min-height: 100px;
+}
+
+.form-group label input[type="checkbox"] {
+    margin-right: 6px;
+    vertical-align: middle;
+}
+
+.form-group select {
+    appearance: none;
+    box-sizing: border-box;
+    min-height: 2.75rem;
+    color: var(--charcoal);
+    width: 100%;
+    padding: 10px;
+    border: 1px solid var(--charcoal);
+    background: var(--white);
+    font-family: var(--body-font);
+    font-size: 1rem;
+    cursor: pointer;
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23333' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    padding-right: 32px;
+}
+/** End Form Styles **/
+
+/** Editable Item Styles **/
+.editable-item {
+    display: flex;
+    gap: 16px;
+    padding: 16px;
+    border: 1px solid var(--pale-gray);
+    background: var(--white);
+    align-items: flex-start;
+    transition: background 0.2s;
+}
+
+.editable-item:hover {
+    background: var(--off-white);
+}
+
+.editable-item.completed {
+    opacity: 0.6;
+}
+
+.editable-item.completed .editable-item-title {
+    color: var(--medium-gray);
+}
+
+.editable-item-content {
+    flex: 1;
+    min-width: 0;
+}
+
+.editable-item-title {
+    font-size: 1rem;
+    font-weight: 500;
+    margin-bottom: 4px;
+    word-wrap: break-word;
+}
+
+.editable-item-actions {
+    display: flex;
+    gap: 8px;
+    flex-shrink: 0;
+}
+
+.editable-item-description {
+    font-size: 0.9rem;
+    color: var(--medium-gray);
+    margin-bottom: 6px;
+    font-style: italic;
+    word-wrap: break-word;
+}
+/** End Editable Item Styles **/
+
+/** Assignee Badge Styles **/
+.assignee-badge {
+    display: inline-block;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--white);
+    padding: 2px 8px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    vertical-align: middle;
+    margin-left: 8px;
+}
+
+.assignee-label {
+    font-family: var(--body-font);
+    font-style: italic;
+    font-size: 0.9rem;
+    color: var(--medium-gray);
+    margin-left: 6px;
+    vertical-align: baseline;
+}
+/** End Assignee Badge Styles **/
 
 /** Dashboard Styles **/
 /* Greeting */
@@ -300,44 +489,10 @@ nav a.active {
 }
 /** End Dashboard Styles **/
 
-/**Todo Page**/
+/**Todo Page Styles**/
 .todo-container {
     max-width: 800px;
     margin: 0 auto;
-}
-
-.empty-state {
-    text-align: center;
-    padding: 64px 32px;
-    color: var(--medium-gray);
-    font-style: italic;
-    border: 1px solid var(--pale-gray);
-}
-
-.loading-state {
-    text-align: center;
-    padding: 64px 32px;
-    color: var(--medium-gray);
-    font-style: italic;
-    border: 1px solid var(--pale-gray);
-}
-
-.todo-item {
-    display: flex;
-    gap: 16px;
-    padding: 16px;
-    border: 1px solid var(--pale-gray);
-    background: var(--white);
-    align-items: flex-start;
-    transition: background 0.2s;
-}
-
-.todo-item:hover {
-    background: var(--off-white);
-}
-
-.todo-item.completed {
-    opacity: 0.6;
 }
 
 .todo-checkbox {
@@ -350,30 +505,6 @@ nav a.active {
     height: 18px;
     cursor: pointer;
     border: 1px solid var(--charcoal);
-}
-
-.todo-content {
-    flex: 1;
-    min-width: 0;
-}
-
-.todo-title {
-    font-size: 1rem;
-    font-weight: 500;
-    margin-bottom: 4px;
-    word-wrap: break-word;
-}
-
-.todo-item.completed .todo-title {
-    color: var(--medium-gray);
-}
-
-.todo-description {
-    font-size: 0.9rem;
-    color: var(--medium-gray);
-    margin-bottom: 6px;
-    font-style: italic;
-    word-wrap: break-word;
 }
 
 .todo-meta {
@@ -395,11 +526,7 @@ nav a.active {
     font-weight: 600;
 }
 
-.todo-actions {
-    display: flex;
-    gap: 8px;
-    flex-shrink: 0;
-}
+
 .todo-toolbar {
     display: flex;
     gap: 24px;
@@ -482,110 +609,9 @@ nav a.active {
     color: var(--light-gray);
     margin-left: 8px;
 }
+/**End Todo Page Styles**/
 
-.form-group label input[type="checkbox"] {
-    margin-right: 6px;
-    vertical-align: middle;
-}
-/**End Todo Page**/
-
-/* Select styling */
-.form-group select {
-    appearance: none;
-    box-sizing: border-box;
-    min-height: 2.75rem;
-    color: var(--charcoal);
-    width: 100%;
-    padding: 10px;
-    border: 1px solid var(--charcoal);
-    background: var(--white);
-    font-family: var(--body-font);
-    font-size: 1rem;
-    cursor: pointer;
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23333' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: right 12px center;
-    padding-right: 32px;
-}
-
-/** Modals **/
-.modal-overlay {
-    display: none;
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.5);
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-}
-
-.modal-content {
-    background: var(--white);
-    border: 1px solid var(--charcoal);
-    padding: 32px;
-    width: 90%;
-    max-width: 500px;
-}
-
-.modal-content h3 {
-    font-size: 1.3rem;
-    font-family: var(--header-font);
-    margin-bottom: 24px;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-}
-
-.modal-actions {
-    display: flex;
-    gap: 12px;
-    margin-top: 24px;
-}
-/** End Modals **/
-
-/** Forms **/
-.form-group {
-    margin-bottom: 20px;
-}
-
-.form-group label {
-    display: block;
-    margin-bottom: 6px;
-    font-size: 0.9rem;
-    font-weight: 500;
-    letter-spacing: 0.02em;
-}
-
-.form-group input[type="text"], .form-group input[type="password"], .form-group input[type="date"], .form-group textarea {
-    appearance: none;
-    box-sizing: border-box;
-    min-height: 2.75rem;
-    color: var(--charcoal);
-    width: 100%;
-    padding: 10px;
-    border: 1px solid var(--charcoal);
-    background: var(--white);
-    font-family: var(--body-font);
-    font-size: 1rem;
-}
-
-.form-group small {
-    display: block;
-    margin-top: 4px;
-    color: var(--medium-gray);
-    font-size: 0.8rem;
-    font-style: italic;
-}
-
-.form-group textarea {
-    resize: vertical;
-    min-height: 100px;
-}
-/** End Forms **/
-
-/* Plans List */
+/** Dinner Planner Styles **/
 .plan-card {
     padding: 20px;
     border: 1px solid var(--pale-gray);
@@ -616,6 +642,7 @@ nav a.active {
     gap: 12px;
 }
 
+
 /** Settings Page **/
 
 .settings-actions {
@@ -636,35 +663,12 @@ nav a.active {
     opacity: 1;
 }
 
-.llm-fields-local,
-.llm-fields-anthropic {
+.llm-fields-local, .llm-fields-anthropic {
     display: none;
 }
 
-.llm-fields-local.active,
-.llm-fields-anthropic.active {
+.llm-fields-local.active, .llm-fields-anthropic.active {
     display: block;
-}
-/* Assignee Badge */
-.assignee-badge {
-    display: inline-block;
-    font-size: 0.7rem;
-    font-weight: 600;
-    color: var(--white);
-    padding: 2px 8px;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    vertical-align: middle;
-    margin-left: 8px;
-}
-
-.assignee-label {
-    font-family: var(--body-font);
-    font-style: italic;
-    font-size: 0.9rem;
-    color: var(--medium-gray);
-    margin-left: 6px;
-    vertical-align: baseline;
 }
 
 /* Family Member Badge */

--- a/templates/dinner_planner.html
+++ b/templates/dinner_planner.html
@@ -115,7 +115,7 @@
             const container = document.getElementById('plans-list');
             
             if (plans.length === 0) {
-                container.innerHTML = '<div class="empty-state">No dinner plans for the next 7 days.</div>';
+                container.innerHTML = '<div class="container-empty-state">No dinner plans for the next 7 days.</div>';
                 return;
             }
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -31,7 +31,7 @@
         </div>
 
         <div class="list-container" id="family-list">
-            <div class="loading-state">Loading family members...</div>
+            <div class="container-loading-state">Loading family members...</div>
         </div>
     </div>
 
@@ -43,7 +43,7 @@
         </div>
 
         <div class="list-container" id="calendar-list">
-            <div class="loading-state">Loading calendars...</div>
+            <div class="container-loading-state">Loading calendars...</div>
         </div>
     </div>
 
@@ -271,16 +271,16 @@
             const container = document.getElementById('family-list');
 
             if (familyMembers.length === 0) {
-                container.innerHTML = '<div class="empty-state">No family members yet. Click "Add Member" to get started.</div>';
+                container.innerHTML = '<div class="container-empty-state">No family members yet. Click "Add Member" to get started.</div>';
                 return;
             }
 
             container.innerHTML = familyMembers.map(member => `
-                <div class="todo-item" data-id="${member.id}">
-                    <div class="todo-content">
-                        <div class="todo-title">${escapeHtml(member.name)}</div>
+                <div class="editable-item" data-id="${member.id}">
+                    <div class="editable-item-content">
+                        <div class="editable-item-title">${escapeHtml(member.name)}</div>
                     </div>
-                    <div class="todo-actions">
+                    <div class="editable-item-actions">
                         <button class="btn-edit" onclick="openEditMemberModal(${member.id})">Edit</button>
                         <button class="btn-delete" onclick="confirmDeleteMember(${member.id})">Delete</button>
                     </div>
@@ -375,7 +375,7 @@
             const container = document.getElementById('calendar-list');
 
             if (calendars.length === 0) {
-                container.innerHTML = '<div class="empty-state">No calendars yet. Click "Add Calendar" to get started.</div>';
+                container.innerHTML = '<div class="container-empty-state">No calendars yet. Click "Add Calendar" to get started.</div>';
                 return;
             }
 
@@ -385,12 +385,12 @@
                     ? `<span class="assignee-label">— ${escapeHtml(member.name)}</span>`
                     : '';
                 return `
-                    <div class="todo-item" data-id="${cal.id}">
-                        <div class="todo-content">
-                            <div class="todo-title">${escapeHtml(cal.label)} ${memberHtml}</div>
-                            <div class="todo-description">${escapeHtml(truncateUrl(cal.url, 60))}</div>
+                    <div class="editable-item" data-id="${cal.id}">
+                        <div class="editable-item-content">
+                            <div class="editable-item-title">${escapeHtml(cal.label)} ${memberHtml}</div>
+                            <div class="editable-item-description">${escapeHtml(truncateUrl(cal.url, 60))}</div>
                         </div>
-                        <div class="todo-actions">
+                        <div class="editable-item-actions">
                             <button class="btn-edit" onclick="openEditCalendarModal(${cal.id})">Edit</button>
                             <button class="btn-delete" onclick="confirmDeleteCalendar(${cal.id})">Delete</button>
                         </div>

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -51,7 +51,7 @@
         </div>
 
         <div class="list-container" id="list-container">
-            <div class="loading-state">Loading tasks...</div>
+            <div class="container-loading-state">Loading tasks...</div>
         </div>
     </div>
 
@@ -250,7 +250,7 @@
             const visible = getFilteredSortedTodos();
 
             if (todos.length === 0 && recurringTodos.length === 0) {
-                container.innerHTML = '<div class="empty-state">No tasks yet. Click "Add Task" to get started.</div>';
+                container.innerHTML = '<div class="container-empty-state">No tasks yet. Click "Add Task" to get started.</div>';
                 return;
             }
 
@@ -266,13 +266,13 @@
                     const pausedHtml = !rt.active ? '<span class="recurring-paused">Paused</span>' : '';
                     const dueBadge = rt.has_due_date ? '<span class="recurring-meta">with due date</span>' : '';
                     return `
-                        <div class="todo-item recurring-template ${!rt.active ? 'completed' : ''}" data-id="${rt.id}">
+                        <div class="editable-item recurring-template ${!rt.active ? 'completed' : ''}" data-id="${rt.id}">
                             <div class="todo-recurring-icon">↻</div>
-                            <div class="todo-content">
-                                <div class="todo-title">${escapeHtml(rt.title)} ${assigneeHtml} ${pausedHtml}</div>
+                            <div class="editable-item-content">
+                                <div class="editable-item-title">${escapeHtml(rt.title)} ${assigneeHtml} ${pausedHtml}</div>
                                 <div class="recurring-schedule">${describeRecurrence(rt)} ${dueBadge}</div>
                             </div>
-                            <div class="todo-actions">
+                            <div class="editable-item-actions">
                                 <button class="btn-edit" onclick="toggleRecurringActive(${rt.id}, ${rt.active})">${rt.active ? 'Pause' : 'Resume'}</button>
                                 <button class="btn-edit" onclick="openEditRecurringModal(${rt.id})">Edit</button>
                                 <button class="btn-delete" onclick="confirmDeleteRecurring(${rt.id})">Delete</button>
@@ -284,7 +284,7 @@
 
             // Render todo instances
             if (visible.length === 0 && recurringTodos.length === 0) {
-                html += '<div class="empty-state">No tasks match the current filter.</div>';
+                html += '<div class="container-empty-state">No tasks match the current filter.</div>';
             } else {
                 html += visible.map(todo => {
                     const dueDateHtml = todo.due_date ? formatDueDate(todo.due_date) : '';
@@ -294,17 +294,17 @@
                         : '';
                     const recurringIcon = todo.recurring_todo_id ? '<span class="recurring-indicator">↻</span>' : '';
                     return `
-                        <div class="todo-item ${todo.completed ? 'completed' : ''}" data-id="${todo.id}">
+                        <div class="editable-item ${todo.completed ? 'completed' : ''}" data-id="${todo.id}">
                             <div class="todo-checkbox">
                                 <input type="checkbox" ${todo.completed ? 'checked' : ''} 
                                        onchange="toggleComplete(${todo.id}, this.checked)">
                             </div>
-                            <div class="todo-content">
-                                <div class="todo-title">${escapeHtml(todo.title)} ${recurringIcon} ${assigneeHtml}</div>
-                                ${todo.description ? `<div class="todo-description">${escapeHtml(todo.description)}</div>` : ''}
+                            <div class="editable-item-content">
+                                <div class="editable-item-title">${escapeHtml(todo.title)} ${recurringIcon} ${assigneeHtml}</div>
+                                ${todo.description ? `<div class="editable-item-description">${escapeHtml(todo.description)}</div>` : ''}
                                 ${dueDateHtml}
                             </div>
-                            <div class="todo-actions">
+                            <div class="editable-item-actions">
                                 <button class="btn-edit" onclick="openEditModal(${todo.id})">Edit</button>
                                 <button class="btn-delete" onclick="confirmDelete(${todo.id})">Delete</button>
                             </div>


### PR DESCRIPTION
Consolidate CSS styles to be more human readable (modals, forms, empty/loading states, editable-item, assignee badge, select styling, etc.). Update templates (dinner_planner.html, settings.html, todo.html) to use the new class names (container-empty-state, container-loading-state, editable-item, editable-item-content, editable-item-title, editable-item-description, editable-item-actions) in place of the old todo-item/todo-content/todo-title/todo-description/todo-actions markup. This unifies UI components and reduces duplicated styling to enable more reusable components across pages.