### PR TITLE
Add modal max height and enable scrolling

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -246,6 +246,8 @@ footer a:hover {
     padding: 32px;
     width: 90%;
     max-width: 500px;
+    max-height: 95vh;
+    overflow: auto;
 }
 
 .modal-content h3 {


### PR DESCRIPTION
Add max-height: 95vh and overflow: auto to modal-content class to prevent modal contents from extending beyond the viewport on small screens and to allow internal scrolling when content is taller than the available height.