### PR TITLE
Fix recurring todo duplicate creation on completion and broken delete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,6 +296,7 @@ Rally uses a simple, file-based migration system. All migrations live in the `mi
 - `004_add_recurring_todos` - Add `recurring_todos` table and `recurring_todo_id` on `todos`
 - `005_add_dinner_plan_assignees` - Add `attendee_ids` and `cook_id` to `dinner_plans`
 - `006_add_reminder_window` - Add `remind_days_before` to `todos` and `recurring_todos`
+- `007_add_last_generated_date` - Add `last_generated_date` to `recurring_todos` (tracks most recently generated instance to prevent duplicates)
 
 ### Running Migrations
 
@@ -438,7 +439,7 @@ rally/
 │   ├── models.py         # Database models (FamilyMember, Calendar, Setting, DashboardSnapshot, Todo, RecurringTodo, DinnerPlan)
 │   ├── schemas.py        # Pydantic schemas
 │   ├── cli.py            # CLI commands (seed, etc.)
-│   ├── recurrence.py     # Recurring todo processing (template → instance generation)
+│   ├── recurrence.py     # Recurring todo processing (template → instance generation, next-date calculation)
 │   ├── generator/
 │   │   ├── __init__.py
 │   │   ├── generate.py   # Summary generation logic with calendar, todos, and dinner plans
@@ -471,6 +472,7 @@ rally/
 │   ├── migrate_add_recurring_todos.py # Migration 004: add recurring_todos table, recurring_todo_id on todos
 │   ├── migrate_add_dinner_plan_assignees.py # Migration 005: add attendee_ids, cook_id to dinner_plans
 │   ├── migrate_add_reminder_window.py # Migration 006: add remind_days_before to todos and recurring_todos
+│   ├── migrate_add_last_generated_date.py # Migration 007: add last_generated_date to recurring_todos
 │   └── run_migrations.py              # Migration runner (executes all migrations in order)
 ├── data/                 # Mounted in container (not in git)
 │   ├── config.toml       # API keys, URLs, coordinates (optional if using Settings UI)
@@ -649,7 +651,7 @@ The database is automatically created when the app starts. Migrations run automa
 - `Setting` - Key-value settings store (LLM provider, API keys, timezone, etc.)
 - `DashboardSnapshot` - Stores generated dashboard data with date, timestamp, JSON data, and active flag
 - `Todo` - Task management with title, description, optional due_date (YYYY-MM-DD), assigned_to (family member), optional recurring_todo_id (link to recurring template), optional remind_days_before (reminder window), completion status, and timestamps
-- `RecurringTodo` - Recurring todo templates with title, description, recurrence_type (daily/weekly/monthly), recurrence_day, assigned_to, has_due_date, remind_days_before, active flag, and timestamps
+- `RecurringTodo` - Recurring todo templates with title, description, recurrence_type (daily/weekly/monthly), recurrence_day, assigned_to, has_due_date, remind_days_before, last_generated_date (tracks most recently generated instance's recurrence date), active flag, and timestamps
 - `DinnerPlan` - Meal planning with date, plan text, attendee_ids (JSON array of family member IDs), cook_id (family member ID), and timestamps. Multiple plans per date are allowed.
 
 ### Dependency Issues

--- a/migrations/migrate_add_last_generated_date.py
+++ b/migrations/migrate_add_last_generated_date.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Migration: Add last_generated_date column to recurring_todos table.
+
+Tracks the recurrence date of the most recently generated instance for each
+recurring todo template. Prevents duplicate instance creation on completion
+or deletion, and ensures the next instance advances to the correct period.
+
+Safe to run multiple times (idempotent).
+"""
+
+import os
+import sqlite3
+from pathlib import Path
+
+
+def migrate():
+    """Run the migration. Return True on success, False on failure."""
+    db_path = os.environ.get("RALLY_DB_PATH")
+
+    if not db_path:
+        prod_path = Path("/data/rally.db")
+        dev_path = Path(__file__).parent.parent / "rally.db"
+        db_path = str(prod_path) if prod_path.exists() else str(dev_path)
+
+    db_path = Path(db_path)
+
+    if not db_path.exists():
+        print(f"✓ Database not found at {db_path}")
+        print("  No migration needed - database will be created with correct schema.")
+        return True
+
+    print(f"Checking database at {db_path}...")
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    try:
+        # Check if recurring_todos table exists (created by migration 004)
+        cursor.execute("PRAGMA table_info(recurring_todos)")
+        columns = [col[1] for col in cursor.fetchall()]
+
+        if not columns:
+            print("✓ recurring_todos table does not exist yet (migration 004 will create it)")
+            print("  No migration needed - table will be created with correct schema.")
+            return True
+
+        if "last_generated_date" in columns:
+            print("✓ Migration: recurring_todos.last_generated_date already exists (idempotent)")
+        else:
+            print("  Adding 'last_generated_date' column to recurring_todos table...")
+            cursor.execute("ALTER TABLE recurring_todos ADD COLUMN last_generated_date VARCHAR(10)")
+
+            # Backfill: set last_generated_date from existing todo instances.
+            # For each recurring todo, find the most recent instance's due_date.
+            print("  Backfilling last_generated_date from existing instances...")
+            cursor.execute("""
+                UPDATE recurring_todos
+                SET last_generated_date = (
+                    SELECT t.due_date
+                    FROM todos t
+                    WHERE t.recurring_todo_id = recurring_todos.id
+                      AND t.due_date IS NOT NULL
+                    ORDER BY t.due_date DESC
+                    LIMIT 1
+                )
+                WHERE EXISTS (
+                    SELECT 1 FROM todos t
+                    WHERE t.recurring_todo_id = recurring_todos.id
+                      AND t.due_date IS NOT NULL
+                )
+            """)
+
+            conn.commit()
+            print("✓ Migration complete: recurring_todos.last_generated_date added and backfilled")
+
+        return True
+
+    except sqlite3.Error as e:
+        print(f"✗ Migration failed: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    import sys
+
+    success = migrate()
+    sys.exit(0 if success else 1)

--- a/migrations/run_migrations.py
+++ b/migrations/run_migrations.py
@@ -17,6 +17,9 @@ def run_migrations():
         )
         from migrate_add_due_date import migrate as migrate_001_add_due_date
         from migrate_add_family_members import migrate as migrate_002_add_family_members
+        from migrate_add_last_generated_date import (
+            migrate as migrate_007_add_last_generated_date,
+        )
         from migrate_add_recurring_todos import migrate as migrate_004_add_recurring_todos
         from migrate_add_reminder_window import migrate as migrate_006_add_reminder_window
         from migrate_add_settings import migrate as migrate_003_add_settings
@@ -32,6 +35,7 @@ def run_migrations():
         ("004_add_recurring_todos", migrate_004_add_recurring_todos),
         ("005_add_dinner_plan_assignees", migrate_005_add_dinner_plan_assignees),
         ("006_add_reminder_window", migrate_006_add_reminder_window),
+        ("007_add_last_generated_date", migrate_007_add_last_generated_date),
     ]
 
     print("=" * 60)

--- a/src/rally/models.py
+++ b/src/rally/models.py
@@ -103,6 +103,9 @@ class RecurringTodo(Base):
     remind_days_before: Mapped[int | None] = mapped_column(
         Integer, nullable=True
     )  # Days before due_date to start showing in LLM briefings
+    last_generated_date: Mapped[str | None] = mapped_column(
+        String(10), nullable=True
+    )  # YYYY-MM-DD: recurrence date of the most recently generated instance
     active: Mapped[bool] = mapped_column(default=True)
     created_at: Mapped[datetime] = mapped_column(default=now_utc)
     updated_at: Mapped[datetime] = mapped_column(default=now_utc, onupdate=now_utc)

--- a/src/rally/schemas.py
+++ b/src/rally/schemas.py
@@ -142,6 +142,7 @@ class RecurringTodoUpdate(BaseModel):
 class RecurringTodoResponse(RecurringTodoBase):
     id: int
     active: bool
+    last_generated_date: str | None = None
     created_at: datetime
     updated_at: datetime
 


### PR DESCRIPTION
## Summary

- **Fix duplicate creation on completion**: Completing a recurring task instance now creates the next period's instance instead of duplicating the current one (e.g., completing a monthly task due Feb 25 creates a Mar 25 instance, not another Feb 25)
- **Fix delete button appearing broken**: Deleting a recurring task instance no longer immediately recreates it with the same due date; it advances to the next recurrence period
- **Add `last_generated_date` tracking**: New column on `RecurringTodo` remembers the recurrence date of the most recently generated instance, preventing re-creation after completion or deletion

## Root Cause

`process_recurring_todos()` used a `created_at`-based cutoff to detect whether an instance already existed for the current period. This failed in two ways:

1. When a completed instance was created in a prior period, the cutoff check missed it and created a duplicate for the same period
2. When an instance was deleted, all evidence was removed, so the system immediately recreated it

## Changes

| File | Change |
|------|--------|
| `src/rally/recurrence.py` | Added `get_next_recurrence_date()`, `_resolve_reference_date()`, rewrote `process_recurring_todos()` to use next-date logic |
| `src/rally/models.py` | Added `last_generated_date` column to `RecurringTodo` |
| `src/rally/schemas.py` | Added `last_generated_date` to `RecurringTodoResponse` |
| `migrations/migrate_add_last_generated_date.py` | New idempotent migration with backfill from existing instances |
| `migrations/run_migrations.py` | Added migration 007 to runner |
| `AGENTS.md` | Updated migration list, model docs, project structure |

## Verification

Tested all three scenarios from the bug report via API:

- Monthly task due 25th: complete Feb 25 → creates Mar 25 (not duplicate Feb 25) ✓
- Monthly task: delete Mar 25 → creates Apr 25 (not recreating Mar 25) ✓
- Weekly task due Monday: delete Mon Mar 2 → creates Mon Mar 9 ✓
- Semgrep security scan: 0 findings ✓
- Lint/format: all checks pass ✓