### PR TITLE
Fix https://github.com/pid1/rally/issues/46

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -494,6 +494,8 @@ rally/
 **Implemented:**
 - ✅ FastAPI web application with routes
 - ✅ Summary generation (`rally.generator`) with ICS parsing and recurring event support
+  - LLM system prompt includes task filtering guideline (guideline 10): the LLM only references tasks explicitly listed in the TODOS section of its prompt
+  - Todo and dinner plan date comparisons use the user's configured local timezone
 - ✅ Configuration via Settings UI (stored in DB) with config.toml fallback
 - ✅ Calendar integration (Google Calendar, iCloud) - filters to next 7 days, deduplicates, handles declined events
 - ✅ Weather integration (OpenWeather API)
@@ -517,7 +519,7 @@ rally/
   - Create, read, update, delete todos
   - Optional due dates with native HTML5 date picker
   - Assign todos to family members
-  - Configurable reminder window (`remind_days_before`) — controls when a todo appears in LLM briefings relative to its due date
+  - Configurable reminder window (`remind_days_before`) — controls when a todo appears in LLM briefings relative to its due date. Uses local timezone (not UTC) for date comparisons.
   - AI formats due dates with day-of-week (e.g., "[Due Friday, Feb 20]")
   - Overdue styling for past-due items
   - Completion tracking with 24-hour visibility window

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Rally helps families come together around a shared daily plan. It synthesizes ca
 - ✅ **Todo Management** - Full CRUD interface for family tasks
   - Create, edit, complete, and delete todos
   - Optional due dates with elegant date picker
-  - Configurable reminder window — set how many days before a due date a todo appears in AI briefings
+  - Configurable reminder window — set how many days before a due date a todo appears in AI briefings (uses your configured local timezone for accurate date comparisons)
   - 24-hour visibility window for completed tasks
   - Integrated into AI summaries for schedule optimization
   - Assign todos to family members
@@ -28,7 +28,7 @@ Rally helps families come together around a shared daily plan. It synthesizes ca
 - 👨‍👩‍👧‍👦 **Family Members** - Manage family members
 - 📆 **Calendar Management** - Add and manage calendars per family member via the Settings UI (ICS feeds, Google CalDAV, Apple iCloud CalDAV)
 - ⚙️ **Settings** - Configure API keys, LLM provider, timezone, and calendars through a web UI, with automatic connection verification on save
-- 🤖 **AI-Powered Summaries** - Configurable LLM generates encouraging, action-oriented daily plans (Anthropic Claude or any OpenAI-compatible provider. GLM 4.7 Flash works well for local inference.)
+- 🤖 **AI-Powered Summaries** - Configurable LLM generates encouraging, action-oriented daily plans (Anthropic Claude or any OpenAI-compatible provider. GLM 4.7 Flash works well for local inference.) The LLM is instructed to only reference tasks explicitly present in its prompt, preventing hallucinated or premature task mentions.
 - 🏠 **Family-Centered** - Understands your routines, roles, and how you work together
 - 📱 **Smart Display Ready** - Elegant grayscale design perfect for e-ink or any display
 - 🎨 **Beautiful Design** - Serif typography, clean layout, professional aesthetic

--- a/src/rally/generator/generate.py
+++ b/src/rally/generator/generate.py
@@ -413,7 +413,7 @@ class SummaryGenerator:
 
             from rally.models import Todo
 
-            today = today_utc()
+            today = now_utc().astimezone(self.local_tz).date()
 
             # Only send incomplete todos to the LLM
             todos = (
@@ -439,8 +439,8 @@ class SummaryGenerator:
                         window_start = due - timedelta(days=todo.remind_days_before)
                         if today < window_start:
                             continue
-                    except ValueError:
-                        pass  # If date is unparseable, include the todo
+                    except ValueError, TypeError, OverflowError:
+                        pass  # If date is unparseable or calculation fails, include the todo
 
                 line = f"{todo.title}"
 
@@ -490,7 +490,7 @@ class SummaryGenerator:
 
             from rally.models import DinnerPlan
 
-            today = today_utc()
+            today = now_utc().astimezone(self.local_tz).date()
 
             # Get all dates in the range
             date_range = [(today + timedelta(days=i)).strftime("%Y-%m-%d") for i in range(7)]
@@ -761,6 +761,7 @@ Guidelines:
 7. DINNER PREP: Only mention dinner prep in briefing if action is needed TODAY, TOMORROW, or the day after (within 48 hours). Don't mention prep for dinners 3+ days away.
 8. The briefing should surface important things that need attention TODAY or VERY SOON (within 1-2 days)
 9. If the weather is actively dangerous (snow, thunderstorms, or tornado risk) within the next 7 days, mention it.
+10. TASK FILTERING: The TODOS section below is pre-filtered. Only mention, reference, or suggest tasks that explicitly appear in the TODOS section. Do not infer, recall, or invent tasks that are not listed. If the TODOS section says "No todos currently active," do not suggest any specific tasks.
 
 Do NOT include any HTML in your response. Plain text only for all values."""
 


### PR DESCRIPTION
## Summary

# Implementation Summary: Fix Reminder Window Filtering (Issue #46)

## What Changed

Single file modified: `src/rally/generator/generate.py` (5 insertions, 4 deletions)

### Change 1: Local timezone date in `load_todos()` (line 416)

Replaced `today = today_utc()` with `today = now_utc().astimezone(self.local_tz).date()`.

This ensures the reminder window filter compares against the user's local date, not UTC. When a user at UTC-6 sets a due date of "March 25" with `remind_days_before = 0`, the filter now correctly evaluates using their local date rather than UTC (which could be a day ahead late in the evening).

### Change 2: Broader exception handling in `load_todos()` (line 442)

Changed `except ValueError:` to `except ValueError, TypeError, OverflowError:` (Python 3.14 PEP 758 syntax, parentheses-free).

This catches additional edge cases: `TypeError` if `remind_days_before` were an unexpected type, and `OverflowError` if `timedelta(days=...)` received an extremely large value. The fallback behavior (include the todo) is safe.

### Change 3: Local timezone date in `load_dinner_plans()` (line 493)

Replaced `today = today_utc()` with `now_utc().astimezone(self.local_tz).date()`.

Same rationale as Change 1. Dinner plan date comparisons now use the user's local date for consistency.

### Change 4: LLM system prompt guideline 10 (line 764)

Added guideline 10 to the LLM system prompt:

> 10. TASK FILTERING: The TODOS section below is pre-filtered. Only mention, reference, or suggest tasks that explicitly appear in the TODOS section. Do not infer, recall, or invent tasks that are not listed. If the TODOS section says "No todos currently active," do not suggest any specific tasks.

This provides defense-in-depth. Even if the Python filter has an edge case, the LLM is instructed to only discuss explicitly listed tasks. Placed before the "Do NOT include any HTML" line as specified.

## Deviations from Plan

None. All four changes were implemented exactly as specified.

... (truncated)
