### PR TITLE
Add custom recurrence rules for flexible task scheduling

### DIFF
--- a/migrations/migrate_add_custom_recurrence.py
+++ b/migrations/migrate_add_custom_recurrence.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Migration: Add custom_rule column to recurring_todos table.
+
+Stores the JSON rule for custom recurrence types (daily-interval,
+weekly-interval with weekday selection, monthly-day, monthly-weekday).
+
+Safe to run multiple times (idempotent).
+"""
+
+import os
+import sqlite3
+from pathlib import Path
+
+
+def migrate():
+    """Run the migration. Return True on success, False on failure."""
+    db_path = os.environ.get("RALLY_DB_PATH")
+
+    if not db_path:
+        prod_path = Path("/data/rally.db")
+        dev_path = Path(__file__).parent.parent / "rally.db"
+        db_path = str(prod_path) if prod_path.exists() else str(dev_path)
+
+    db_path = Path(db_path)
+
+    if not db_path.exists():
+        print(f"✓ Database not found at {db_path}")
+        print("  No migration needed - database will be created with correct schema.")
+        return True
+
+    print(f"Checking database at {db_path}...")
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute("PRAGMA table_info(recurring_todos)")
+        columns = [col[1] for col in cursor.fetchall()]
+
+        if not columns:
+            print("✓ recurring_todos table does not exist yet (migration 004 will create it)")
+            print("  No migration needed - table will be created with correct schema.")
+            return True
+
+        if "custom_rule" in columns:
+            print("✓ Migration: recurring_todos.custom_rule already exists (idempotent)")
+        else:
+            print("  Adding 'custom_rule' column to recurring_todos table...")
+            cursor.execute("ALTER TABLE recurring_todos ADD COLUMN custom_rule TEXT")
+            conn.commit()
+            print("✓ Migration complete: recurring_todos.custom_rule added")
+
+        return True
+
+    except sqlite3.Error as e:
+        print(f"✗ Migration failed: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    import sys
+
+    success = migrate()
+    sys.exit(0 if success else 1)

--- a/migrations/run_migrations.py
+++ b/migrations/run_migrations.py
@@ -18,6 +18,7 @@ def run_migrations():
         from migrate_add_due_date import migrate as migrate_001_add_due_date
         from migrate_add_family_members import migrate as migrate_002_add_family_members
         from migrate_add_caldav_support import migrate as migrate_008_add_caldav_support
+        from migrate_add_custom_recurrence import migrate as migrate_009_add_custom_recurrence
         from migrate_add_last_generated_date import (
             migrate as migrate_007_add_last_generated_date,
         )
@@ -38,6 +39,7 @@ def run_migrations():
         ("006_add_reminder_window", migrate_006_add_reminder_window),
         ("007_add_last_generated_date", migrate_007_add_last_generated_date),
         ("008_add_caldav_support", migrate_008_add_caldav_support),
+        ("009_add_custom_recurrence", migrate_009_add_custom_recurrence),
     ]
 
     print("=" * 60)

--- a/src/rally/models.py
+++ b/src/rally/models.py
@@ -109,10 +109,11 @@ class RecurringTodo(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     title: Mapped[str] = mapped_column(String(200))
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
-    recurrence_type: Mapped[str] = mapped_column(String(20))  # daily, weekly, monthly
+    recurrence_type: Mapped[str] = mapped_column(String(20))  # daily, weekly, monthly, custom
     recurrence_day: Mapped[int | None] = mapped_column(
         Integer, nullable=True
     )  # 0-6 for weekly, 1-31 for monthly
+    custom_rule: Mapped[dict | None] = mapped_column(JSON, nullable=True)  # rule dict for custom recurrence type
     assigned_to: Mapped[int | None] = mapped_column(Integer, nullable=True)
     has_due_date: Mapped[bool] = mapped_column(default=False)
     remind_days_before: Mapped[int | None] = mapped_column(

--- a/src/rally/recurrence.py
+++ b/src/rally/recurrence.py
@@ -13,6 +13,166 @@ from rally.models import RecurringTodo, Todo
 from rally.utils.timezone import today_utc
 
 
+# ── Custom rule helpers ──────────────────────────────────────────────────────
+
+
+def _advance_months(year: int, month: int, interval: int) -> tuple[int, int]:
+    """Advance year/month by interval months."""
+    month += interval
+    year += (month - 1) // 12
+    month = ((month - 1) % 12) + 1
+    return year, month
+
+
+def _find_nth_weekday_in_month(year: int, month: int, ordinal: str, weekday: int) -> date:
+    """Find the nth occurrence of a weekday in a month.
+
+    ordinal: "first", "second", "third", "fourth", "last"
+    weekday: 0=Monday … 6=Sunday
+
+    Falls back to the last valid occurrence when the requested ordinal doesn't
+    exist (e.g. "fifth Monday").
+    """
+    num_days = cal_module.monthrange(year, month)[1]
+    occurrences = [date(year, month, d) for d in range(1, num_days + 1) if date(year, month, d).weekday() == weekday]
+
+    ordinal_map = {"first": 0, "second": 1, "third": 2, "fourth": 3, "last": -1}
+    idx = ordinal_map.get(ordinal, 0)
+
+    if idx == -1 or idx >= len(occurrences):
+        return occurrences[-1]
+    return occurrences[idx]
+
+
+def _next_custom(rule: dict, after_date: date) -> date:
+    """Next occurrence of a custom rule strictly after after_date."""
+    freq = rule["freq"]
+    interval = int(rule.get("interval", 1))
+
+    if freq == "daily":
+        return after_date + timedelta(days=interval)
+
+    if freq == "weekly":
+        weekdays = sorted(rule["weekdays"])
+        current_wd = after_date.weekday()
+        later_this_week = [w for w in weekdays if w > current_wd]
+        if later_this_week:
+            return after_date + timedelta(days=later_this_week[0] - current_wd)
+        # Advance to the first listed weekday of the next N-week cycle
+        week_start = after_date - timedelta(days=current_wd)
+        return week_start + timedelta(weeks=interval, days=weekdays[0])
+
+    if freq == "monthly":
+        mode = rule.get("mode", "day")
+        if mode == "day":
+            day = int(rule["day"])
+            clamped = min(day, cal_module.monthrange(after_date.year, after_date.month)[1])
+            candidate = after_date.replace(day=clamped)
+            if candidate > after_date:
+                return candidate
+            ny, nm = _advance_months(after_date.year, after_date.month, interval)
+            return date(ny, nm, min(day, cal_module.monthrange(ny, nm)[1]))
+
+        if mode == "weekday":
+            ordinal = rule["ordinal"]
+            weekday = int(rule["weekday"])
+            candidate = _find_nth_weekday_in_month(after_date.year, after_date.month, ordinal, weekday)
+            if candidate > after_date:
+                return candidate
+            ny, nm = _advance_months(after_date.year, after_date.month, interval)
+            return _find_nth_weekday_in_month(ny, nm, ordinal, weekday)
+
+    return after_date + timedelta(days=1)
+
+
+def _last_custom(rule: dict, today: date) -> date:
+    """Most recent occurrence of a custom rule on or before today."""
+    freq = rule["freq"]
+    interval = int(rule.get("interval", 1))
+
+    if freq == "daily":
+        return today
+
+    if freq == "weekly":
+        weekdays = sorted(rule["weekdays"])
+        current_wd = today.weekday()
+        past = [w for w in weekdays if w <= current_wd]
+        if past:
+            return today - timedelta(days=current_wd - past[-1])
+        # Previous N-week cycle — last listed weekday
+        week_start = today - timedelta(days=current_wd)
+        prev_week_start = week_start - timedelta(weeks=interval)
+        return prev_week_start + timedelta(days=weekdays[-1])
+
+    if freq == "monthly":
+        mode = rule.get("mode", "day")
+        if mode == "day":
+            day = int(rule["day"])
+            clamped = min(day, cal_module.monthrange(today.year, today.month)[1])
+            if today.day >= clamped:
+                return today.replace(day=clamped)
+            first = today.replace(day=1)
+            prev_end = first - timedelta(days=1)
+            return prev_end.replace(day=min(day, cal_module.monthrange(prev_end.year, prev_end.month)[1]))
+
+        if mode == "weekday":
+            ordinal = rule["ordinal"]
+            weekday = int(rule["weekday"])
+            candidate = _find_nth_weekday_in_month(today.year, today.month, ordinal, weekday)
+            if candidate <= today:
+                return candidate
+            first = today.replace(day=1)
+            prev_end = first - timedelta(days=1)
+            return _find_nth_weekday_in_month(prev_end.year, prev_end.month, ordinal, weekday)
+
+    return today
+
+
+def _first_custom(rule: dict, today: date) -> date:
+    """First occurrence of a custom rule on or after today (for new templates)."""
+    freq = rule["freq"]
+
+    if freq == "daily":
+        return today
+
+    if freq == "weekly":
+        weekdays = sorted(rule["weekdays"])
+        current_wd = today.weekday()
+        upcoming = [w for w in weekdays if w >= current_wd]
+        if upcoming:
+            return today + timedelta(days=upcoming[0] - current_wd)
+        # Next week — take the first listed weekday (interval doesn't backdate first occurrence)
+        week_start = today - timedelta(days=current_wd)
+        return week_start + timedelta(days=7 + weekdays[0])
+
+    if freq == "monthly":
+        mode = rule.get("mode", "day")
+        if mode == "day":
+            day = int(rule["day"])
+            clamped = min(day, cal_module.monthrange(today.year, today.month)[1])
+            candidate = today.replace(day=clamped)
+            if candidate >= today:
+                return candidate
+            interval = int(rule.get("interval", 1))
+            ny, nm = _advance_months(today.year, today.month, interval)
+            return date(ny, nm, min(day, cal_module.monthrange(ny, nm)[1]))
+
+        if mode == "weekday":
+            ordinal = rule["ordinal"]
+            weekday = int(rule["weekday"])
+            candidate = _find_nth_weekday_in_month(today.year, today.month, ordinal, weekday)
+            if candidate >= today:
+                return candidate
+            interval = int(rule.get("interval", 1))
+            ny, nm = _advance_months(today.year, today.month, interval)
+            return _find_nth_weekday_in_month(ny, nm, ordinal, weekday)
+
+    return today
+
+
+# ── Public recurrence API ────────────────────────────────────────────────────
+
+
 def get_last_recurrence_date(rt: RecurringTodo, today: date) -> date:
     """Get the most recent date this recurrence should have fired."""
     if rt.recurrence_type == "daily":
@@ -31,6 +191,8 @@ def get_last_recurrence_date(rt: RecurringTodo, today: date) -> date:
             last_month_end = first_of_month - timedelta(days=1)
             clamped = min(day, cal_module.monthrange(last_month_end.year, last_month_end.month)[1])
             return last_month_end.replace(day=clamped)
+    elif rt.recurrence_type == "custom" and rt.custom_rule:
+        return _last_custom(rt.custom_rule, today)
     return today
 
 
@@ -62,6 +224,8 @@ def get_next_recurrence_date(rt: RecurringTodo, after_date: date) -> date:
             next_year, next_month = after_date.year, after_date.month + 1
         clamped = min(day, cal_module.monthrange(next_year, next_month)[1])
         return date(next_year, next_month, clamped)
+    elif rt.recurrence_type == "custom" and rt.custom_rule:
+        return _next_custom(rt.custom_rule, after_date)
     return after_date + timedelta(days=1)
 
 
@@ -82,6 +246,8 @@ def get_first_recurrence_date(rt: RecurringTodo, today: date) -> date:
         day = rt.recurrence_day or 1
         clamped = min(day, cal_module.monthrange(today.year, today.month)[1])
         return today.replace(day=clamped)
+    elif rt.recurrence_type == "custom" and rt.custom_rule:
+        return _first_custom(rt.custom_rule, today)
     return today
 
 

--- a/src/rally/routers/recurring_todos.py
+++ b/src/rally/routers/recurring_todos.py
@@ -27,6 +27,7 @@ def create_recurring_todo(rt: RecurringTodoCreate, db: Session = Depends(get_db)
         assigned_to=rt.assigned_to,
         has_due_date=rt.has_due_date,
         remind_days_before=rt.remind_days_before,
+        custom_rule=rt.custom_rule,
     )
     db.add(db_rt)
     db.commit()
@@ -66,6 +67,8 @@ def update_recurring_todo(rt_id: int, rt: RecurringTodoUpdate, db: Session = Dep
         db_rt.remind_days_before = rt.remind_days_before
     if rt.active is not None:
         db_rt.active = rt.active
+    if rt.custom_rule is not UNSET:
+        db_rt.custom_rule = rt.custom_rule
 
     db.commit()
     db.refresh(db_rt)

--- a/src/rally/schemas.py
+++ b/src/rally/schemas.py
@@ -139,11 +139,12 @@ class TodoResponse(TodoBase):
 class RecurringTodoBase(BaseModel):
     title: str
     description: str | None = None
-    recurrence_type: str  # daily, weekly, monthly
+    recurrence_type: str  # daily, weekly, monthly, custom
     recurrence_day: int | None = None  # 0-6 for weekly, 1-31 for monthly
     assigned_to: int | None = None
     has_due_date: bool = False
     remind_days_before: int | None = None  # Days before due_date to start LLM reminders
+    custom_rule: dict | None = None  # JSON rule for custom recurrence type
 
 
 class RecurringTodoCreate(RecurringTodoBase):
@@ -159,6 +160,7 @@ class RecurringTodoUpdate(BaseModel):
     has_due_date: bool | None = None
     remind_days_before: int | None = UNSET  # Days before due_date; None means "always"
     active: bool | None = None
+    custom_rule: dict | None = UNSET  # UNSET means not changing; None means clear
 
 
 class RecurringTodoResponse(RecurringTodoBase):

--- a/static/styles.css
+++ b/static/styles.css
@@ -807,6 +807,41 @@ footer a:hover {
 }
 /** End Dinner Planner Styles **/
 
+/** Custom Recurrence Styles **/
+.custom-recurrence-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.weekday-checkboxes {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 4px;
+}
+
+.weekday-label {
+    font-family: var(--body-font);
+    font-size: 0.9rem;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+    color: var(--charcoal);
+    padding: 4px 8px;
+    border: 1px solid var(--light-gray);
+    background: var(--white);
+    user-select: none;
+}
+
+.weekday-label input[type="checkbox"],
+.weekday-label input[type="radio"] {
+    accent-color: var(--charcoal);
+    margin: 0;
+}
+/** End Custom Recurrence Styles **/
+
 /** Settings Page Styles **/
 .settings-actions {
     margin-top: 24px;

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -88,11 +88,67 @@
                         <option value="daily">Daily</option>
                         <option value="weekly">Weekly</option>
                         <option value="monthly">Monthly</option>
+                        <option value="custom">Custom</option>
                     </select>
                 </div>
                 <div class="form-group" id="recurring-day-group" style="display:none;">
                     <label id="recurring-day-label">Day</label>
                     <select id="recurring-day"></select>
+                </div>
+                <div id="recurring-custom-group" style="display:none;">
+                    <div class="form-group">
+                        <label>Repeat every</label>
+                        <div class="custom-recurrence-row">
+                            <input type="number" id="custom-interval" min="1" value="1" class="remind-days-input">
+                            <select id="custom-freq" style="flex:1;">
+                                <option value="daily">Days</option>
+                                <option value="weekly">Weeks</option>
+                                <option value="monthly">Months</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="form-group" id="custom-weekly-group" style="display:none;">
+                        <label>On</label>
+                        <div class="weekday-checkboxes" id="custom-weekdays">
+                            <label class="weekday-label"><input type="checkbox" value="0"> Mon</label>
+                            <label class="weekday-label"><input type="checkbox" value="1"> Tue</label>
+                            <label class="weekday-label"><input type="checkbox" value="2"> Wed</label>
+                            <label class="weekday-label"><input type="checkbox" value="3"> Thu</label>
+                            <label class="weekday-label"><input type="checkbox" value="4"> Fri</label>
+                            <label class="weekday-label"><input type="checkbox" value="5"> Sat</label>
+                            <label class="weekday-label"><input type="checkbox" value="6"> Sun</label>
+                        </div>
+                    </div>
+                    <div class="form-group" id="custom-monthly-group" style="display:none;">
+                        <label>On</label>
+                        <div style="margin-bottom:8px;">
+                            <label class="weekday-label"><input type="radio" name="custom-monthly-mode" value="day" checked> Day of month</label>
+                            <label class="weekday-label"><input type="radio" name="custom-monthly-mode" value="weekday"> Relative weekday</label>
+                        </div>
+                        <div id="custom-monthly-day-group">
+                            <select id="custom-monthly-day"></select>
+                        </div>
+                        <div id="custom-monthly-weekday-group" style="display:none;">
+                            <div class="custom-recurrence-row">
+                                <select id="custom-ordinal" style="flex:1;">
+                                    <option value="first">First</option>
+                                    <option value="second">Second</option>
+                                    <option value="third">Third</option>
+                                    <option value="fourth">Fourth</option>
+                                    <option value="last">Last</option>
+                                </select>
+                                <select id="custom-weekday" style="flex:1;">
+                                    <option value="0">Monday</option>
+                                    <option value="1">Tuesday</option>
+                                    <option value="2">Wednesday</option>
+                                    <option value="3">Thursday</option>
+                                    <option value="4">Friday</option>
+                                    <option value="5">Saturday</option>
+                                    <option value="6">Sunday</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div class="form-group">
                     <label>Assigned To (optional)</label>
@@ -556,7 +612,28 @@
             if (rt.recurrence_type === 'daily') return 'Daily';
             if (rt.recurrence_type === 'weekly') return `Weekly on ${DAY_NAMES[rt.recurrence_day] || 'Monday'}`;
             if (rt.recurrence_type === 'monthly') return `Monthly on the ${ordinal(rt.recurrence_day || 1)}`;
+            if (rt.recurrence_type === 'custom') return describeCustomRule(rt.custom_rule);
             return rt.recurrence_type;
+        }
+
+        function describeCustomRule(rule) {
+            if (!rule) return 'Custom';
+            const { freq, interval } = rule;
+            const n = interval || 1;
+            const every = n === 1 ? 'Every' : `Every ${n}`;
+            if (freq === 'daily') {
+                return n === 1 ? 'Daily' : `Every ${n} days`;
+            }
+            if (freq === 'weekly') {
+                const days = (rule.weekdays || [0]).map(d => DAY_NAMES[d].slice(0, 3)).join(', ');
+                return `${every} week${n !== 1 ? 's' : ''} on ${days}`;
+            }
+            if (freq === 'monthly') {
+                const mo = `${every} month${n !== 1 ? 's' : ''}`;
+                if (rule.mode === 'day') return `${mo} on the ${ordinal(rule.day)}`;
+                if (rule.mode === 'weekday') return `${mo} on the ${rule.ordinal} ${DAY_NAMES[rule.weekday]}`;
+            }
+            return 'Custom';
         }
 
         function ordinal(n) {
@@ -565,15 +642,32 @@
             return n + (s[(v-20)%10] || s[v] || s[0]);
         }
 
+        // Populate custom monthly day-of-month select on first use
+        (function initCustomMonthlyDay() {
+            const sel = document.getElementById('custom-monthly-day');
+            sel.innerHTML = Array.from({length: 31}, (_, i) =>
+                `<option value="${i + 1}">${ordinal(i + 1)}</option>`
+            ).join('');
+        })();
+
         // Recurring type / day selector logic
         function updateDaySelector() {
             const type = document.getElementById('recurring-type').value;
             const dayGroup = document.getElementById('recurring-day-group');
             const daySelect = document.getElementById('recurring-day');
             const dayLabel = document.getElementById('recurring-day-label');
+            const customGroup = document.getElementById('recurring-custom-group');
+
+            dayGroup.style.display = 'none';
+            customGroup.style.display = 'none';
 
             if (type === 'daily') {
-                dayGroup.style.display = 'none';
+                return;
+            }
+
+            if (type === 'custom') {
+                customGroup.style.display = '';
+                updateCustomSubGroups();
                 return;
             }
 
@@ -591,8 +685,79 @@
             }
         }
 
+        function updateCustomSubGroups() {
+            const freq = document.getElementById('custom-freq').value;
+            document.getElementById('custom-weekly-group').style.display = freq === 'weekly' ? '' : 'none';
+            document.getElementById('custom-monthly-group').style.display = freq === 'monthly' ? '' : 'none';
+        }
+
+        function updateCustomMonthlyMode() {
+            const mode = document.querySelector('input[name="custom-monthly-mode"]:checked').value;
+            document.getElementById('custom-monthly-day-group').style.display = mode === 'day' ? '' : 'none';
+            document.getElementById('custom-monthly-weekday-group').style.display = mode === 'weekday' ? '' : 'none';
+        }
+
         document.getElementById('recurring-type').addEventListener('change', updateDaySelector);
+        document.getElementById('custom-freq').addEventListener('change', updateCustomSubGroups);
+        document.querySelectorAll('input[name="custom-monthly-mode"]').forEach(r =>
+            r.addEventListener('change', updateCustomMonthlyMode)
+        );
         document.getElementById('recurring-has-due-date').addEventListener('change', toggleRecurringRemindGroup);
+
+        function resetCustomFields() {
+            document.getElementById('custom-interval').value = '1';
+            document.getElementById('custom-freq').value = 'daily';
+            document.querySelectorAll('#custom-weekdays input[type="checkbox"]').forEach(cb => cb.checked = false);
+            document.querySelector('input[name="custom-monthly-mode"][value="day"]').checked = true;
+            document.getElementById('custom-monthly-day').value = '1';
+            document.getElementById('custom-ordinal').value = 'first';
+            document.getElementById('custom-weekday').value = '0';
+            updateCustomSubGroups();
+            updateCustomMonthlyMode();
+        }
+
+        function loadCustomRule(rule) {
+            if (!rule) return;
+            document.getElementById('custom-interval').value = rule.interval || 1;
+            document.getElementById('custom-freq').value = rule.freq || 'daily';
+            updateCustomSubGroups();
+            if (rule.freq === 'weekly') {
+                const wds = rule.weekdays || [];
+                document.querySelectorAll('#custom-weekdays input[type="checkbox"]').forEach(cb => {
+                    cb.checked = wds.includes(parseInt(cb.value));
+                });
+            } else if (rule.freq === 'monthly') {
+                const mode = rule.mode || 'day';
+                document.querySelector(`input[name="custom-monthly-mode"][value="${mode}"]`).checked = true;
+                updateCustomMonthlyMode();
+                if (mode === 'day') {
+                    document.getElementById('custom-monthly-day').value = rule.day || 1;
+                } else {
+                    document.getElementById('custom-ordinal').value = rule.ordinal || 'first';
+                    document.getElementById('custom-weekday').value = rule.weekday != null ? rule.weekday : 0;
+                }
+            }
+        }
+
+        function buildCustomRule() {
+            const freq = document.getElementById('custom-freq').value;
+            const interval = parseInt(document.getElementById('custom-interval').value) || 1;
+            const rule = { freq, interval };
+            if (freq === 'weekly') {
+                rule.weekdays = [...document.querySelectorAll('#custom-weekdays input[type="checkbox"]:checked')]
+                    .map(cb => parseInt(cb.value));
+                if (rule.weekdays.length === 0) rule.weekdays = [0]; // default Monday
+            } else if (freq === 'monthly') {
+                rule.mode = document.querySelector('input[name="custom-monthly-mode"]:checked').value;
+                if (rule.mode === 'day') {
+                    rule.day = parseInt(document.getElementById('custom-monthly-day').value);
+                } else {
+                    rule.ordinal = document.getElementById('custom-ordinal').value;
+                    rule.weekday = parseInt(document.getElementById('custom-weekday').value);
+                }
+            }
+            return rule;
+        }
 
         function openAddRecurringModal() {
             editingRecurringId = null;
@@ -603,6 +768,7 @@
             document.getElementById('recurring-type').value = 'daily';
             document.getElementById('recurring-remind-days').value = '';
             document.getElementById('btn-delete-recurring').style.display = 'none';
+            resetCustomFields();
             updateDaySelector();
             toggleRecurringRemindGroup();
             document.getElementById('recurring-modal-overlay').style.display = 'flex';
@@ -618,8 +784,11 @@
             document.getElementById('recurring-title').value = rt.title;
             document.getElementById('recurring-description').value = rt.description || '';
             document.getElementById('recurring-type').value = rt.recurrence_type;
+            resetCustomFields();
             updateDaySelector();
-            if (rt.recurrence_day !== null) {
+            if (rt.recurrence_type === 'custom') {
+                loadCustomRule(rt.custom_rule);
+            } else if (rt.recurrence_day !== null) {
                 document.getElementById('recurring-day').value = rt.recurrence_day;
             }
             document.getElementById('recurring-assigned-to').value = rt.assigned_to || '';
@@ -682,14 +851,16 @@
             const type = document.getElementById('recurring-type').value;
             const assignedTo = document.getElementById('recurring-assigned-to').value;
             const recurringRemindDays = document.getElementById('recurring-remind-days').value;
+            const isBuiltIn = type === 'daily' || type === 'weekly' || type === 'monthly';
             const data = {
                 title: document.getElementById('recurring-title').value,
                 description: document.getElementById('recurring-description').value || null,
                 recurrence_type: type,
-                recurrence_day: type !== 'daily' ? parseInt(document.getElementById('recurring-day').value) : null,
+                recurrence_day: isBuiltIn && type !== 'daily' ? parseInt(document.getElementById('recurring-day').value) : null,
                 assigned_to: assignedTo ? parseInt(assignedTo) : null,
                 has_due_date: document.getElementById('recurring-has-due-date').checked,
                 remind_days_before: recurringRemindDays !== '' ? parseInt(recurringRemindDays) : null,
+                custom_rule: type === 'custom' ? buildCustomRule() : null,
             };
 
             try {


### PR DESCRIPTION
## Summary
This PR adds support for custom recurrence rules, allowing users to create flexible recurring tasks beyond the built-in daily/weekly/monthly options. Users can now define tasks that repeat at custom intervals with fine-grained control over frequency and occurrence patterns.

## Key Changes

**Frontend (templates/todo.html & static/styles.css)**
- Added "Custom" option to recurrence type selector
- Implemented comprehensive custom recurrence UI with conditional sub-groups:
  - Interval selector (repeat every N days/weeks/months)
  - Weekly mode: checkboxes for selecting specific weekdays
  - Monthly mode: toggle between day-of-month and relative weekday (e.g., "second Friday")
- Added helper functions to build/load/describe custom rules
- Added event listeners to show/hide relevant UI sections based on frequency selection
- Added CSS styling for weekday checkboxes and custom recurrence layout

**Backend (src/rally/recurrence.py)**
- Implemented core custom rule logic with three main functions:
  - `_next_custom()`: Calculate next occurrence strictly after a given date
  - `_last_custom()`: Find most recent occurrence on or before today
  - `_first_custom()`: Find first occurrence on or after today (for new templates)
- Added helper functions for month arithmetic and finding nth weekday in month
- Integrated custom rules into existing public API (`get_next_recurrence_date`, `get_last_recurrence_date`, `get_first_recurrence_date`)

**Data Model & API**
- Added `custom_rule` JSON field to `RecurringTodo` model to store rule configuration
- Updated schemas to accept `custom_rule` in request/response payloads
- Updated router to persist custom rules when creating/updating recurring todos

**Database**
- Added migration script (`migrate_add_custom_recurrence.py`) to add `custom_rule` TEXT column to `recurring_todos` table
- Migration is idempotent and handles cases where database doesn't exist yet

## Implementation Details

- Custom rules are stored as JSON objects with structure: `{freq, interval, weekdays?, mode?, day?, ordinal?, weekday?}`
- Weekly rules support multiple weekday selection with fallback to Monday if none selected
- Monthly rules support two modes:
  - `day`: specific day of month (e.g., 15th) with clamping for months with fewer days
  - `weekday`: relative occurrence (e.g., "last Friday") using ordinal + weekday
- All date calculations properly handle edge cases like month boundaries and leap years
- UI state management ensures only relevant fields are shown based on selected frequency

https://claude.ai/code/session_01W2afMpyF76KmzjhvdY9Grh