### PR TITLE
Fix due dates not being removable from tasks

### DIFF
--- a/src/rally/routers/todos.py
+++ b/src/rally/routers/todos.py
@@ -83,7 +83,7 @@ def update_todo(
         db_todo.title = todo.title
     if todo.description is not None:
         db_todo.description = todo.description
-    if todo.due_date is not None:
+    if todo.due_date is not UNSET:
         db_todo.due_date = todo.due_date
     if todo.assigned_to is not UNSET:
         db_todo.assigned_to = todo.assigned_to

--- a/src/rally/schemas.py
+++ b/src/rally/schemas.py
@@ -116,7 +116,7 @@ class TodoCreate(TodoBase):
 class TodoUpdate(BaseModel):
     title: str | None = None
     description: str | None = None
-    due_date: str | None = None  # YYYY-MM-DD format
+    due_date: str | None = UNSET  # YYYY-MM-DD format; None means "clear"; UNSET means "not provided"
     assigned_to: int | None = UNSET  # family_members.id; None means "Everyone"
     remind_days_before: int | None = UNSET  # Days before due_date; None means "always"
     completed: bool | None = None


### PR DESCRIPTION
The TodoUpdate schema used None as both the "not provided" sentinel and
the value for "clear the due date", causing the update endpoint to skip
clearing when the frontend sent null. Apply the same UNSET sentinel
pattern already used for assigned_to and remind_days_before.

https://claude.ai/code/session_01VwinrnErURVfLydjwVyJis