### PR TITLE
Show "Last completed" date on recurring task templates (issue #49)

### DIFF
--- a/src/rally/routers/recurring_todos.py
+++ b/src/rally/routers/recurring_todos.py
@@ -1,11 +1,13 @@
 """Recurring todos router for Rally."""
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from rally.database import get_db
-from rally.models import RecurringTodo
+from rally.models import RecurringTodo, Todo
 from rally.schemas import UNSET, RecurringTodoCreate, RecurringTodoResponse, RecurringTodoUpdate
+from rally.utils.timezone import ensure_utc
 
 router = APIRouter(prefix="/api/recurring-todos", tags=["recurring-todos"])
 
@@ -13,7 +15,25 @@ router = APIRouter(prefix="/api/recurring-todos", tags=["recurring-todos"])
 @router.get("", response_model=list[RecurringTodoResponse])
 def list_recurring_todos(db: Session = Depends(get_db)):
     """List all recurring todo templates."""
-    return db.query(RecurringTodo).order_by(RecurringTodo.created_at.desc()).all()
+    rts = db.query(RecurringTodo).order_by(RecurringTodo.created_at.desc()).all()
+
+    last_completed_rows = (
+        db.query(Todo.recurring_todo_id, func.max(Todo.updated_at).label("last_completed_at"))
+        .filter(Todo.completed == True, Todo.recurring_todo_id.isnot(None))  # noqa: E712
+        .group_by(Todo.recurring_todo_id)
+        .all()
+    )
+    last_completed_map = {row.recurring_todo_id: row.last_completed_at for row in last_completed_rows}
+
+    results = []
+    for rt in rts:
+        response = RecurringTodoResponse.model_validate(rt)
+        last_dt = last_completed_map.get(rt.id)
+        if last_dt:
+            response.last_completed_date = ensure_utc(last_dt).date().isoformat()
+        results.append(response)
+
+    return results
 
 
 @router.post("", response_model=RecurringTodoResponse, status_code=201)

--- a/src/rally/schemas.py
+++ b/src/rally/schemas.py
@@ -167,6 +167,7 @@ class RecurringTodoResponse(RecurringTodoBase):
     id: int
     active: bool
     last_generated_date: str | None = None
+    last_completed_date: str | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -423,6 +423,7 @@
                             <div class="editable-item-content">
                                 <div class="editable-item-title">${escapeHtml(rt.title)} ${assigneeHtml} ${pausedHtml}</div>
                                 <div class="recurring-schedule">${describeRecurrence(rt)} ${dueBadge}</div>
+                                <div class="recurring-schedule">Last completed: ${formatLastCompleted(rt.last_completed_date)}</div>
                             </div>
                             <div class="editable-item-actions">
                                 <button class="btn-edit" onclick="toggleRecurringActive(${rt.id}, ${rt.active})">${rt.active ? 'Pause' : 'Resume'}</button>
@@ -640,6 +641,19 @@
             const s = ['th','st','nd','rd'];
             const v = n % 100;
             return n + (s[(v-20)%10] || s[v] || s[0]);
+        }
+
+        function formatLastCompleted(dateStr) {
+            if (!dateStr) return 'Never';
+            const completed = new Date(dateStr + 'T00:00:00');
+            const today = new Date();
+            today.setHours(0, 0, 0, 0);
+            const yesterday = new Date(today);
+            yesterday.setDate(today.getDate() - 1);
+            if (completed.getTime() === today.getTime()) return 'Today';
+            if (completed.getTime() === yesterday.getTime()) return 'Yesterday';
+            const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+            return `${months[completed.getMonth()]} ${ordinal(completed.getDate())}, ${completed.getFullYear()}`;
         }
 
         // Populate custom monthly day-of-month select on first use


### PR DESCRIPTION
Adds a Last completed line beneath the recurrence schedule for every
recurring task template. The backend queries the most recent completed
Todo instance per template and returns the date as YYYY-MM-DD; the
frontend formats it as Today, Yesterday, or "Apr 26th, 2026".

https://claude.ai/code/session_017prRbWYto1qGREQirBaXik