### PR TITLE
Add weekdays-only option for daily recurring tasks

### DIFF
--- a/src/rally/recurrence.py
+++ b/src/rally/recurrence.py
@@ -50,7 +50,14 @@ def _next_custom(rule: dict, after_date: date) -> date:
     interval = int(rule.get("interval", 1))
 
     if freq == "daily":
-        return after_date + timedelta(days=interval)
+        next_date = after_date + timedelta(days=interval)
+        if rule.get("weekdays_only"):
+            wd = next_date.weekday()
+            if wd == 5:  # Saturday -> Monday
+                next_date += timedelta(days=2)
+            elif wd == 6:  # Sunday -> Monday
+                next_date += timedelta(days=1)
+        return next_date
 
     if freq == "weekly":
         weekdays = sorted(rule["weekdays"])

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -107,6 +107,12 @@
                             </select>
                         </div>
                     </div>
+                    <div class="form-group" id="custom-weekdays-only-group" style="display:none;">
+                        <label title="When checked, if the next due date falls on a weekend, it will be moved to the following Monday. Useful for tasks that must be done at a specific interval but can only be completed on weekdays (e.g., medical appointments, office pickups).">
+                            <input type="checkbox" id="custom-weekdays-only">
+                            Schedule on weekdays only
+                        </label>
+                    </div>
                     <div class="form-group" id="custom-weekly-group" style="display:none;">
                         <label>On</label>
                         <div class="weekday-checkboxes" id="custom-weekdays">
@@ -623,7 +629,8 @@
             const n = interval || 1;
             const every = n === 1 ? 'Every' : `Every ${n}`;
             if (freq === 'daily') {
-                return n === 1 ? 'Daily' : `Every ${n} days`;
+                const base = n === 1 ? 'Daily' : `Every ${n} days`;
+                return rule.weekdays_only ? `${base} (weekdays only)` : base;
             }
             if (freq === 'weekly') {
                 const days = (rule.weekdays || [0]).map(d => DAY_NAMES[d].slice(0, 3)).join(', ');
@@ -701,8 +708,12 @@
 
         function updateCustomSubGroups() {
             const freq = document.getElementById('custom-freq').value;
+            document.getElementById('custom-weekdays-only-group').style.display = freq === 'daily' ? '' : 'none';
             document.getElementById('custom-weekly-group').style.display = freq === 'weekly' ? '' : 'none';
             document.getElementById('custom-monthly-group').style.display = freq === 'monthly' ? '' : 'none';
+            if (freq !== 'daily') {
+                document.getElementById('custom-weekdays-only').checked = false;
+            }
         }
 
         function updateCustomMonthlyMode() {
@@ -721,6 +732,7 @@
         function resetCustomFields() {
             document.getElementById('custom-interval').value = '1';
             document.getElementById('custom-freq').value = 'daily';
+            document.getElementById('custom-weekdays-only').checked = false;
             document.querySelectorAll('#custom-weekdays input[type="checkbox"]').forEach(cb => cb.checked = false);
             document.querySelector('input[name="custom-monthly-mode"][value="day"]').checked = true;
             document.getElementById('custom-monthly-day').value = '1';
@@ -735,6 +747,9 @@
             document.getElementById('custom-interval').value = rule.interval || 1;
             document.getElementById('custom-freq').value = rule.freq || 'daily';
             updateCustomSubGroups();
+            if (rule.freq === 'daily') {
+                document.getElementById('custom-weekdays-only').checked = !!rule.weekdays_only;
+            }
             if (rule.freq === 'weekly') {
                 const wds = rule.weekdays || [];
                 document.querySelectorAll('#custom-weekdays input[type="checkbox"]').forEach(cb => {
@@ -757,6 +772,9 @@
             const freq = document.getElementById('custom-freq').value;
             const interval = parseInt(document.getElementById('custom-interval').value) || 1;
             const rule = { freq, interval };
+            if (freq === 'daily' && document.getElementById('custom-weekdays-only').checked) {
+                rule.weekdays_only = true;
+            }
             if (freq === 'weekly') {
                 rule.weekdays = [...document.querySelectorAll('#custom-weekdays input[type="checkbox"]:checked')]
                     .map(cb => parseInt(cb.value));


### PR DESCRIPTION
## Summary
This PR adds a "Schedule on weekdays only" option for daily recurring tasks. When enabled, if a task's next due date falls on a weekend (Saturday or Sunday), it will automatically be moved to the following Monday.

## Key Changes
- **Frontend (templates/todo.html)**:
  - Added a new checkbox form group "Schedule on weekdays only" that appears only when daily frequency is selected
  - Updated the recurrence rule display to show "(weekdays only)" suffix for daily tasks with this option enabled
  - Modified `updateCustomSubGroups()` to show/hide the weekdays-only option based on frequency and reset the checkbox when switching away from daily frequency
  - Updated `resetCustomFields()` to reset the weekdays-only checkbox
  - Modified `loadCustomRule()` to populate the weekdays-only checkbox when editing existing rules
  - Updated `buildCustomRule()` to include the `weekdays_only` flag in the rule object when the checkbox is checked

- **Backend (src/rally/recurrence.py)**:
  - Enhanced `_next_custom()` function to handle the weekdays-only logic for daily recurrence
  - When a calculated next date falls on Saturday (weekday 5), it advances by 2 days to Monday
  - When a calculated next date falls on Sunday (weekday 6), it advances by 1 day to Monday

## Implementation Details
- The weekdays-only option is only available for daily frequency tasks, as indicated by the conditional display logic
- The feature respects the recurrence interval (e.g., "Every 3 days" with weekdays-only will still maintain the 3-day interval but skip weekends)
- The tooltip explains the use case: tasks that must be done at a specific interval but can only be completed on weekdays (e.g., medical appointments, office pickups)

https://claude.ai/code/session_01A2rdwew7YsFmKFWbBtgzRh