### PR TITLE
Expand dinner planner to support multiple meal types

### DIFF
--- a/migrations/migrate_add_meal_type.py
+++ b/migrations/migrate_add_meal_type.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Migration to add meal_type column to dinner_plans table.
+
+Existing records are migrated to type 'Dinner'.
+Run this once to upgrade existing databases. Safe to run multiple times (idempotent).
+"""
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def migrate():
+    db_path = os.environ.get("RALLY_DB_PATH")
+
+    if not db_path:
+        prod_path = Path("/data/rally.db")
+        dev_path = Path(__file__).parent.parent / "rally.db"
+        db_path = str(prod_path) if prod_path.exists() else str(dev_path)
+
+    db_path = Path(db_path)
+
+    if not db_path.exists():
+        print(f"✓ Database not found at {db_path}")
+        print("  No migration needed - database will be created with correct schema on first run.")
+        return True
+
+    print(f"Checking database at {db_path}...")
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='dinner_plans'")
+        if not cursor.fetchone():
+            print("✓ Migration: dinner_plans table does not exist yet (will be created on first run)")
+            return True
+
+        cursor.execute("PRAGMA table_info(dinner_plans)")
+        columns = [col[1] for col in cursor.fetchall()]
+
+        if "meal_type" not in columns:
+            print("  Adding 'meal_type' column to dinner_plans table...")
+            cursor.execute(
+                "ALTER TABLE dinner_plans ADD COLUMN meal_type VARCHAR(20) NOT NULL DEFAULT 'Dinner'"
+            )
+            print("✓ Migration: dinner_plans.meal_type column added (existing records set to 'Dinner')")
+        else:
+            print("✓ Migration: dinner_plans.meal_type column already exists (idempotent check)")
+
+        conn.commit()
+        return True
+
+    except sqlite3.Error as e:
+        print(f"✗ Migration failed: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    success = migrate()
+    sys.exit(0 if success else 1)

--- a/migrations/run_migrations.py
+++ b/migrations/run_migrations.py
@@ -22,6 +22,7 @@ def run_migrations():
         from migrate_add_last_generated_date import (
             migrate as migrate_007_add_last_generated_date,
         )
+        from migrate_add_meal_type import migrate as migrate_010_add_meal_type
         from migrate_add_recurring_todos import migrate as migrate_004_add_recurring_todos
         from migrate_add_reminder_window import migrate as migrate_006_add_reminder_window
         from migrate_add_settings import migrate as migrate_003_add_settings
@@ -40,6 +41,7 @@ def run_migrations():
         ("007_add_last_generated_date", migrate_007_add_last_generated_date),
         ("008_add_caldav_support", migrate_008_add_caldav_support),
         ("009_add_custom_recurrence", migrate_009_add_custom_recurrence),
+        ("010_add_meal_type", migrate_010_add_meal_type),
     ]
 
     print("=" * 60)

--- a/src/rally/cli.py
+++ b/src/rally/cli.py
@@ -160,30 +160,46 @@ def seed():
         for todo in todos:
             db.add(todo)
 
-        # Create sample dinner plans (multiple per date to showcase the feature)
+        # Create sample meal plans (multiple per date to showcase the feature)
         today_date = today_utc()
         dinner_plans = [
-            # Tonight: two separate dinners
+            # Today: breakfast and dinner for different groups
             DinnerPlan(
                 date=today_date.strftime("%Y-%m-%d"),
+                meal_type="Breakfast",
+                plan="Pancakes and bacon",
+                attendee_ids=[dad.id, jake.id, emma.id],
+                cook_id=dad.id,
+            ),
+            DinnerPlan(
+                date=today_date.strftime("%Y-%m-%d"),
+                meal_type="Dinner",
                 plan="Chicken pot pie",
                 attendee_ids=[dad.id, jake.id],
                 cook_id=dad.id,
             ),
             DinnerPlan(
                 date=today_date.strftime("%Y-%m-%d"),
+                meal_type="Dinner",
                 plan="Texas Roadhouse",
                 attendee_ids=[mom.id, emma.id],
             ),
-            # Tomorrow: whole family
+            # Tomorrow: whole family dinner
             DinnerPlan(
                 date=(today_date + timedelta(days=1)).strftime("%Y-%m-%d"),
+                meal_type="Dinner",
                 plan="Spaghetti and meatballs with garlic bread",
                 cook_id=mom.id,
             ),
-            # Day after: assigned cook, everyone eating
+            # Day after: lunch and dinner
             DinnerPlan(
                 date=(today_date + timedelta(days=3)).strftime("%Y-%m-%d"),
+                meal_type="Lunch",
+                plan="Leftovers",
+            ),
+            DinnerPlan(
+                date=(today_date + timedelta(days=3)).strftime("%Y-%m-%d"),
+                meal_type="Dinner",
                 plan="Grilled burgers and corn on the cob",
                 cook_id=dad.id,
             ),
@@ -198,7 +214,7 @@ def seed():
         print(f"   - {len(calendars)} calendars")
         print(f"   - {len(sample_settings)} settings")
         print(f"   - {len(todos)} sample todos")
-        print(f"   - {len(dinner_plans)} dinner plans")
+        print(f"   - {len(dinner_plans)} meal plans")
 
     except Exception as e:
         db.rollback()

--- a/src/rally/generator/generate.py
+++ b/src/rally/generator/generate.py
@@ -483,7 +483,7 @@ class SummaryGenerator:
             db.close()
 
     def load_dinner_plans(self) -> str:
-        """Load dinner plans for next 7 days from database for LLM context."""
+        """Load meal plans for next 7 days from database for LLM context."""
         db = SessionLocal()
         try:
             from datetime import datetime
@@ -504,7 +504,7 @@ class SummaryGenerator:
             )
 
             if not plans:
-                return "No dinner plans for the next 7 days."
+                return "No meal plans for the next 7 days."
 
             # Load family members for attendee/cook names
             members = self.load_family_members()
@@ -514,13 +514,14 @@ class SummaryGenerator:
             for plan in plans:
                 plan_date = datetime.strptime(plan.date, "%Y-%m-%d").date()
                 days_away = (plan_date - today).days
+                meal_type = getattr(plan, "meal_type", "Dinner") or "Dinner"
 
                 if days_away == 0:
-                    day_label = "Tonight"
+                    day_label = f"Today ({meal_type})"
                 elif days_away == 1:
-                    day_label = "Tomorrow night"
+                    day_label = f"Tomorrow ({meal_type})"
                 else:
-                    day_label = f"{plan_date.strftime('%A')} ({plan_date.strftime('%b %d')})"
+                    day_label = f"{plan_date.strftime('%A')} ({plan_date.strftime('%b %d')}) [{meal_type}]"
 
                 line = f"{day_label}: {plan.plan}"
 

--- a/src/rally/main.py
+++ b/src/rally/main.py
@@ -56,8 +56,14 @@ def todo_page(request: Request):
 
 @app.get("/dinner-planner", response_class=HTMLResponse)
 def dinner_planner_page(request: Request):
-    """Serve the dinner planner page."""
+    """Serve the meal planner page."""
     return templates.TemplateResponse("dinner_planner.html", {"request": request})
+
+
+@app.get("/meal-planner", response_class=RedirectResponse)
+def meal_planner_redirect():
+    """Redirect /meal-planner to /dinner-planner for convenience."""
+    return RedirectResponse(url="/dinner-planner")
 
 
 @app.get("/settings", response_class=HTMLResponse)

--- a/src/rally/models.py
+++ b/src/rally/models.py
@@ -128,12 +128,13 @@ class RecurringTodo(Base):
 
 
 class DinnerPlan(Base):
-    """Dinner plan model - meal plans by date."""
+    """Meal plan model - meal plans by date."""
 
     __tablename__ = "dinner_plans"
 
     id: Mapped[int] = mapped_column(primary_key=True)
     date: Mapped[str] = mapped_column(String(10))  # YYYY-MM-DD (multiple plans per date allowed)
+    meal_type: Mapped[str] = mapped_column(String(20), default="Dinner")  # Breakfast, Lunch, Dinner, Snacks
     plan: Mapped[str] = mapped_column(Text)
     attendee_ids: Mapped[list | None] = mapped_column(
         JSON, nullable=True

--- a/src/rally/routers/dinner_planner.py
+++ b/src/rally/routers/dinner_planner.py
@@ -1,6 +1,7 @@
-"""Dinner planner router for Rally."""
+"""Meal planner router for Rally."""
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import case
 from sqlalchemy.orm import Session
 
 from rally.database import get_db
@@ -9,19 +10,27 @@ from rally.schemas import UNSET, DinnerPlanCreate, DinnerPlanResponse, DinnerPla
 
 router = APIRouter(prefix="/api/dinner-plans", tags=["dinner-plans"])
 
+# Fixed meal type sort order: Breakfast < Lunch < Dinner < Snacks
+_MEAL_TYPE_ORDER = case(
+    {"Breakfast": 0, "Lunch": 1, "Dinner": 2, "Snacks": 3},
+    value=DinnerPlan.meal_type,
+    else_=99,
+)
+
 
 @router.get("", response_model=list[DinnerPlanResponse])
 def list_dinner_plans(db: Session = Depends(get_db)):
-    """List all dinner plans."""
-    plans = db.query(DinnerPlan).order_by(DinnerPlan.date.asc(), DinnerPlan.id.asc()).all()
+    """List all meal plans ordered by date then meal type."""
+    plans = db.query(DinnerPlan).order_by(DinnerPlan.date.asc(), _MEAL_TYPE_ORDER).all()
     return plans
 
 
 @router.post("", response_model=DinnerPlanResponse, status_code=201)
 def create_dinner_plan(plan: DinnerPlanCreate, db: Session = Depends(get_db)):
-    """Create a new dinner plan. Multiple plans per date are allowed."""
+    """Create a new meal plan. Multiple plans per date are allowed."""
     db_plan = DinnerPlan(
         date=plan.date,
+        meal_type=plan.meal_type,
         plan=plan.plan,
         attendee_ids=plan.attendee_ids,
         cook_id=plan.cook_id,
@@ -34,17 +43,22 @@ def create_dinner_plan(plan: DinnerPlanCreate, db: Session = Depends(get_db)):
 
 @router.get("/date/{date}", response_model=list[DinnerPlanResponse])
 def get_dinner_plans_by_date(date: str, db: Session = Depends(get_db)):
-    """Get all dinner plans for a specific date (YYYY-MM-DD)."""
-    plans = db.query(DinnerPlan).filter(DinnerPlan.date == date).order_by(DinnerPlan.id.asc()).all()
+    """Get all meal plans for a specific date (YYYY-MM-DD)."""
+    plans = (
+        db.query(DinnerPlan)
+        .filter(DinnerPlan.date == date)
+        .order_by(_MEAL_TYPE_ORDER)
+        .all()
+    )
     return plans
 
 
 @router.get("/{plan_id}", response_model=DinnerPlanResponse)
 def get_dinner_plan(plan_id: int, db: Session = Depends(get_db)):
-    """Get a specific dinner plan by ID."""
+    """Get a specific meal plan by ID."""
     plan = db.query(DinnerPlan).filter(DinnerPlan.id == plan_id).first()
     if not plan:
-        raise HTTPException(status_code=404, detail="Dinner plan not found")
+        raise HTTPException(status_code=404, detail="Meal plan not found")
     return plan
 
 
@@ -54,14 +68,15 @@ def update_dinner_plan(
     plan: DinnerPlanUpdate,
     db: Session = Depends(get_db),
 ):
-    """Update a dinner plan."""
+    """Update a meal plan."""
     db_plan = db.query(DinnerPlan).filter(DinnerPlan.id == plan_id).first()
     if not db_plan:
-        raise HTTPException(status_code=404, detail="Dinner plan not found")
+        raise HTTPException(status_code=404, detail="Meal plan not found")
 
-    # Update only provided fields
     if plan.date is not None:
         db_plan.date = plan.date
+    if plan.meal_type is not None:
+        db_plan.meal_type = plan.meal_type
     if plan.plan is not None:
         db_plan.plan = plan.plan
     if plan.attendee_ids is not UNSET:
@@ -76,10 +91,10 @@ def update_dinner_plan(
 
 @router.delete("/{plan_id}", status_code=204)
 def delete_dinner_plan(plan_id: int, db: Session = Depends(get_db)):
-    """Delete a dinner plan."""
+    """Delete a meal plan."""
     db_plan = db.query(DinnerPlan).filter(DinnerPlan.id == plan_id).first()
     if not db_plan:
-        raise HTTPException(status_code=404, detail="Dinner plan not found")
+        raise HTTPException(status_code=404, detail="Meal plan not found")
 
     db.delete(db_plan)
     db.commit()

--- a/src/rally/schemas.py
+++ b/src/rally/schemas.py
@@ -174,11 +174,14 @@ class RecurringTodoResponse(RecurringTodoBase):
     model_config = ConfigDict(from_attributes=True)
 
 
-# Dinner Plans
+# Meal Plans (stored in dinner_plans table)
+
+MEAL_TYPES = ("Breakfast", "Lunch", "Dinner", "Snacks")
 
 
 class DinnerPlanBase(BaseModel):
     date: str  # YYYY-MM-DD format
+    meal_type: str = "Dinner"  # Breakfast, Lunch, Dinner, Snacks
     plan: str
     attendee_ids: list[int] | None = None  # family_member IDs (who's eating); None = everyone
     cook_id: int | None = None  # family_member ID (who's cooking)
@@ -190,6 +193,7 @@ class DinnerPlanCreate(DinnerPlanBase):
 
 class DinnerPlanUpdate(BaseModel):
     date: str | None = None
+    meal_type: str | None = None
     plan: str | None = None
     attendee_ids: list[int] | None = UNSET  # None means "clear"; UNSET means "not provided"
     cook_id: int | None = UNSET  # None means "clear"; UNSET means "not provided"

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -19,7 +19,7 @@
     <nav>
         <a href="/dashboard" class="active">Dashboard</a>
         <a href="/todo">Tasks</a>
-        <a href="/dinner-planner">Dinner Planner</a>
+        <a href="/dinner-planner">Meal Planner</a>
     </nav>
 
     <!-- Greeting -->

--- a/templates/dinner_planner.html
+++ b/templates/dinner_planner.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Rally — Dinner Planner</title>
+    <title>Rally — Meal Planner</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📰</text></svg>">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -13,31 +13,31 @@
 <body>
     <header class="header">
         <h1>Rally</h1>
-        <div class="subtitle">Dinner Planner</div>
+        <div class="subtitle">Meal Planner</div>
     </header>
 
     <nav>
         <a href="/dashboard">Dashboard</a>
         <a href="/todo">Tasks</a>
-        <a href="/dinner-planner" class="active">Dinner Planner</a>
+        <a href="/dinner-planner" class="active">Meal Planner</a>
     </nav>
 
     <div class="section-container">
         <div class="header-container">
-            <h2>Dinner Planner</h2>
+            <h2>Meal Planner</h2>
             <div class="header-actions">
-                <button class="btn-add" id="btn-add-dinner">Add Dinner</button>
+                <button class="btn-add" id="btn-add-meal">Add Meal</button>
             </div>
         </div>
         <div class="list-container" id="plans-list">
-            <div class="container-loading-state">Loading dinner plans...</div>
+            <div class="container-loading-state">Loading meal plans...</div>
         </div>
     </div>
 
     <!-- Modal for add/edit -->
     <div class="modal-overlay" id="modal-overlay">
         <div class="modal-content">
-            <h3 id="modal-title">Add Dinner Plan</h3>
+            <h3 id="modal-title">Add Meal Plan</h3>
             <form id="plan-form">
                 <input type="hidden" id="plan-edit-id">
                 <div class="form-group">
@@ -45,8 +45,17 @@
                     <input type="date" id="plan-date" required>
                 </div>
                 <div class="form-group">
+                    <label>Meal Type</label>
+                    <select id="plan-meal-type" required>
+                        <option value="Breakfast">Breakfast</option>
+                        <option value="Lunch">Lunch</option>
+                        <option value="Dinner">Dinner</option>
+                        <option value="Snacks">Snacks</option>
+                    </select>
+                </div>
+                <div class="form-group">
                     <label>Meal Plan</label>
-                    <textarea id="plan-text" placeholder="What's for dinner?" required rows="3"></textarea>
+                    <textarea id="plan-text" placeholder="What's on the menu?" required rows="3"></textarea>
                 </div>
                 <div class="form-group">
                     <label>Who's Eating? <small>(leave unchecked for everyone)</small></label>
@@ -74,6 +83,10 @@
         let plans = [];
         let familyMembers = [];
         let editingId = null;
+        let defaultMealType = 'Dinner';
+
+        const MEAL_TYPES = ['Breakfast', 'Lunch', 'Dinner', 'Snacks'];
+        const MEAL_TYPE_ORDER = { 'Breakfast': 0, 'Lunch': 1, 'Dinner': 2, 'Snacks': 3 };
 
         // Get date N days from now
         function getDateInDays(days) {
@@ -93,7 +106,7 @@
             const planDate = new Date(date);
             planDate.setHours(0, 0, 0, 0);
 
-            if (planDate.getTime() === today.getTime()) return 'Tonight';
+            if (planDate.getTime() === today.getTime()) return 'Today';
             if (planDate.getTime() === tomorrow.getTime()) return 'Tomorrow';
 
             return date.toLocaleDateString('en-US', { weekday: 'long', month: 'short', day: 'numeric' });
@@ -136,15 +149,41 @@
             return val ? parseInt(val) : null;
         }
 
+        // Settings
+        async function fetchDefaultMealType() {
+            try {
+                const response = await fetch('/api/settings');
+                const data = await response.json();
+                const s = data.settings || {};
+                defaultMealType = s.meal_default_type || 'Dinner';
+            } catch (_) {
+                defaultMealType = 'Dinner';
+            }
+            populateMealTypeSelector();
+        }
+
+        function populateMealTypeSelector() {
+            const select = document.getElementById('plan-meal-type');
+            select.innerHTML = MEAL_TYPES.map(t => {
+                const label = t === defaultMealType ? `${t} (default)` : t;
+                return `<option value="${t}">${label}</option>`;
+            }).join('');
+        }
+
         // API calls
         async function fetchPlans() {
             const response = await fetch('/api/dinner-plans');
             const allPlans = await response.json();
 
-            // Filter to next 7 days
+            // Filter to next 7 days, then sort by date then meal type order
             const today = new Date().toISOString().split('T')[0];
             const weekFromNow = getDateInDays(7);
-            plans = allPlans.filter(p => p.date >= today && p.date <= weekFromNow);
+            plans = allPlans
+                .filter(p => p.date >= today && p.date <= weekFromNow)
+                .sort((a, b) => {
+                    if (a.date !== b.date) return a.date.localeCompare(b.date);
+                    return (MEAL_TYPE_ORDER[a.meal_type] ?? 99) - (MEAL_TYPE_ORDER[b.meal_type] ?? 99);
+                });
 
             renderPlans();
         }
@@ -181,7 +220,7 @@
             const container = document.getElementById('plans-list');
 
             if (plans.length === 0) {
-                container.innerHTML = '<div class="container-empty-state">No dinner plans for the next 7 days. Click "Add Dinner" to get started.</div>';
+                container.innerHTML = '<div class="container-empty-state">No meal plans for the next 7 days. Click "Add Meal" to get started.</div>';
                 return;
             }
 
@@ -199,10 +238,12 @@
                 const metaHtml = parts.length > 0
                     ? `<div class="editable-item-description">${parts.join(' · ')}</div>` : '';
 
+                const mealType = plan.meal_type || 'Dinner';
+
                 return `
                     <div class="editable-item" data-id="${plan.id}">
                         <div class="editable-item-content">
-                            <div class="editable-item-title">${escapeHtml(plan.plan)}</div>
+                            <div class="editable-item-title"><strong>${escapeHtml(mealType)}:</strong> ${escapeHtml(plan.plan)}</div>
                             ${metaHtml}
                             <div class="plan-date">${escapeHtml(formatDate(plan.date))}</div>
                         </div>
@@ -223,10 +264,12 @@
         // Modal
         function openAddModal() {
             editingId = null;
-            document.getElementById('modal-title').textContent = 'Add Dinner Plan';
+            document.getElementById('modal-title').textContent = 'Add Meal Plan';
             document.getElementById('plan-form').reset();
             document.getElementById('plan-edit-id').value = '';
             document.getElementById('plan-date').value = new Date().toISOString().split('T')[0];
+            // Pre-select default meal type
+            document.getElementById('plan-meal-type').value = defaultMealType;
             document.querySelectorAll('.attendee-cb').forEach(cb => cb.checked = false);
             document.getElementById('plan-cook').value = '';
             document.getElementById('btn-delete-plan').style.display = 'none';
@@ -238,9 +281,10 @@
             if (!plan) return;
 
             editingId = id;
-            document.getElementById('modal-title').textContent = 'Edit Dinner Plan';
+            document.getElementById('modal-title').textContent = 'Edit Meal Plan';
             document.getElementById('plan-edit-id').value = id;
             document.getElementById('plan-date').value = plan.date;
+            document.getElementById('plan-meal-type').value = plan.meal_type || 'Dinner';
             document.getElementById('plan-text').value = plan.plan;
 
             // Set attendee checkboxes
@@ -260,33 +304,21 @@
             editingId = null;
         }
 
-        async function confirmDelete(id) {
-            if (!confirm('Are you sure you want to delete this dinner plan?')) return;
-
-            try {
-                await deletePlan(id);
-                await fetchPlans();
-            } catch (error) {
-                console.error('Error deleting plan:', error);
-                alert('Failed to delete dinner plan');
-            }
-        }
-
         async function confirmDeleteFromModal() {
             if (!editingId) return;
-            if (!confirm('Are you sure you want to delete this dinner plan?')) return;
+            if (!confirm('Are you sure you want to delete this meal plan?')) return;
             try {
                 await deletePlan(editingId);
                 closeModal();
                 await fetchPlans();
             } catch (error) {
                 console.error('Error deleting plan:', error);
-                alert('Failed to delete dinner plan');
+                alert('Failed to delete meal plan');
             }
         }
 
         // Event handlers
-        document.getElementById('btn-add-dinner').addEventListener('click', openAddModal);
+        document.getElementById('btn-add-meal').addEventListener('click', openAddModal);
         document.getElementById('btn-cancel').addEventListener('click', closeModal);
         document.getElementById('modal-overlay').addEventListener('click', (e) => {
             if (e.target.id === 'modal-overlay') closeModal();
@@ -296,26 +328,27 @@
             e.preventDefault();
 
             const date = document.getElementById('plan-date').value;
+            const meal_type = document.getElementById('plan-meal-type').value;
             const plan = document.getElementById('plan-text').value;
             const attendee_ids = getSelectedAttendeeIds();
             const cook_id = getSelectedCookId();
 
             try {
                 if (editingId) {
-                    await updatePlan(editingId, { date, plan, attendee_ids, cook_id });
+                    await updatePlan(editingId, { date, meal_type, plan, attendee_ids, cook_id });
                 } else {
-                    await savePlan({ date, plan, attendee_ids, cook_id });
+                    await savePlan({ date, meal_type, plan, attendee_ids, cook_id });
                 }
                 closeModal();
                 await fetchPlans();
             } catch (error) {
                 console.error('Error saving plan:', error);
-                alert('Failed to save dinner plan');
+                alert('Failed to save meal plan');
             }
         });
 
-        // Initialize — family members must load before plans render (plans display member names)
-        fetchFamilyMembers().then(() => {
+        // Initialize — settings and family members load before plans render
+        Promise.all([fetchDefaultMealType(), fetchFamilyMembers()]).then(() => {
             fetchPlans();
         });
     </script>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -19,7 +19,7 @@
     <nav>
         <a href="/dashboard">Dashboard</a>
         <a href="/todo">Tasks</a>
-        <a href="/dinner-planner">Dinner Planner</a>
+        <a href="/dinner-planner">Meal Planner</a>
     </nav>
 
     <!-- Family Members Section -->
@@ -122,6 +122,25 @@
             <div class="form-group">
                 <label>Agent Voice</label>
                 <textarea id="ai-agent-voice" rows="8" placeholder="Describe the tone and personality for Rally's summaries..."></textarea>
+            </div>
+            <button type="submit" class="btn-save">Save</button>
+        </form>
+    </div>
+
+    <!-- Meal Planner Section -->
+    <div class="border-container">
+        <div class="header-container">
+            <h2>Meal Planner</h2>
+        </div>
+        <form id="meal-planner-form">
+            <div class="form-group">
+                <label>Default Meal Type</label>
+                <select id="meal-default-type">
+                    <option value="Breakfast">Breakfast</option>
+                    <option value="Lunch">Lunch</option>
+                    <option value="Dinner">Dinner</option>
+                    <option value="Snacks">Snacks</option>
+                </select>
             </div>
             <button type="submit" class="btn-save">Save</button>
         </form>
@@ -526,6 +545,9 @@
             document.getElementById('ai-family-context').value = s.family_context || '';
             document.getElementById('ai-agent-voice').value = s.agent_voice || '';
 
+            // Meal Planner
+            document.getElementById('meal-default-type').value = s.meal_default_type || 'Dinner';
+
             // General
             document.getElementById('general-timezone').value = s.local_timezone || '';
         }
@@ -746,6 +768,20 @@
             } catch (error) {
                 console.error('Error saving AI settings:', error);
                 alert('Failed to save AI settings');
+            }
+        });
+
+        // Meal Planner form
+        document.getElementById('meal-planner-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            try {
+                await saveSettings({
+                    meal_default_type: document.getElementById('meal-default-type').value
+                });
+                alert('Meal Planner settings saved.');
+            } catch (error) {
+                console.error('Error saving meal planner settings:', error);
+                alert('Failed to save meal planner settings');
             }
         });
 

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -19,7 +19,7 @@
     <nav>
         <a href="/dashboard">Dashboard</a>
         <a href="/todo" class="active">Tasks</a>
-        <a href="/dinner-planner">Dinner Planner</a>
+        <a href="/dinner-planner">Meal Planner</a>
     </nav>
 
     <div class="section-container">


### PR DESCRIPTION
## Summary
Rebrand and expand the "Dinner Planner" feature to "Meal Planner" with support for multiple meal types (Breakfast, Lunch, Dinner, Snacks). Users can now plan different meals for the same day and set a default meal type in settings.

## Key Changes

- **Meal Type Support**: Added `meal_type` field to `DinnerPlan` model with four options: Breakfast, Lunch, Dinner, Snacks
- **Database Migration**: Created migration script to add `meal_type` column to existing `dinner_plans` table (defaults to "Dinner" for backward compatibility)
- **Sorting**: Plans are now sorted by date, then by meal type order (Breakfast → Lunch → Dinner → Snacks)
- **Settings Integration**: Added "Default Meal Type" setting in settings page to allow users to configure their preferred default meal type
- **UI Updates**: 
  - Added meal type selector dropdown in the add/edit meal plan modal
  - Display meal type in plan titles (e.g., "Breakfast: Pancakes and bacon")
  - Updated all user-facing text from "Dinner Planner" to "Meal Planner"
  - Changed "Tonight" label to "Today" to be meal-type agnostic
- **API Updates**: Updated all endpoints to handle `meal_type` field and sort results appropriately
- **Convenience Redirect**: Added `/meal-planner` route that redirects to `/dinner-planner`
- **LLM Context**: Updated meal plan context generation to include meal type information for AI agent

## Implementation Details

- Default meal type is fetched from settings on page load and pre-selects in the form
- Meal type order is enforced both in frontend (JavaScript) and backend (SQLAlchemy query)
- Migration is idempotent and safe to run multiple times
- Backward compatible: existing plans without meal_type default to "Dinner"
- Sample seed data updated to demonstrate multiple meal types per day

https://claude.ai/code/session_017EAjHCgUS1Eg4fFB9weGVV