### PR TITLE
Fix UTC offset bug in recurring todo completion dates

### DIFF
--- a/src/rally/routers/recurring_todos.py
+++ b/src/rally/routers/recurring_todos.py
@@ -17,20 +17,42 @@ def list_recurring_todos(db: Session = Depends(get_db)):
     """List all recurring todo templates."""
     rts = db.query(RecurringTodo).order_by(RecurringTodo.created_at.desc()).all()
 
-    last_completed_rows = (
-        db.query(Todo.recurring_todo_id, func.max(Todo.updated_at).label("last_completed_at"))
-        .filter(Todo.completed == True, Todo.recurring_todo_id.isnot(None))  # noqa: E712
+    # For instances with a due_date, use it directly — it's a local YYYY-MM-DD string
+    # and avoids the UTC-offset bug that affects updated_at timestamps.
+    due_date_rows = (
+        db.query(Todo.recurring_todo_id, func.max(Todo.due_date).label("last_due_date"))
+        .filter(
+            Todo.completed == True,  # noqa: E712
+            Todo.recurring_todo_id.isnot(None),
+            Todo.due_date.isnot(None),
+        )
         .group_by(Todo.recurring_todo_id)
         .all()
     )
-    last_completed_map = {row.recurring_todo_id: row.last_completed_at for row in last_completed_rows}
+    # Fall back to updated_at for instances that have no due_date.
+    no_due_date_rows = (
+        db.query(Todo.recurring_todo_id, func.max(Todo.updated_at).label("last_completed_at"))
+        .filter(
+            Todo.completed == True,  # noqa: E712
+            Todo.recurring_todo_id.isnot(None),
+            Todo.due_date.is_(None),
+        )
+        .group_by(Todo.recurring_todo_id)
+        .all()
+    )
+
+    last_completed_map: dict[int, str] = {}
+    for row in no_due_date_rows:
+        last_completed_map[row.recurring_todo_id] = ensure_utc(row.last_completed_at).date().isoformat()
+    for row in due_date_rows:
+        last_completed_map[row.recurring_todo_id] = row.last_due_date
 
     results = []
     for rt in rts:
         response = RecurringTodoResponse.model_validate(rt)
-        last_dt = last_completed_map.get(rt.id)
-        if last_dt:
-            response.last_completed_date = ensure_utc(last_dt).date().isoformat()
+        last_date = last_completed_map.get(rt.id)
+        if last_date:
+            response.last_completed_date = last_date
         results.append(response)
 
     return results


### PR DESCRIPTION
## Summary
Fixed a bug where recurring todo completion dates were affected by UTC offset issues in `updated_at` timestamps. The solution prioritizes `due_date` (which is stored as a local YYYY-MM-DD string) over `updated_at` for determining the last completion date.

## Key Changes
- Split the completion date query into two paths:
  - **Primary path**: Uses `due_date` for todos that have it set, avoiding UTC conversion issues entirely
  - **Fallback path**: Uses `updated_at` only for todos without a `due_date`, with explicit UTC conversion
- Updated the `last_completed_map` to store date strings directly instead of datetime objects
- Simplified the response building logic by moving date conversion into the map construction phase
- Added clarifying comments explaining the rationale for the dual-query approach

## Implementation Details
- The `due_date` field is treated as a local date string and used directly without timezone conversion
- The `updated_at` field is explicitly converted to UTC before extracting the date for consistency
- Both query results are merged into a single map that provides the appropriate date string for each recurring todo

https://claude.ai/code/session_01LTxCidot8RepYzBpjXyCey