### PR TITLE
feat: add meal reviews and history view

### DIFF
--- a/migrations/migrate_011_add_meal_reviews.py
+++ b/migrations/migrate_011_add_meal_reviews.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Migration 011: Add rating and review columns to dinner_plans.
+
+Safe to run multiple times (idempotent).
+"""
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def migrate():
+    """Run the migration. Return True on success, False on failure."""
+    db_path = os.environ.get("RALLY_DB_PATH")
+
+    if not db_path:
+        prod_path = Path("/data/rally.db")
+        dev_path = Path(__file__).parent.parent / "rally.db"
+        db_path = str(prod_path) if prod_path.exists() else str(dev_path)
+
+    db_path = Path(db_path)
+
+    if not db_path.exists():
+        print(f"  Database not found at {db_path}")
+        print("  No migration needed - database will be created with correct schema.")
+        return True
+
+    print(f"Checking database at {db_path}...")
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    try:
+        # CHECK: Do the columns already exist?
+        cursor.execute("PRAGMA table_info(dinner_plans)")
+        columns = [col[1] for col in cursor.fetchall()]
+
+        has_rating = "rating" in columns
+        has_review = "review" in columns
+
+        if has_rating and has_review:
+            print(
+                "  Migration 011: dinner_plans.rating and dinner_plans.review already exist (idempotent)"
+            )
+            return True
+
+        # EXECUTE: Add missing columns
+        if not has_rating:
+            print("  Adding dinner_plans.rating column...")
+            cursor.execute("ALTER TABLE dinner_plans ADD COLUMN rating INTEGER")
+            print("  dinner_plans.rating added")
+
+        if not has_review:
+            print("  Adding dinner_plans.review column...")
+            cursor.execute("ALTER TABLE dinner_plans ADD COLUMN review TEXT")
+            print("  dinner_plans.review added")
+
+        conn.commit()
+        print("  Migration 011 complete: meal review columns added")
+        return True
+
+    except sqlite3.Error as e:
+        print(f"  Migration 011 failed: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    success = migrate()
+    sys.exit(0 if success else 1)

--- a/migrations/run_migrations.py
+++ b/migrations/run_migrations.py
@@ -12,16 +12,17 @@ def run_migrations():
     """Run all migrations in order."""
     # Import migrations
     try:
+        from migrate_add_caldav_support import migrate as migrate_008_add_caldav_support
+        from migrate_add_custom_recurrence import migrate as migrate_009_add_custom_recurrence
         from migrate_add_dinner_plan_assignees import (
             migrate as migrate_005_add_dinner_plan_assignees,
         )
         from migrate_add_due_date import migrate as migrate_001_add_due_date
         from migrate_add_family_members import migrate as migrate_002_add_family_members
-        from migrate_add_caldav_support import migrate as migrate_008_add_caldav_support
-        from migrate_add_custom_recurrence import migrate as migrate_009_add_custom_recurrence
         from migrate_add_last_generated_date import (
             migrate as migrate_007_add_last_generated_date,
         )
+        from migrate_add_meal_reviews import migrate as migrate_011_add_meal_reviews
         from migrate_add_meal_type import migrate as migrate_010_add_meal_type
         from migrate_add_recurring_todos import migrate as migrate_004_add_recurring_todos
         from migrate_add_reminder_window import migrate as migrate_006_add_reminder_window
@@ -42,6 +43,7 @@ def run_migrations():
         ("008_add_caldav_support", migrate_008_add_caldav_support),
         ("009_add_custom_recurrence", migrate_009_add_custom_recurrence),
         ("010_add_meal_type", migrate_010_add_meal_type),
+        ("011_add_meal_reviews", migrate_011_add_meal_reviews),
     ]
 
     print("=" * 60)

--- a/src/rally/main.py
+++ b/src/rally/main.py
@@ -60,6 +60,12 @@ def dinner_planner_page(request: Request):
     return templates.TemplateResponse("dinner_planner.html", {"request": request})
 
 
+@app.get("/meal-history", response_class=HTMLResponse)
+def meal_history_page(request: Request):
+    """Serve the meal history and reviews page."""
+    return templates.TemplateResponse("meal_history.html", {"request": request})
+
+
 @app.get("/meal-planner", response_class=RedirectResponse)
 def meal_planner_redirect():
     """Redirect /meal-planner to /dinner-planner for convenience."""

--- a/src/rally/models.py
+++ b/src/rally/models.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from sqlalchemy import JSON, Boolean, Integer, String, Text
+from sqlalchemy import JSON, Boolean, CheckConstraint, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from rally.database import Base
@@ -113,7 +113,9 @@ class RecurringTodo(Base):
     recurrence_day: Mapped[int | None] = mapped_column(
         Integer, nullable=True
     )  # 0-6 for weekly, 1-31 for monthly
-    custom_rule: Mapped[dict | None] = mapped_column(JSON, nullable=True)  # rule dict for custom recurrence type
+    custom_rule: Mapped[dict | None] = mapped_column(
+        JSON, nullable=True
+    )  # rule dict for custom recurrence type
     assigned_to: Mapped[int | None] = mapped_column(Integer, nullable=True)
     has_due_date: Mapped[bool] = mapped_column(default=False)
     remind_days_before: Mapped[int | None] = mapped_column(
@@ -134,7 +136,9 @@ class DinnerPlan(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     date: Mapped[str] = mapped_column(String(10))  # YYYY-MM-DD (multiple plans per date allowed)
-    meal_type: Mapped[str] = mapped_column(String(20), default="Dinner")  # Breakfast, Lunch, Dinner, Snacks
+    meal_type: Mapped[str] = mapped_column(
+        String(20), default="Dinner"
+    )  # Breakfast, Lunch, Dinner, Snacks
     plan: Mapped[str] = mapped_column(Text)
     attendee_ids: Mapped[list | None] = mapped_column(
         JSON, nullable=True
@@ -142,5 +146,15 @@ class DinnerPlan(Base):
     cook_id: Mapped[int | None] = mapped_column(
         Integer, nullable=True
     )  # FK to family_members.id (who's cooking)
+    rating: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )  # 1-5 star rating; null means not yet reviewed
+    review: Mapped[str | None] = mapped_column(Text, nullable=True)  # Free-text review of the meal
     created_at: Mapped[datetime] = mapped_column(default=now_utc)
     updated_at: Mapped[datetime] = mapped_column(default=now_utc, onupdate=now_utc)
+
+    __table_args__ = (
+        CheckConstraint(
+            "rating IS NULL OR (rating >= 1 AND rating <= 5)", name="ck_dinner_plan_rating"
+        ),
+    )

--- a/src/rally/routers/dinner_planner.py
+++ b/src/rally/routers/dinner_planner.py
@@ -1,12 +1,19 @@
 """Meal planner router for Rally."""
 
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import case
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import case, nullslast
 from sqlalchemy.orm import Session
 
 from rally.database import get_db
-from rally.models import DinnerPlan
-from rally.schemas import UNSET, DinnerPlanCreate, DinnerPlanResponse, DinnerPlanUpdate
+from rally.models import DinnerPlan, Setting
+from rally.schemas import (
+    UNSET,
+    DinnerPlanCreate,
+    DinnerPlanResponse,
+    DinnerPlanReviewUpdate,
+    DinnerPlanUpdate,
+)
+from rally.utils.timezone import today_local
 
 router = APIRouter(prefix="/api/dinner-plans", tags=["dinner-plans"])
 
@@ -41,15 +48,42 @@ def create_dinner_plan(plan: DinnerPlanCreate, db: Session = Depends(get_db)):
     return db_plan
 
 
+@router.get("/history", response_model=list[DinnerPlanResponse])
+def list_meal_history(
+    sort: str = Query("rating_desc", pattern="^(rating_desc|date_desc|date_asc)$"),
+    min_rating: int | None = Query(None, ge=1, le=5),
+    db: Session = Depends(get_db),
+):
+    """List past meal plans (before today in the user's timezone).
+
+    Sort options:
+    - rating_desc: highest rated first, null ratings last
+    - date_desc: most recent first
+    - date_asc: oldest first
+    """
+    settings = {r.key: r.value for r in db.query(Setting).all()}
+    tz_name = settings.get("local_timezone", "UTC")
+    today = today_local(tz_name).strftime("%Y-%m-%d")
+
+    query = db.query(DinnerPlan).filter(DinnerPlan.date < today)
+
+    if min_rating is not None:
+        query = query.filter(DinnerPlan.rating >= min_rating)
+
+    if sort == "rating_desc":
+        query = query.order_by(nullslast(DinnerPlan.rating.desc()), DinnerPlan.date.desc())
+    elif sort == "date_asc":
+        query = query.order_by(DinnerPlan.date.asc(), _MEAL_TYPE_ORDER)
+    else:  # date_desc
+        query = query.order_by(DinnerPlan.date.desc(), _MEAL_TYPE_ORDER)
+
+    return query.all()
+
+
 @router.get("/date/{date}", response_model=list[DinnerPlanResponse])
 def get_dinner_plans_by_date(date: str, db: Session = Depends(get_db)):
     """Get all meal plans for a specific date (YYYY-MM-DD)."""
-    plans = (
-        db.query(DinnerPlan)
-        .filter(DinnerPlan.date == date)
-        .order_by(_MEAL_TYPE_ORDER)
-        .all()
-    )
+    plans = db.query(DinnerPlan).filter(DinnerPlan.date == date).order_by(_MEAL_TYPE_ORDER).all()
     return plans
 
 
@@ -83,6 +117,34 @@ def update_dinner_plan(
         db_plan.attendee_ids = plan.attendee_ids
     if plan.cook_id is not UNSET:
         db_plan.cook_id = plan.cook_id
+
+    db.commit()
+    db.refresh(db_plan)
+    return db_plan
+
+
+@router.put("/{plan_id}/review", response_model=DinnerPlanResponse)
+def review_meal(
+    plan_id: int,
+    review: DinnerPlanReviewUpdate,
+    db: Session = Depends(get_db),
+):
+    """Submit or update a meal review (rating and/or text)."""
+    db_plan = db.query(DinnerPlan).filter(DinnerPlan.id == plan_id).first()
+    if not db_plan:
+        raise HTTPException(status_code=404, detail="Meal plan not found")
+
+    if review.rating is not None:
+        if review.rating < 1 or review.rating > 5:
+            raise HTTPException(status_code=422, detail="Rating must be between 1 and 5")
+        db_plan.rating = review.rating
+    elif review.rating is None and "rating" in review.model_fields_set:
+        db_plan.rating = None
+
+    if review.review is not None:
+        db_plan.review = review.review
+    elif review.review is None and "review" in review.model_fields_set:
+        db_plan.review = None
 
     db.commit()
     db.refresh(db_plan)

--- a/src/rally/schemas.py
+++ b/src/rally/schemas.py
@@ -116,7 +116,9 @@ class TodoCreate(TodoBase):
 class TodoUpdate(BaseModel):
     title: str | None = None
     description: str | None = None
-    due_date: str | None = UNSET  # YYYY-MM-DD format; None means "clear"; UNSET means "not provided"
+    due_date: str | None = (
+        UNSET  # YYYY-MM-DD format; None means "clear"; UNSET means "not provided"
+    )
     assigned_to: int | None = UNSET  # family_members.id; None means "Everyone"
     remind_days_before: int | None = UNSET  # Days before due_date; None means "always"
     completed: bool | None = None
@@ -185,6 +187,8 @@ class DinnerPlanBase(BaseModel):
     plan: str
     attendee_ids: list[int] | None = None  # family_member IDs (who's eating); None = everyone
     cook_id: int | None = None  # family_member ID (who's cooking)
+    rating: int | None = None  # 1-5 star rating; null = not yet reviewed
+    review: str | None = None  # Free-text review
 
 
 class DinnerPlanCreate(DinnerPlanBase):
@@ -197,6 +201,13 @@ class DinnerPlanUpdate(BaseModel):
     plan: str | None = None
     attendee_ids: list[int] | None = UNSET  # None means "clear"; UNSET means "not provided"
     cook_id: int | None = UNSET  # None means "clear"; UNSET means "not provided"
+
+
+class DinnerPlanReviewUpdate(BaseModel):
+    """Lightweight schema for submitting/editing a meal review."""
+
+    rating: int | None = None  # 1-5; None means "clear rating"
+    review: str | None = None  # Free-text; None means "clear review"
 
 
 class DinnerPlanResponse(DinnerPlanBase):

--- a/src/rally/utils/timezone.py
+++ b/src/rally/utils/timezone.py
@@ -4,7 +4,8 @@ Provides timezone-aware datetime functions to ensure consistent behavior
 regardless of server timezone configuration.
 """
 
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
+from zoneinfo import ZoneInfo
 
 
 def now_utc() -> datetime:
@@ -23,6 +24,18 @@ def today_utc():
         date: Today's date in UTC timezone.
     """
     return now_utc().date()
+
+
+def today_local(tz_name: str = "UTC") -> date:
+    """Get today's date in the user's configured timezone.
+
+    Args:
+        tz_name: IANA timezone name (e.g. "America/Chicago"). Defaults to UTC.
+
+    Returns:
+        date: Today's date in the specified timezone.
+    """
+    return now_utc().astimezone(ZoneInfo(tz_name)).date()
 
 
 def ensure_utc(dt: datetime) -> datetime:

--- a/static/styles.css
+++ b/static/styles.css
@@ -807,6 +807,225 @@ footer a:hover {
 }
 /** End Dinner Planner Styles **/
 
+/** Nav Dropdown Styles **/
+.nav-dropdown {
+    display: inline-block;
+    position: relative;
+    margin: 0 8px;
+}
+
+.nav-dropdown-btn {
+    color: var(--charcoal);
+    text-decoration: none;
+    padding: 8px 16px;
+    border: 1px solid var(--charcoal);
+    display: inline-block;
+    transition: background 0.2s;
+    font-size: 0.9rem;
+    letter-spacing: 0.05em;
+    font-family: var(--body-font);
+    cursor: pointer;
+    background: var(--white);
+    line-height: inherit;
+}
+
+.nav-dropdown-btn::after {
+    content: "";
+    display: inline-block;
+    margin-left: 6px;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 5px solid var(--charcoal);
+    vertical-align: middle;
+}
+
+.nav-dropdown-btn:hover,
+.nav-dropdown-btn.active {
+    background: var(--off-white);
+}
+
+.nav-dropdown-btn.active {
+    background: var(--charcoal);
+    color: var(--white);
+}
+
+.nav-dropdown-content {
+    display: none;
+    position: absolute;
+    left: 0;
+    top: 100%;
+    background: var(--white);
+    border: 1px solid var(--charcoal);
+    border-top: none;
+    min-width: 180px;
+    z-index: 100;
+}
+
+.nav-dropdown-content a {
+    display: block;
+    padding: 8px 16px;
+    color: var(--charcoal);
+    text-decoration: none;
+    font-size: 0.9rem;
+    letter-spacing: 0.05em;
+    border: none;
+    margin: 0;
+    transition: background 0.15s;
+}
+
+.nav-dropdown-content a:hover {
+    background: var(--off-white);
+}
+
+.nav-dropdown-content a.active {
+    background: var(--charcoal);
+    color: var(--white);
+}
+
+/* Desktop: show on hover */
+@media (hover: hover) {
+    .nav-dropdown:hover .nav-dropdown-content {
+        display: block;
+    }
+}
+
+/* Mobile/touch: show on click via .open class */
+.nav-dropdown.open .nav-dropdown-content {
+    display: block;
+}
+
+/* Mobile layout: stack nav vertically */
+@media screen and (max-width: 767px) {
+    nav {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        align-items: center;
+    }
+
+    .nav-dropdown {
+        margin: 0;
+        width: 100%;
+        text-align: center;
+    }
+
+    .nav-dropdown-btn {
+        width: 100%;
+    }
+
+    .nav-dropdown-content {
+        position: static;
+        border: 1px solid var(--charcoal);
+        margin-top: 8px;
+    }
+}
+/** End Nav Dropdown Styles **/
+
+/** Star Rating Styles **/
+.star-rating {
+    display: inline-flex;
+    gap: 2px;
+    cursor: default;
+}
+
+.star-rating .star {
+    font-size: 1.1rem;
+    color: var(--pale-gray);
+    user-select: none;
+}
+
+.star-rating .star.filled {
+    color: var(--charcoal);
+}
+
+/* Interactive star rating (for review modal) */
+.star-rating-input {
+    display: inline-flex;
+    gap: 4px;
+    cursor: pointer;
+}
+
+.star-rating-input .star {
+    font-size: 1.4rem;
+    color: var(--pale-gray);
+    transition: color 0.1s;
+    user-select: none;
+}
+
+.star-rating-input .star.filled {
+    color: var(--charcoal);
+}
+
+.star-rating-input .star.hover {
+    color: var(--medium-gray);
+}
+/** End Star Rating Styles **/
+
+/** Meal History Styles **/
+.history-card {
+    padding: 16px;
+    border: 1px solid var(--pale-gray);
+    background: var(--white);
+    transition: background 0.2s;
+}
+
+.history-card:hover {
+    background: var(--off-white);
+}
+
+.history-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    margin-bottom: 8px;
+}
+
+.history-card-title {
+    font-size: 1rem;
+    font-weight: 500;
+    word-wrap: break-word;
+}
+
+.history-card-date {
+    font-size: 0.85rem;
+    color: var(--medium-gray);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    flex-shrink: 0;
+}
+
+.history-card-meta {
+    font-size: 0.9rem;
+    color: var(--medium-gray);
+    font-style: italic;
+    margin-bottom: 8px;
+}
+
+.history-card-review {
+    font-size: 0.95rem;
+    color: var(--dark-gray);
+    font-style: italic;
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--silver);
+    line-height: 1.6;
+}
+
+.history-card-rating-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 6px;
+}
+
+.no-review-text {
+    font-size: 0.85rem;
+    color: var(--light-gray);
+    font-style: italic;
+}
+/** End Meal History Styles **/
+
 /** Custom Recurrence Styles **/
 .custom-recurrence-row {
     display: flex;
@@ -952,12 +1171,6 @@ footer a:hover {
 @media screen and (max-width: 767px) {
     body {
         padding: 24px 16px;
-    }
-
-    nav {
-        display: flex;
-        flex-direction: column;
-        gap: 12px;
     }
 
     .header h1 {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -19,7 +19,13 @@
     <nav>
         <a href="/dashboard" class="active">Dashboard</a>
         <a href="/todo">Tasks</a>
-        <a href="/dinner-planner">Meal Planner</a>
+        <div class="nav-dropdown" id="meal-dropdown">
+            <button class="nav-dropdown-btn" onclick="toggleMealDropdown(event)">Meal Planner</button>
+            <div class="nav-dropdown-content">
+                <a href="/dinner-planner">Current &amp; Upcoming</a>
+                <a href="/meal-history">Previous Meals</a>
+            </div>
+        </div>
     </nav>
 
     <!-- Greeting -->
@@ -86,6 +92,15 @@
         
         // Auto-refresh every 30 minutes
         setTimeout(function() { location.reload(); }, 30 * 60 * 1000);
+
+        // Nav dropdown toggle (for touch devices)
+        function toggleMealDropdown(e) {
+            e.stopPropagation();
+            document.getElementById('meal-dropdown').classList.toggle('open');
+        }
+        document.addEventListener('click', function() {
+            document.getElementById('meal-dropdown').classList.remove('open');
+        });
     </script>
 </body>
 </html>

--- a/templates/dinner_planner.html
+++ b/templates/dinner_planner.html
@@ -19,7 +19,13 @@
     <nav>
         <a href="/dashboard">Dashboard</a>
         <a href="/todo">Tasks</a>
-        <a href="/dinner-planner" class="active">Meal Planner</a>
+        <div class="nav-dropdown" id="meal-dropdown">
+            <button class="nav-dropdown-btn active" onclick="toggleMealDropdown(event)">Meal Planner</button>
+            <div class="nav-dropdown-content">
+                <a href="/dinner-planner" class="active">Current &amp; Upcoming</a>
+                <a href="/meal-history">Previous Meals</a>
+            </div>
+        </div>
     </nav>
 
     <div class="section-container">
@@ -350,6 +356,15 @@
         // Initialize — settings and family members load before plans render
         Promise.all([fetchDefaultMealType(), fetchFamilyMembers()]).then(() => {
             fetchPlans();
+        });
+
+        // Nav dropdown toggle (for touch devices)
+        function toggleMealDropdown(e) {
+            e.stopPropagation();
+            document.getElementById('meal-dropdown').classList.toggle('open');
+        }
+        document.addEventListener('click', function() {
+            document.getElementById('meal-dropdown').classList.remove('open');
         });
     </script>
 

--- a/templates/meal_history.html
+++ b/templates/meal_history.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Rally — Meal History</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📰</text></svg>">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="/static/styles.css" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <h1>Rally</h1>
+        <div class="subtitle">Meal History</div>
+    </header>
+
+    <nav>
+        <a href="/dashboard">Dashboard</a>
+        <a href="/todo">Tasks</a>
+        <div class="nav-dropdown" id="meal-dropdown">
+            <button class="nav-dropdown-btn active" onclick="toggleMealDropdown(event)">Meal Planner</button>
+            <div class="nav-dropdown-content">
+                <a href="/dinner-planner">Current &amp; Upcoming</a>
+                <a href="/meal-history" class="active">Previous Meals</a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="section-container">
+        <div class="header-container">
+            <h2>Meal History</h2>
+        </div>
+
+        <!-- Sort/filter toolbar -->
+        <div class="todo-toolbar">
+            <div class="toolbar-group">
+                <label>Sort</label>
+                <select id="sort-select">
+                    <option value="rating_desc">Highest Rated</option>
+                    <option value="date_desc">Most Recent</option>
+                    <option value="date_asc">Oldest First</option>
+                </select>
+            </div>
+            <div class="toolbar-group">
+                <label>Rating</label>
+                <div class="filter-chips" id="rating-filters">
+                    <button class="filter-chip active" data-min="">All</button>
+                    <button class="filter-chip" data-min="5">5 Stars</button>
+                    <button class="filter-chip" data-min="4">4+ Stars</button>
+                    <button class="filter-chip" data-min="3">3+ Stars</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="list-container" id="history-list">
+            <div class="container-loading-state">Loading meal history...</div>
+        </div>
+    </div>
+
+    <!-- Review modal -->
+    <div class="modal-overlay" id="review-modal-overlay">
+        <div class="modal-content">
+            <h3 id="review-modal-title">Add Review</h3>
+            <form id="review-form">
+                <input type="hidden" id="review-plan-id">
+                <div class="form-group">
+                    <label>Rating</label>
+                    <div class="star-rating-input" id="star-rating-input" role="radiogroup" aria-label="Meal rating">
+                        <span class="star" data-value="1" tabindex="0" role="radio" aria-checked="false" aria-label="1 star">&#9733;</span>
+                        <span class="star" data-value="2" tabindex="0" role="radio" aria-checked="false" aria-label="2 stars">&#9733;</span>
+                        <span class="star" data-value="3" tabindex="0" role="radio" aria-checked="false" aria-label="3 stars">&#9733;</span>
+                        <span class="star" data-value="4" tabindex="0" role="radio" aria-checked="false" aria-label="4 stars">&#9733;</span>
+                        <span class="star" data-value="5" tabindex="0" role="radio" aria-checked="false" aria-label="5 stars">&#9733;</span>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label>Review <small>(optional)</small></label>
+                    <textarea id="review-text" placeholder="How was this meal?" rows="4"></textarea>
+                </div>
+                <div class="modal-actions">
+                    <button type="submit" class="btn-primary">Save Review</button>
+                    <button type="button" class="btn-cancel" id="btn-cancel-review">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <script>
+        // State
+        let historyPlans = [];
+        let familyMembers = [];
+        let currentSort = 'rating_desc';
+        let currentMinRating = '';
+
+        // Star rating state
+        let selectedRating = 0;
+
+        // Family member helpers
+        async function fetchFamilyMembers() {
+            const response = await fetch('/api/family');
+            familyMembers = await response.json();
+        }
+
+        function getMemberById(id) {
+            return familyMembers.find(m => m.id === id);
+        }
+
+        // Format date for display
+        function formatDate(dateStr) {
+            const date = new Date(dateStr + 'T00:00:00');
+            return date.toLocaleDateString('en-US', {
+                weekday: 'long',
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric'
+            });
+        }
+
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        // Build star display HTML
+        function renderStars(rating) {
+            if (!rating) return '<span class="no-review-text">Not yet rated</span>';
+            let html = '<span class="star-rating">';
+            for (let i = 1; i <= 5; i++) {
+                html += `<span class="star${i <= rating ? ' filled' : ''}">&#9733;</span>`;
+            }
+            html += '</span>';
+            return html;
+        }
+
+        // API calls
+        async function fetchHistory() {
+            const params = new URLSearchParams({ sort: currentSort });
+            if (currentMinRating) {
+                params.set('min_rating', currentMinRating);
+            }
+            const response = await fetch(`/api/dinner-plans/history?${params}`);
+            historyPlans = await response.json();
+            renderHistory();
+        }
+
+        async function saveReview(planId, rating, review) {
+            const body = {};
+            if (rating > 0) body.rating = rating;
+            if (review) body.review = review;
+
+            const response = await fetch(`/api/dinner-plans/${planId}/review`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body)
+            });
+            if (!response.ok) throw new Error('Failed to save review');
+            return response.json();
+        }
+
+        // Render
+        function renderHistory() {
+            const container = document.getElementById('history-list');
+
+            if (historyPlans.length === 0) {
+                container.innerHTML = '<div class="container-empty-state">No meal history yet. Past meals will appear here once you have some plans behind you.</div>';
+                return;
+            }
+
+            container.innerHTML = historyPlans.map(plan => {
+                // Build meta parts
+                const parts = [];
+                if (plan.attendee_ids && plan.attendee_ids.length > 0) {
+                    const names = plan.attendee_ids.map(id => getMemberById(id)?.name || '?').join(', ');
+                    parts.push(`Eating: ${escapeHtml(names)}`);
+                }
+                if (plan.cook_id) {
+                    const cook = getMemberById(plan.cook_id);
+                    if (cook) parts.push(`Cook: ${escapeHtml(cook.name)}`);
+                }
+                const metaHtml = parts.length > 0
+                    ? `<div class="history-card-meta">${parts.join(' · ')}</div>` : '';
+
+                const mealType = plan.meal_type || 'Dinner';
+                const reviewHtml = plan.review
+                    ? `<div class="history-card-review">${escapeHtml(plan.review)}</div>`
+                    : '';
+
+                const ratingRow = `<div class="history-card-rating-row">
+                    ${renderStars(plan.rating)}
+                    <button class="btn-edit" onclick="openReviewModal(${plan.id})">${plan.rating ? 'Edit Review' : 'Add Review'}</button>
+                </div>`;
+
+                return `
+                    <div class="history-card" data-id="${plan.id}">
+                        <div class="history-card-header">
+                            <div class="history-card-title"><strong>${escapeHtml(mealType)}:</strong> ${escapeHtml(plan.plan)}</div>
+                            <div class="history-card-date">${escapeHtml(formatDate(plan.date))}</div>
+                        </div>
+                        ${metaHtml}
+                        ${ratingRow}
+                        ${reviewHtml}
+                    </div>
+                `;
+            }).join('');
+        }
+
+        // Review modal
+        function openReviewModal(planId) {
+            const plan = historyPlans.find(p => p.id === planId);
+            if (!plan) return;
+
+            document.getElementById('review-plan-id').value = planId;
+            document.getElementById('review-modal-title').textContent =
+                plan.rating ? 'Edit Review' : 'Add Review';
+            document.getElementById('review-text').value = plan.review || '';
+
+            // Set star rating
+            selectedRating = plan.rating || 0;
+            updateStarDisplay();
+
+            document.getElementById('review-modal-overlay').style.display = 'flex';
+        }
+
+        function closeReviewModal() {
+            document.getElementById('review-modal-overlay').style.display = 'none';
+            selectedRating = 0;
+        }
+
+        function updateStarDisplay() {
+            const stars = document.querySelectorAll('#star-rating-input .star');
+            stars.forEach(star => {
+                const val = parseInt(star.dataset.value);
+                star.classList.toggle('filled', val <= selectedRating);
+                star.setAttribute('aria-checked', val <= selectedRating ? 'true' : 'false');
+            });
+        }
+
+        // Star rating interaction
+        document.querySelectorAll('#star-rating-input .star').forEach(star => {
+            star.addEventListener('click', function() {
+                selectedRating = parseInt(this.dataset.value);
+                updateStarDisplay();
+            });
+
+            star.addEventListener('keydown', function(e) {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    selectedRating = parseInt(this.dataset.value);
+                    updateStarDisplay();
+                }
+            });
+
+            star.addEventListener('mouseenter', function() {
+                const hoverVal = parseInt(this.dataset.value);
+                document.querySelectorAll('#star-rating-input .star').forEach(s => {
+                    const val = parseInt(s.dataset.value);
+                    s.classList.toggle('hover', val <= hoverVal && val > selectedRating);
+                });
+            });
+
+            star.addEventListener('mouseleave', function() {
+                document.querySelectorAll('#star-rating-input .star').forEach(s => {
+                    s.classList.remove('hover');
+                });
+            });
+        });
+
+        // Sort/filter handlers
+        document.getElementById('sort-select').addEventListener('change', function() {
+            currentSort = this.value;
+            fetchHistory();
+        });
+
+        document.getElementById('rating-filters').addEventListener('click', function(e) {
+            const chip = e.target.closest('.filter-chip');
+            if (!chip) return;
+
+            document.querySelectorAll('#rating-filters .filter-chip').forEach(c => c.classList.remove('active'));
+            chip.classList.add('active');
+            currentMinRating = chip.dataset.min;
+            fetchHistory();
+        });
+
+        // Modal events
+        document.getElementById('btn-cancel-review').addEventListener('click', closeReviewModal);
+        document.getElementById('review-modal-overlay').addEventListener('click', function(e) {
+            if (e.target.id === 'review-modal-overlay') closeReviewModal();
+        });
+
+        document.getElementById('review-form').addEventListener('submit', async function(e) {
+            e.preventDefault();
+            const planId = parseInt(document.getElementById('review-plan-id').value);
+            const reviewText = document.getElementById('review-text').value.trim();
+
+            try {
+                await saveReview(planId, selectedRating, reviewText || null);
+                closeReviewModal();
+                await fetchHistory();
+            } catch (error) {
+                console.error('Error saving review:', error);
+                alert('Failed to save review');
+            }
+        });
+
+        // Nav dropdown toggle (for touch devices)
+        function toggleMealDropdown(e) {
+            e.stopPropagation();
+            document.getElementById('meal-dropdown').classList.toggle('open');
+        }
+        document.addEventListener('click', function() {
+            document.getElementById('meal-dropdown').classList.remove('open');
+        });
+
+        // Initialize
+        fetchFamilyMembers().then(() => {
+            fetchHistory();
+        });
+    </script>
+
+    <footer>
+        <a href="/settings">Settings</a>
+    </footer>
+</body>
+</html>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -19,7 +19,13 @@
     <nav>
         <a href="/dashboard">Dashboard</a>
         <a href="/todo">Tasks</a>
-        <a href="/dinner-planner">Meal Planner</a>
+        <div class="nav-dropdown" id="meal-dropdown">
+            <button class="nav-dropdown-btn" onclick="toggleMealDropdown(event)">Meal Planner</button>
+            <div class="nav-dropdown-content">
+                <a href="/dinner-planner">Current &amp; Upcoming</a>
+                <a href="/meal-history">Previous Meals</a>
+            </div>
+        </div>
     </nav>
 
     <!-- Family Members Section -->
@@ -801,6 +807,15 @@
 
         // ── Initialize ──
         Promise.all([fetchMembers(), fetchCalendars(), fetchSettings()]);
+
+        // Nav dropdown toggle (for touch devices)
+        function toggleMealDropdown(e) {
+            e.stopPropagation();
+            document.getElementById('meal-dropdown').classList.toggle('open');
+        }
+        document.addEventListener('click', function() {
+            document.getElementById('meal-dropdown').classList.remove('open');
+        });
     </script>
 
     <footer>

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -19,7 +19,13 @@
     <nav>
         <a href="/dashboard">Dashboard</a>
         <a href="/todo" class="active">Tasks</a>
-        <a href="/dinner-planner">Meal Planner</a>
+        <div class="nav-dropdown" id="meal-dropdown">
+            <button class="nav-dropdown-btn" onclick="toggleMealDropdown(event)">Meal Planner</button>
+            <div class="nav-dropdown-content">
+                <a href="/dinner-planner">Current &amp; Upcoming</a>
+                <a href="/meal-history">Previous Meals</a>
+            </div>
+        </div>
     </nav>
 
     <div class="section-container">
@@ -921,6 +927,15 @@
         fetchFamilyMembers().then(() => {
             fetchTodos();
             fetchRecurringTodos();
+        });
+
+        // Nav dropdown toggle (for touch devices)
+        function toggleMealDropdown(e) {
+            e.stopPropagation();
+            document.getElementById('meal-dropdown').classList.toggle('open');
+        }
+        document.addEventListener('click', function() {
+            document.getElementById('meal-dropdown').classList.remove('open');
         });
     </script>
 


### PR DESCRIPTION
## What

Adds meal reviews and a history view so families can rate past meals and browse them by rating.

Closes #66

## Changes

**Data model**
- `rating` (integer, 1-5, nullable) and `review` (text, nullable) columns on `DinnerPlan`
- Migration 011: idempotent ALTER TABLE with check constraint on rating range

**API**
- `GET /api/dinner-plans/history` -- returns past meals (date < today in user timezone). Supports `sort` (rating_desc, date_desc, date_asc) and `min_rating` query params.
- `PUT /api/dinner-plans/{id}/review` -- lightweight endpoint for updating only rating and review fields without touching the plan itself.

**UI**
- New `/meal-history` page with sort/filter toolbar, star rating display, and review modal
- "Meal Planner" nav link converted to a dropdown across all pages: "Current & Upcoming" and "Previous Meals"
- Interactive 5-star selector in the review modal (click + keyboard accessible)
- Touch-friendly dropdown toggle for mobile

## Verification

- Migration runs idempotently (tested: run twice, second run reports "already exists")
- `ruff check` and `ruff format` pass on all changed files
- All routes registered correctly (`/meal-history`, `/api/dinner-plans/history`, `/api/dinner-plans/{id}/review`)
- Existing `POST /api/dinner-plans` still works without rating/review (both nullable)
- Star selector handles click and keyboard (Enter/Space) interactions