### PR TITLE
fix: stretch mobile nav links to full page width

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -900,7 +900,11 @@ footer a:hover {
         display: flex;
         flex-direction: column;
         gap: 12px;
-        align-items: center;
+        align-items: stretch;
+    }
+
+    nav > a {
+        margin: 0;
     }
 
     .nav-dropdown {


### PR DESCRIPTION
## Summary
Fixes #71 — mobile nav links no longer stretched the full width of the page after the Meal History feature was introduced.

## Root cause
Before Meal History, the mobile nav was a flex column with the default `align-items: stretch`, so links spanned the full width. The mobile rule added alongside the nav dropdown set `align-items: center`, which shrank plain `nav a` links to their content width, while the Meal Planner dropdown button stayed full width via its explicit `width: 100%`.

## Changes
- Restore `align-items: stretch` on the mobile nav flex column so links span the page width again
- Zero out the links' horizontal margins (`nav > a { margin: 0; }`) in the mobile breakpoint so they align flush with the dropdown button, which has no margin

Link text remains centered via the existing `nav { text-align: center; }`.

https://claude.ai/code/session_01NRqoQGi8kNDTsAbphNWmwW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRqoQGi8kNDTsAbphNWmwW)_