### PR TITLE
Add version history for AI settings (agent_voice, family_context)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,11 @@ Rally uses a simple, file-based migration system. All migrations live in the `mi
 - `005_add_dinner_plan_assignees` - Add `attendee_ids` and `cook_id` to `dinner_plans`
 - `006_add_reminder_window` - Add `remind_days_before` to `todos` and `recurring_todos`
 - `007_add_last_generated_date` - Add `last_generated_date` to `recurring_todos` (tracks most recently generated instance to prevent duplicates)
+- `008_add_caldav_support` - Add CalDAV fields (`cal_type`, `username`, `password`) to `calendars`
+- `009_add_custom_recurrence` - Add `custom_rule` to `recurring_todos`
+- `010_add_meal_type` - Add `meal_type` to `dinner_plans`
+- `011_add_meal_reviews` - Add `rating` and `review` to `dinner_plans`
+- `012_add_ai_settings_history` - Add `ai_settings_history` table; seed it from existing `agent_voice` / `family_context` settings rows, point `current_agent_voice_history_id` / `current_family_context_history_id` settings keys at the seed rows, and remove the original settings rows
 
 ### Running Migrations
 
@@ -436,7 +441,7 @@ rally/
 │   ├── __init__.py
 │   ├── main.py           # FastAPI application
 │   ├── database.py       # SQLAlchemy database setup
-│   ├── models.py         # Database models (FamilyMember, Calendar, Setting, DashboardSnapshot, Todo, RecurringTodo, DinnerPlan)
+│   ├── models.py         # Database models (FamilyMember, Calendar, Setting, AISettingsHistory, DashboardSnapshot, Todo, RecurringTodo, DinnerPlan)
 │   ├── schemas.py        # Pydantic schemas
 │   ├── cli.py            # CLI commands (seed, etc.)
 │   ├── recurrence.py     # Recurring todo processing (template → instance generation, next-date calculation)
@@ -473,6 +478,11 @@ rally/
 │   ├── migrate_add_dinner_plan_assignees.py # Migration 005: add attendee_ids, cook_id to dinner_plans
 │   ├── migrate_add_reminder_window.py # Migration 006: add remind_days_before to todos and recurring_todos
 │   ├── migrate_add_last_generated_date.py # Migration 007: add last_generated_date to recurring_todos
+│   ├── migrate_add_caldav_support.py  # Migration 008: add CalDAV fields to calendars
+│   ├── migrate_add_custom_recurrence.py # Migration 009: add custom_rule to recurring_todos
+│   ├── migrate_add_meal_type.py       # Migration 010: add meal_type to dinner_plans
+│   ├── migrate_011_add_meal_reviews.py # Migration 011: add rating and review to dinner_plans
+│   ├── migrate_012_add_ai_settings_history.py # Migration 012: add ai_settings_history table
 │   └── run_migrations.py              # Migration runner (executes all migrations in order)
 ├── data/                 # Mounted in container (not in git)
 │   ├── config.toml       # API keys, URLs, coordinates (optional if using Settings UI)
@@ -515,6 +525,11 @@ rally/
   - Configure LLM provider, API keys, timezone
   - DB settings take precedence over config.toml
   - Connection verification on save: LLM, Weather, and Calendar settings show a verification modal with spinner, checkmark on success (auto-closes), or error message with Close button on failure
+- ✅ AI settings snapshotting with version history and rollback
+  - `agent_voice` and `family_context` each have their own Save button and Version History link on the settings page
+  - Every explicit save inserts a versioned snapshot into `ai_settings_history` (`field_name` discriminator); the active snapshot per field is referenced by the `current_agent_voice_history_id` / `current_family_context_history_id` settings keys
+  - Version History modal lists snapshots newest first with a `Current` badge and in-place expandable value previews; **Change Version** rolls the field back (bumps `last_used_at`, repoints the setting, no new row) and updates the field without a page reload
+  - Fields roll back independently; all snapshots are retained indefinitely
 - ✅ Todo management - Full CRUD API and UI
   - Create, read, update, delete todos
   - Optional due dates with native HTML5 date picker
@@ -590,6 +605,11 @@ rally/
 - `/api/settings` - Key-value settings endpoints
   - `GET /api/settings` - Get all settings
   - `PUT /api/settings` - Bulk upsert settings
+- `/api/settings/ai` - Versioned AI settings endpoints (`agent_voice`, `family_context`)
+  - `GET /api/settings/ai` - Get the currently active value and history ID for each field
+  - `PUT /api/settings/ai/{field_name}` - Explicit save: inserts a new `ai_settings_history` snapshot (`created_at` = `last_used_at` = now, UTC) and points the field's `current_<field>_history_id` setting at it
+  - `GET /api/settings/ai/{field_name}/history` - List all snapshots for a field, newest first (by `created_at` descending), plus the current history ID
+  - `POST /api/settings/ai/{field_name}/rollback` - Make an existing snapshot active: bumps its `last_used_at` and repoints the setting — no new row inserted. Body: `{history_id}`
 - `/api/settings/test-llm` - LLM connectivity test
   - `POST /api/settings/test-llm` - Test LLM provider connection (sends minimal 1-token request). Returns `{success, message}` or `{success, error}`.
 - `/api/settings/test-weather` - Weather connectivity test
@@ -657,6 +677,7 @@ The database is automatically created when the app starts. Migrations run automa
 - `FamilyMember` - Family members with name, color, and timestamps
 - `Calendar` - ICS calendar feeds linked to family members, with optional owner email
 - `Setting` - Key-value settings store (LLM provider, API keys, timezone, etc.)
+- `AISettingsHistory` - Versioned snapshots of `agent_voice` / `family_context` with field_name discriminator, value, created_at, and last_used_at; active snapshot per field referenced via `current_<field>_history_id` settings keys
 - `DashboardSnapshot` - Stores generated dashboard data with date, timestamp, JSON data, and active flag
 - `Todo` - Task management with title, description, optional due_date (YYYY-MM-DD), assigned_to (family member), optional recurring_todo_id (link to recurring template), optional remind_days_before (reminder window), completion status, and timestamps
 - `RecurringTodo` - Recurring todo templates with title, description, recurrence_type (daily/weekly/monthly), recurrence_day, assigned_to, has_due_date, remind_days_before, last_generated_date (tracks most recently generated instance's recurrence date), active flag, and timestamps

--- a/migrations/migrate_012_add_ai_settings_history.py
+++ b/migrations/migrate_012_add_ai_settings_history.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Migration 012: Add ai_settings_history table for AI settings snapshotting.
+
+Creates the ai_settings_history table (versioned snapshots of agent_voice and
+family_context), seeds it from any existing agent_voice / family_context rows
+in the key-value settings table, points the new
+current_agent_voice_history_id / current_family_context_history_id settings
+keys at the seed rows, and removes the original agent_voice / family_context
+settings rows (their values live in ai_settings_history from now on).
+
+Safe to run multiple times (idempotent).
+"""
+
+import os
+import sqlite3
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+FIELDS = ("agent_voice", "family_context")
+
+
+def migrate():
+    """Run the migration. Return True on success, False on failure."""
+    db_path = os.environ.get("RALLY_DB_PATH")
+
+    if not db_path:
+        prod_path = Path("/data/rally.db")
+        dev_path = Path(__file__).parent.parent / "rally.db"
+        db_path = str(prod_path) if prod_path.exists() else str(dev_path)
+
+    db_path = Path(db_path)
+
+    if not db_path.exists():
+        print(f"  Database not found at {db_path}")
+        print("  No migration needed - database will be created with correct schema.")
+        return True
+
+    print(f"Checking database at {db_path}...")
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    try:
+        # CREATE: history table and field_name index (idempotent)
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS ai_settings_history (
+                id INTEGER NOT NULL PRIMARY KEY,
+                field_name VARCHAR(50) NOT NULL,
+                value TEXT NOT NULL,
+                created_at DATETIME NOT NULL,
+                last_used_at DATETIME NOT NULL
+            )
+        """)
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS ix_ai_settings_history_field_name
+            ON ai_settings_history(field_name)
+        """)
+
+        # Settings table may not exist yet on a fresh database
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='settings'")
+        if not cursor.fetchone():
+            conn.commit()
+            print("  Migration 012: ai_settings_history created; no settings table to seed from")
+            return True
+
+        # Match SQLAlchemy's SQLite datetime format (naive UTC)
+        now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")
+
+        for field in FIELDS:
+            pointer_key = f"current_{field}_history_id"
+
+            # CHECK: Is this field already migrated?
+            cursor.execute("SELECT value FROM settings WHERE key = ?", (pointer_key,))
+            if cursor.fetchone():
+                print(f"  Migration 012: {pointer_key} already set (idempotent)")
+                continue
+
+            cursor.execute("SELECT value FROM settings WHERE key = ?", (field,))
+            row = cursor.fetchone()
+            if row is None:
+                print(f"  Migration 012: no existing {field} setting to migrate")
+                continue
+
+            # EXECUTE: Seed history row, point the setting at it, drop the original row
+            cursor.execute(
+                """
+                INSERT INTO ai_settings_history (field_name, value, created_at, last_used_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (field, row[0], now, now),
+            )
+            history_id = cursor.lastrowid
+            cursor.execute(
+                "INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)",
+                (pointer_key, str(history_id), now),
+            )
+            cursor.execute("DELETE FROM settings WHERE key = ?", (field,))
+            print(f"  Migration 012: migrated {field} into ai_settings_history row {history_id}")
+
+        conn.commit()
+        print("  Migration 012 complete: ai_settings_history ready")
+        return True
+
+    except sqlite3.Error as e:
+        print(f"  Migration 012 failed: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    success = migrate()
+    sys.exit(0 if success else 1)

--- a/migrations/run_migrations.py
+++ b/migrations/run_migrations.py
@@ -12,6 +12,10 @@ def run_migrations():
     """Run all migrations in order."""
     # Import migrations
     try:
+        from migrate_011_add_meal_reviews import migrate as migrate_011_add_meal_reviews
+        from migrate_012_add_ai_settings_history import (
+            migrate as migrate_012_add_ai_settings_history,
+        )
         from migrate_add_caldav_support import migrate as migrate_008_add_caldav_support
         from migrate_add_custom_recurrence import migrate as migrate_009_add_custom_recurrence
         from migrate_add_dinner_plan_assignees import (
@@ -22,7 +26,6 @@ def run_migrations():
         from migrate_add_last_generated_date import (
             migrate as migrate_007_add_last_generated_date,
         )
-        from migrate_011_add_meal_reviews import migrate as migrate_011_add_meal_reviews
         from migrate_add_meal_type import migrate as migrate_010_add_meal_type
         from migrate_add_recurring_todos import migrate as migrate_004_add_recurring_todos
         from migrate_add_reminder_window import migrate as migrate_006_add_reminder_window
@@ -44,6 +47,7 @@ def run_migrations():
         ("009_add_custom_recurrence", migrate_009_add_custom_recurrence),
         ("010_add_meal_type", migrate_010_add_meal_type),
         ("011_add_meal_reviews", migrate_011_add_meal_reviews),
+        ("012_add_ai_settings_history", migrate_012_add_ai_settings_history),
     ]
 
     print("=" * 60)

--- a/src/rally/generator/generate.py
+++ b/src/rally/generator/generate.py
@@ -12,8 +12,8 @@ import requests
 from icalendar import Calendar
 
 from rally.database import SessionLocal, init_db
+from rally.models import AISettingsHistory, DashboardSnapshot, FamilyMember, Setting
 from rally.models import Calendar as CalendarModel
-from rally.models import DashboardSnapshot, FamilyMember, Setting
 from rally.utils.timezone import ensure_utc, now_utc, today_utc
 
 
@@ -521,7 +521,9 @@ class SummaryGenerator:
                 elif days_away == 1:
                     day_label = f"Tomorrow ({meal_type})"
                 else:
-                    day_label = f"{plan_date.strftime('%A')} ({plan_date.strftime('%b %d')}) [{meal_type}]"
+                    day_label = (
+                        f"{plan_date.strftime('%A')} ({plan_date.strftime('%b %d')}) [{meal_type}]"
+                    )
 
                 line = f"{day_label}: {plan.plan}"
 
@@ -540,16 +542,35 @@ class SummaryGenerator:
         finally:
             db.close()
 
+    def _load_ai_setting(self, field_name: str) -> str | None:
+        """Resolve the active AI setting value via its history pointer in settings."""
+        pointer = self._db_settings.get(f"current_{field_name}_history_id")
+        if pointer:
+            try:
+                db = SessionLocal()
+                try:
+                    row = db.get(AISettingsHistory, int(pointer))
+                    if row and row.value:
+                        return row.value
+                finally:
+                    db.close()
+            except Exception:
+                pass
+        # Pre-migration fallback: value stored directly in the settings table
+        return self._db_settings.get(field_name)
+
     def load_context(self) -> str:
         """Load family context from DB settings, falling back to file."""
-        if self._db_settings.get("family_context"):
-            return self._db_settings["family_context"]
+        value = self._load_ai_setting("family_context")
+        if value:
+            return value
         return (self.data_dir / "context.txt").read_text()
 
     def load_voice(self) -> str:
         """Load agent voice profile from DB settings, falling back to file."""
-        if self._db_settings.get("agent_voice"):
-            return self._db_settings["agent_voice"]
+        value = self._load_ai_setting("agent_voice")
+        if value:
+            return value
         return (self.data_dir / "agent_voice.txt").read_text()
 
     def load_template(self) -> str:

--- a/src/rally/models.py
+++ b/src/rally/models.py
@@ -65,6 +65,29 @@ class Setting(Base):
     updated_at: Mapped[datetime] = mapped_column(default=now_utc, onupdate=now_utc)
 
 
+class AISettingsHistory(Base):
+    """Versioned snapshots of AI settings (agent_voice, family_context).
+
+    A new row is inserted on every explicit save of either field. The active
+    snapshot for each field is referenced from the settings table via the
+    'current_agent_voice_history_id' / 'current_family_context_history_id'
+    keys. Rollback re-points the reference and bumps last_used_at — no new
+    row is inserted.
+    """
+
+    __tablename__ = "ai_settings_history"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    field_name: Mapped[str] = mapped_column(
+        String(50), index=True
+    )  # 'agent_voice' or 'family_context'
+    value: Mapped[str] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(default=now_utc)
+    last_used_at: Mapped[datetime] = mapped_column(
+        default=now_utc
+    )  # Bumped whenever this row becomes the active version (save or rollback)
+
+
 class DashboardSnapshot(Base):
     """Dashboard snapshot model - stores generated daily summary data."""
 

--- a/src/rally/routers/settings.py
+++ b/src/rally/routers/settings.py
@@ -4,14 +4,21 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from rally.database import get_db
-from rally.models import Calendar, Setting
+from rally.models import AISettingsHistory, Calendar, Setting
 from rally.schemas import (
+    AI_SETTINGS_FIELDS,
+    AISettingHistoryEntry,
+    AISettingHistoryResponse,
+    AISettingRollback,
+    AISettingState,
+    AISettingValueUpdate,
     CalendarCreate,
     CalendarResponse,
     CalendarUpdate,
     SettingsResponse,
     SettingsUpdate,
 )
+from rally.utils.timezone import now_utc
 
 router = APIRouter(tags=["settings"])
 
@@ -39,6 +46,100 @@ def update_settings(payload: SettingsUpdate, db: Session = Depends(get_db)):
 
     rows = db.query(Setting).all()
     return SettingsResponse(settings={r.key: r.value for r in rows})
+
+
+# --- AI Settings (versioned agent_voice / family_context) ---
+
+
+def _ai_pointer_key(field_name: str) -> str:
+    """Settings key referencing the active ai_settings_history row for a field."""
+    return f"current_{field_name}_history_id"
+
+
+def _validate_ai_field(field_name: str) -> None:
+    if field_name not in AI_SETTINGS_FIELDS:
+        raise HTTPException(status_code=404, detail=f"Unknown AI settings field: {field_name}")
+
+
+def _get_current_ai_snapshot(db: Session, field_name: str) -> AISettingsHistory | None:
+    """Resolve the active history row for a field via its settings pointer."""
+    pointer = db.query(Setting).filter(Setting.key == _ai_pointer_key(field_name)).first()
+    if not pointer:
+        return None
+    return db.get(AISettingsHistory, int(pointer.value))
+
+
+def _set_ai_pointer(db: Session, field_name: str, history_id: int) -> None:
+    """Upsert the settings pointer for a field to reference a history row."""
+    key = _ai_pointer_key(field_name)
+    pointer = db.query(Setting).filter(Setting.key == key).first()
+    if pointer:
+        pointer.value = str(history_id)
+    else:
+        db.add(Setting(key=key, value=str(history_id)))
+
+
+@router.get("/api/settings/ai", response_model=dict[str, AISettingState])
+def get_ai_settings(db: Session = Depends(get_db)):
+    """Get the currently active value for each AI settings field."""
+    result = {}
+    for field_name in AI_SETTINGS_FIELDS:
+        row = _get_current_ai_snapshot(db, field_name)
+        result[field_name] = AISettingState(
+            field_name=field_name,
+            value=row.value if row else "",
+            history_id=row.id if row else None,
+        )
+    return result
+
+
+@router.put("/api/settings/ai/{field_name}", response_model=AISettingState)
+def save_ai_setting(field_name: str, payload: AISettingValueUpdate, db: Session = Depends(get_db)):
+    """Explicitly save an AI settings field — inserts a new history snapshot."""
+    _validate_ai_field(field_name)
+    now = now_utc()  # Single timestamp so created_at == last_used_at on insert
+    row = AISettingsHistory(
+        field_name=field_name, value=payload.value, created_at=now, last_used_at=now
+    )
+    db.add(row)
+    db.flush()  # Assign row.id before pointing the setting at it
+    _set_ai_pointer(db, field_name, row.id)
+    db.commit()
+    db.refresh(row)
+    return AISettingState(field_name=field_name, value=row.value, history_id=row.id)
+
+
+@router.get("/api/settings/ai/{field_name}/history", response_model=AISettingHistoryResponse)
+def get_ai_setting_history(field_name: str, db: Session = Depends(get_db)):
+    """List all snapshots for a field, newest first."""
+    _validate_ai_field(field_name)
+    rows = (
+        db.query(AISettingsHistory)
+        .filter(AISettingsHistory.field_name == field_name)
+        .order_by(AISettingsHistory.created_at.desc(), AISettingsHistory.id.desc())
+        .all()
+    )
+    current = _get_current_ai_snapshot(db, field_name)
+    return AISettingHistoryResponse(
+        field_name=field_name,
+        current_history_id=current.id if current else None,
+        history=[AISettingHistoryEntry.model_validate(r) for r in rows],
+    )
+
+
+@router.post("/api/settings/ai/{field_name}/rollback", response_model=AISettingState)
+def rollback_ai_setting(field_name: str, payload: AISettingRollback, db: Session = Depends(get_db)):
+    """Make an existing snapshot the active version — no new history row."""
+    _validate_ai_field(field_name)
+    row = db.get(AISettingsHistory, payload.history_id)
+    if not row or row.field_name != field_name:
+        raise HTTPException(status_code=404, detail="History entry not found")
+
+    row.last_used_at = now_utc()
+    _set_ai_pointer(db, field_name, row.id)
+    db.commit()
+    db.refresh(row)
+    return AISettingState(field_name=field_name, value=row.value, history_id=row.id)
 
 
 # --- Connectivity Tests ---

--- a/src/rally/schemas.py
+++ b/src/rally/schemas.py
@@ -98,6 +98,51 @@ class SettingsResponse(BaseModel):
     settings: dict[str, str]
 
 
+# AI Settings (versioned agent_voice / family_context)
+
+AI_SETTINGS_FIELDS = ("agent_voice", "family_context")
+
+
+class AISettingValueUpdate(BaseModel):
+    """Explicit save of an AI settings field — creates a new history snapshot."""
+
+    value: str
+
+
+class AISettingRollback(BaseModel):
+    """Roll an AI settings field back to an existing history snapshot."""
+
+    history_id: int
+
+
+class AISettingState(BaseModel):
+    """Currently active value of an AI settings field."""
+
+    field_name: str
+    value: str
+    history_id: int | None = None  # None when no snapshot exists yet
+
+
+class AISettingHistoryEntry(BaseModel):
+    """One snapshot row from ai_settings_history."""
+
+    id: int
+    field_name: str
+    value: str
+    created_at: datetime
+    last_used_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AISettingHistoryResponse(BaseModel):
+    """Version history for one AI settings field, newest first."""
+
+    field_name: str
+    current_history_id: int | None = None
+    history: list[AISettingHistoryEntry]
+
+
 # Todos
 
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -1141,6 +1141,104 @@ footer a:hover {
     overflow-y: auto;
 }
 
+/* AI Settings Version History */
+.ai-field-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 10px;
+}
+
+.btn-ghost {
+    border: none;
+    background: transparent;
+    color: var(--medium-gray);
+    font-family: var(--body-font);
+    font-size: 0.9rem;
+    letter-spacing: 0.02em;
+    text-decoration: underline;
+    cursor: pointer;
+    padding: 10px 8px;
+    transition: color 0.2s;
+}
+
+.btn-ghost:hover {
+    color: var(--charcoal);
+}
+
+.history-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-height: 55vh;
+    overflow-y: auto;
+}
+
+.history-item {
+    border: 1px solid var(--pale-gray);
+    padding: 12px 16px;
+    cursor: pointer;
+    transition: border-color 0.2s;
+}
+
+.history-item.selected {
+    border-color: var(--charcoal);
+}
+
+.history-item-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.history-radio {
+    color: var(--charcoal);
+    flex-shrink: 0;
+}
+
+.history-timestamp {
+    font-family: var(--body-font);
+    font-size: 0.9rem;
+    color: var(--charcoal);
+}
+
+.history-current-badge {
+    border: 1px solid var(--charcoal);
+    padding: 2px 8px;
+    font-family: var(--body-font);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--charcoal);
+}
+
+.history-value-toggle {
+    border: none;
+    background: transparent;
+    color: var(--medium-gray);
+    font-family: var(--body-font);
+    font-size: 0.85rem;
+    cursor: pointer;
+    padding: 6px 0 0 26px;
+    transition: color 0.2s;
+}
+
+.history-value-toggle:hover {
+    color: var(--charcoal);
+}
+
+.history-value {
+    margin: 8px 0 0 26px;
+    padding: 12px;
+    border: 1px solid var(--pale-gray);
+    background: var(--off-white);
+    font-family: var(--body-font);
+    font-size: 0.9rem;
+    color: var(--charcoal);
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
 /** End Settings Page Styles **/
 
 /** Responsive Design **/

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -120,17 +120,24 @@
         <div class="header-container">
             <h2>AI</h2>
         </div>
-        <form id="ai-form">
+        <div id="ai-form">
             <div class="form-group">
                 <label>Family Context</label>
                 <textarea id="ai-family-context" rows="12" placeholder="Describe your family, routines, values, and scheduling preferences..."></textarea>
+                <div class="ai-field-actions">
+                    <button type="button" class="btn-save" onclick="saveAiField('family_context')">Save</button>
+                    <button type="button" class="btn-ghost" onclick="openHistoryModal('family_context')">Version History</button>
+                </div>
             </div>
             <div class="form-group">
                 <label>Agent Voice</label>
                 <textarea id="ai-agent-voice" rows="8" placeholder="Describe the tone and personality for Rally's summaries..."></textarea>
+                <div class="ai-field-actions">
+                    <button type="button" class="btn-save" onclick="saveAiField('agent_voice')">Save</button>
+                    <button type="button" class="btn-ghost" onclick="openHistoryModal('agent_voice')">Version History</button>
+                </div>
             </div>
-            <button type="submit" class="btn-save">Save</button>
-        </form>
+        </div>
     </div>
 
     <!-- Meal Planner Section -->
@@ -237,6 +244,18 @@
                     <button type="button" class="btn-cancel" id="btn-cancel-calendar">Cancel</button>
                 </div>
             </form>
+        </div>
+    </div>
+
+    <!-- Version History Modal -->
+    <div class="modal-overlay" id="history-modal-overlay">
+        <div class="modal-content">
+            <h3 id="history-modal-title">Version History</h3>
+            <div class="history-list" id="history-list"></div>
+            <div class="modal-actions">
+                <button type="button" class="btn-primary" id="btn-change-version">Change Version</button>
+                <button type="button" class="btn-cancel" id="btn-cancel-history">Cancel</button>
+            </div>
         </div>
     </div>
 
@@ -547,10 +566,6 @@
             document.getElementById('llm-anthropic-model').value = s.llm_anthropic_model || '';
             toggleLlmFields(provider);
 
-            // AI
-            document.getElementById('ai-family-context').value = s.family_context || '';
-            document.getElementById('ai-agent-voice').value = s.agent_voice || '';
-
             // Meal Planner
             document.getElementById('meal-default-type').value = s.meal_default_type || 'Dinner';
 
@@ -571,6 +586,147 @@
         function toggleLlmFields(provider) {
             document.querySelector('.llm-fields-local').classList.toggle('active', provider === 'local');
             document.querySelector('.llm-fields-anthropic').classList.toggle('active', provider === 'anthropic');
+        }
+
+        // ── AI Settings (versioned agent_voice / family_context) ──
+
+        const AI_FIELD_META = {
+            family_context: { label: 'Family Context', inputId: 'ai-family-context' },
+            agent_voice: { label: 'Agent Voice', inputId: 'ai-agent-voice' }
+        };
+
+        let historyField = null;
+        let historyEntries = [];
+        let currentHistoryId = null;
+        let selectedHistoryId = null;
+        let expandedHistoryIds = new Set();
+
+        async function fetchAiSettings() {
+            const response = await fetch('/api/settings/ai');
+            const data = await response.json();
+            for (const [field, meta] of Object.entries(AI_FIELD_META)) {
+                document.getElementById(meta.inputId).value = (data[field] && data[field].value) || '';
+            }
+        }
+
+        async function saveAiField(field) {
+            const meta = AI_FIELD_META[field];
+            try {
+                const response = await fetch('/api/settings/ai/' + field, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ value: document.getElementById(meta.inputId).value })
+                });
+                if (!response.ok) throw new Error('Failed to save');
+                alert(meta.label + ' saved.');
+            } catch (error) {
+                console.error('Error saving ' + field + ':', error);
+                alert('Failed to save ' + meta.label);
+            }
+        }
+
+        async function openHistoryModal(field) {
+            historyField = field;
+            historyEntries = [];
+            currentHistoryId = null;
+            selectedHistoryId = null;
+            expandedHistoryIds = new Set();
+
+            document.getElementById('history-modal-title').textContent = AI_FIELD_META[field].label + ' Version History';
+            document.getElementById('history-list').innerHTML = '<div class="container-loading-state">Loading version history...</div>';
+            document.getElementById('history-modal-overlay').style.display = 'flex';
+
+            try {
+                const response = await fetch('/api/settings/ai/' + field + '/history');
+                if (!response.ok) throw new Error('Failed to load history');
+                const data = await response.json();
+                historyEntries = data.history;
+                currentHistoryId = data.current_history_id;
+                selectedHistoryId = data.current_history_id;
+                renderHistoryList();
+            } catch (error) {
+                console.error('Error loading version history:', error);
+                document.getElementById('history-list').innerHTML = '<div class="container-empty-state">Failed to load version history.</div>';
+            }
+        }
+
+        function closeHistoryModal() {
+            document.getElementById('history-modal-overlay').style.display = 'none';
+            historyField = null;
+        }
+
+        function formatUtcTimestamp(isoString) {
+            // Timestamps are stored as naive UTC; tag them so Date parses correctly
+            const hasZone = isoString.endsWith('Z') || /[+-]\d{2}:?\d{2}$/.test(isoString);
+            const d = new Date(hasZone ? isoString : isoString + 'Z');
+            const pad = n => String(n).padStart(2, '0');
+            return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} `
+                + `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())} UTC`;
+        }
+
+        function renderHistoryList() {
+            const container = document.getElementById('history-list');
+
+            if (historyEntries.length === 0) {
+                container.innerHTML = '<div class="container-empty-state">No saved versions yet. Click "Save" to create the first snapshot.</div>';
+                return;
+            }
+
+            container.innerHTML = historyEntries.map(entry => {
+                const selected = entry.id === selectedHistoryId;
+                const expanded = expandedHistoryIds.has(entry.id);
+                const currentBadge = entry.id === currentHistoryId
+                    ? '<span class="history-current-badge">Current</span>'
+                    : '';
+                return `
+                    <div class="history-item ${selected ? 'selected' : ''}" onclick="selectHistoryEntry(${entry.id})">
+                        <div class="history-item-header">
+                            <span class="history-radio">${selected ? '●' : '○'}</span>
+                            <span class="history-timestamp">${formatUtcTimestamp(entry.created_at)}</span>
+                            ${currentBadge}
+                        </div>
+                        <button type="button" class="history-value-toggle" onclick="toggleHistoryValue(event, ${entry.id})">${expanded ? '▼' : '►'} Value</button>
+                        <div class="history-value" style="display: ${expanded ? 'block' : 'none'}">${escapeHtml(entry.value)}</div>
+                    </div>
+                `;
+            }).join('');
+        }
+
+        function selectHistoryEntry(id) {
+            selectedHistoryId = id;
+            renderHistoryList();
+        }
+
+        function toggleHistoryValue(event, id) {
+            event.stopPropagation();
+            if (expandedHistoryIds.has(id)) {
+                expandedHistoryIds.delete(id);
+            } else {
+                expandedHistoryIds.add(id);
+            }
+            renderHistoryList();
+        }
+
+        async function changeVersion() {
+            if (!historyField || selectedHistoryId == null) {
+                closeHistoryModal();
+                return;
+            }
+            const field = historyField;
+            try {
+                const response = await fetch('/api/settings/ai/' + field + '/rollback', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ history_id: selectedHistoryId })
+                });
+                if (!response.ok) throw new Error('Failed to change version');
+                const data = await response.json();
+                document.getElementById(AI_FIELD_META[field].inputId).value = data.value;
+                closeHistoryModal();
+            } catch (error) {
+                console.error('Error changing version:', error);
+                alert('Failed to change version');
+            }
         }
 
         // ── Connection Verification ──
@@ -762,19 +918,11 @@
             }
         });
 
-        // AI form
-        document.getElementById('ai-form').addEventListener('submit', async (e) => {
-            e.preventDefault();
-            try {
-                await saveSettings({
-                    family_context: document.getElementById('ai-family-context').value,
-                    agent_voice: document.getElementById('ai-agent-voice').value
-                });
-                alert('AI settings saved.');
-            } catch (error) {
-                console.error('Error saving AI settings:', error);
-                alert('Failed to save AI settings');
-            }
+        // Version history modal
+        document.getElementById('btn-change-version').addEventListener('click', changeVersion);
+        document.getElementById('btn-cancel-history').addEventListener('click', closeHistoryModal);
+        document.getElementById('history-modal-overlay').addEventListener('click', (e) => {
+            if (e.target.id === 'history-modal-overlay') closeHistoryModal();
         });
 
         // Meal Planner form
@@ -806,7 +954,7 @@
         });
 
         // ── Initialize ──
-        Promise.all([fetchMembers(), fetchCalendars(), fetchSettings()]);
+        Promise.all([fetchMembers(), fetchCalendars(), fetchSettings(), fetchAiSettings()]);
 
         // Nav dropdown toggle (for touch devices)
         function toggleMealDropdown(e) {


### PR DESCRIPTION
## Summary
Implement versioned snapshots for AI settings fields (`agent_voice` and `family_context`), allowing users to save multiple versions and roll back to previous snapshots. This replaces the simple key-value storage with a dedicated `ai_settings_history` table and adds a UI modal for browsing and restoring past versions.

## Key Changes

### Backend
- **New Model**: `AISettingsHistory` table stores versioned snapshots with `field_name`, `value`, `created_at`, and `last_used_at` timestamps
- **New API Endpoints**:
  - `GET /api/settings/ai` — fetch currently active values for all AI fields
  - `PUT /api/settings/ai/{field_name}` — save a new snapshot
  - `GET /api/settings/ai/{field_name}/history` — list all snapshots (newest first)
  - `POST /api/settings/ai/{field_name}/rollback` — restore a previous snapshot
- **Migration 012**: Creates `ai_settings_history` table, seeds it from existing `agent_voice`/`family_context` settings rows, points new `current_*_history_id` settings keys at seed rows, and removes original settings rows
- **Fallback Logic**: `generate.py` includes pre-migration fallback to read directly from settings table if history pointer doesn't exist

### Frontend
- **UI Changes**: Convert AI form from `<form>` to `<div>`, add per-field "Save" and "Version History" buttons
- **Version History Modal**: New modal displays all snapshots with timestamps, current badge, expandable value preview, and radio-button selection
- **Client Functions**: `saveAiField()`, `openHistoryModal()`, `changeVersion()`, and supporting utilities for rendering and managing history state
- **Initialization**: Call `fetchAiSettings()` on page load to populate current values from API

### Styling
- New CSS classes for version history UI: `.ai-field-actions`, `.btn-ghost`, `.history-list`, `.history-item`, `.history-value-toggle`, etc.

## Notable Implementation Details
- Timestamps are stored as naive UTC in SQLite; frontend formats them with explicit UTC label
- `last_used_at` is bumped on both save (new row) and rollback (existing row re-pointed)
- History entries are ordered newest-first for intuitive browsing
- Modal state (expanded entries, selected version) is managed in JavaScript and re-rendered on interaction
- HTML escaping prevents XSS when displaying stored values in the modal

https://claude.ai/code/session_01SQuH8DrcLtTxL7cRMwGqe4