### PR TITLE
fix: prevent browsers from serving stale cached CSS

### DIFF
--- a/src/rally/main.py
+++ b/src/rally/main.py
@@ -5,11 +5,26 @@ from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from starlette.responses import Response
 
 from rally.database import init_db
 from rally.routers import dashboard, dinner_planner, family, recurring_todos, settings, todos
+from rally.utils.static_version import STATIC_VERSION
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
+
+
+class NoCacheStaticFiles(StaticFiles):
+    """Serve static files with Cache-Control: no-cache.
+
+    Browsers must revalidate (cheap 304 via ETag) instead of heuristically
+    caching assets and serving stale CSS after a deploy.
+    """
+
+    def file_response(self, *args, **kwargs) -> Response:
+        response = super().file_response(*args, **kwargs)
+        response.headers["Cache-Control"] = "no-cache"
+        return response
 
 
 @asynccontextmanager
@@ -28,10 +43,11 @@ app = FastAPI(
 # Static files
 static_dir = BASE_DIR / "static"
 if static_dir.is_dir():
-    app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+    app.mount("/static", NoCacheStaticFiles(directory=str(static_dir)), name="static")
 
 # Templates
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+templates.env.globals["css_version"] = STATIC_VERSION
 
 # Include routers
 app.include_router(dashboard.router)

--- a/src/rally/routers/dashboard.py
+++ b/src/rally/routers/dashboard.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from rally.database import get_db
 from rally.generator.generate import SummaryGenerator
 from rally.models import DashboardSnapshot
+from rally.utils.static_version import STATIC_VERSION
 from rally.utils.timezone import ensure_utc, now_utc
 
 router = APIRouter(tags=["dashboard"])
@@ -63,6 +64,7 @@ def _render_html(data: dict, date_str: str, timestamp: datetime) -> str:
     html = html.replace("{{briefing_section}}", briefing_section)
     html = html.replace("{{timestamp}}", timestamp_str)  # Fallback for non-JS browsers
     html = html.replace("{{timestamp_utc}}", timestamp_utc)  # For JS timezone conversion
+    html = html.replace("{{css_version}}", STATIC_VERSION)
     return html
 
 

--- a/src/rally/utils/static_version.py
+++ b/src/rally/utils/static_version.py
@@ -1,0 +1,24 @@
+"""Static asset versioning for cache busting.
+
+Browsers (Safari in particular) heuristically cache /static/styles.css and
+keep serving stale copies after a deploy. Appending a content hash to the
+stylesheet URL forces a fresh fetch whenever the file actually changes.
+"""
+
+import hashlib
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent.parent.parent
+STATIC_DIR = BASE_DIR / "static"
+
+
+def _compute_version() -> str:
+    """Return a short content hash of the stylesheet."""
+    css_path = STATIC_DIR / "styles.css"
+    if not css_path.is_file():
+        return "0"
+    return hashlib.md5(css_path.read_bytes()).hexdigest()[:12]
+
+
+# Computed once at import time; deploys restart the app, which refreshes it.
+STATIC_VERSION = _compute_version()

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
-    <link href="/static/styles.css" rel="stylesheet">
+    <link href="/static/styles.css?v={{css_version}}" rel="stylesheet">
 </head>
 <body>
     <header class="header">

--- a/templates/dinner_planner.html
+++ b/templates/dinner_planner.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
-    <link href="/static/styles.css" rel="stylesheet">
+    <link href="/static/styles.css?v={{ css_version }}" rel="stylesheet">
 </head>
 <body>
     <header class="header">

--- a/templates/meal_history.html
+++ b/templates/meal_history.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
-    <link href="/static/styles.css" rel="stylesheet">
+    <link href="/static/styles.css?v={{ css_version }}" rel="stylesheet">
 </head>
 <body>
     <header class="header">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
-    <link href="/static/styles.css" rel="stylesheet">
+    <link href="/static/styles.css?v={{ css_version }}" rel="stylesheet">
 </head>
 <body>
     <header class="header">

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
-    <link href="/static/styles.css" rel="stylesheet">
+    <link href="/static/styles.css?v={{ css_version }}" rel="stylesheet">
 </head>
 <body>
     <header class="header">


### PR DESCRIPTION
## Summary
Style fixes weren't showing up after deploys (e.g. the mobile nav fix from #72 and the version-history styles from #73 both appeared "broken" on devices that had an older `styles.css` cached). Every page links `/static/styles.css` with no version, and `StaticFiles` serves it without a `Cache-Control` header, so Safari heuristically caches the stylesheet and keeps serving the stale copy.

## Changes
Two complementary layers:

1. **Content-hash cache busting** — new `rally/utils/static_version.py` computes a short MD5 of `styles.css` at startup, and every page now links `/static/styles.css?v=<hash>`. Any CSS change yields a new URL, which bypasses caches that are already stale.
   - Jinja-rendered pages (todo, dinner planner, meal history, settings) get it via a `css_version` template global registered on the shared `Jinja2Templates` env.
   - The dashboard's string-replacement renderer substitutes a `{{css_version}}` token explicitly, since `dashboard.html` is not rendered through Jinja.
2. **`Cache-Control: no-cache` on `/static`** — a small `NoCacheStaticFiles` subclass stamps the header on every static response, so browsers revalidate with ETag/If-Modified-Since (a cheap 304 when unchanged) instead of heuristically caching.

## Verification
Tested against starlette's `TestClient`, executing the actual `NoCacheStaticFiles` class from `main.py`:
- `/static/styles.css` responses carry `Cache-Control: no-cache` plus an ETag, and conditional requests return 304
- all four Jinja templates render the versioned stylesheet link
- the dashboard token replacement substitutes the hash correctly

`ruff check` passes on all changed files.

https://claude.ai/code/session_01NRqoQGi8kNDTsAbphNWmwW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRqoQGi8kNDTsAbphNWmwW)_