### PR TITLE
Add completed_at to todos and update logic

### DIFF
--- a/migrations/migrate_add_completed_at.py
+++ b/migrations/migrate_add_completed_at.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Migration: Add completed_at column to todos.
+
+Safe to run multiple times (idempotent).
+"""
+
+import os
+import sqlite3
+from pathlib import Path
+
+
+def migrate():
+    """Run the migration. Return True on success, False on failure."""
+    db_path = os.environ.get("RALLY_DB_PATH")
+
+    if not db_path:
+        prod_path = Path("/data/rally.db")
+        dev_path = Path(__file__).parent.parent / "rally.db"
+        db_path = str(prod_path) if prod_path.exists() else str(dev_path)
+
+    db_path = Path(db_path)
+
+    if not db_path.exists():
+        print(f"✓ Database not found at {db_path}")
+        print("  No migration needed - database will be created with correct schema.")
+        return True
+
+    print(f"Checking database at {db_path}...")
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute("PRAGMA table_info(todos)")
+        columns = [col[1] for col in cursor.fetchall()]
+
+        if not columns:
+            print("✓ todos table does not exist yet")
+            print("  No migration needed - table will be created with correct schema.")
+            return True
+
+        if "completed_at" in columns:
+            print("✓ Migration: todos.completed_at already exists (idempotent)")
+        else:
+            print("  Adding 'completed_at' column to todos table...")
+            cursor.execute("ALTER TABLE todos ADD COLUMN completed_at DATETIME")
+            print("✓ Migration: todos.completed_at added")
+
+        print("  Backfilling completed_at from updated_at for completed todos...")
+        cursor.execute("""
+            UPDATE todos
+            SET completed_at = updated_at
+            WHERE completed = 1
+              AND completed_at IS NULL
+        """)
+        print(f"✓ Backfilled completed_at for {cursor.rowcount} todos")
+
+        conn.commit()
+        return True
+
+    except sqlite3.Error as e:
+        print(f"✗ Migration failed: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    import sys
+
+    success = migrate()
+    sys.exit(0 if success else 1)

--- a/migrations/run_migrations.py
+++ b/migrations/run_migrations.py
@@ -16,6 +16,7 @@ def run_migrations():
         from migrate_012_add_ai_settings_history import (
             migrate as migrate_012_add_ai_settings_history,
         )
+        from migrate_add_completed_at import migrate as migrate_013_add_completed_at
         from migrate_add_caldav_support import migrate as migrate_008_add_caldav_support
         from migrate_add_custom_recurrence import migrate as migrate_009_add_custom_recurrence
         from migrate_add_dinner_plan_assignees import (
@@ -48,6 +49,7 @@ def run_migrations():
         ("010_add_meal_type", migrate_010_add_meal_type),
         ("011_add_meal_reviews", migrate_011_add_meal_reviews),
         ("012_add_ai_settings_history", migrate_012_add_ai_settings_history),
+        ("013_add_completed_at", migrate_013_add_completed_at),
     ]
 
     print("=" * 60)

--- a/src/rally/models.py
+++ b/src/rally/models.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from sqlalchemy import JSON, Boolean, CheckConstraint, Integer, String, Text
+from sqlalchemy import JSON, Boolean, CheckConstraint, DateTime, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from rally.database import Base
@@ -120,6 +120,7 @@ class Todo(Base):
         Integer, nullable=True
     )  # Days before due_date to start showing in LLM briefings
     completed: Mapped[bool] = mapped_column(default=False)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     created_at: Mapped[datetime] = mapped_column(default=now_utc)
     updated_at: Mapped[datetime] = mapped_column(default=now_utc, onupdate=now_utc)
 

--- a/src/rally/routers/recurring_todos.py
+++ b/src/rally/routers/recurring_todos.py
@@ -1,5 +1,6 @@
 """Recurring todos router for Rally."""
 
+from datetime import datetime
 from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -9,9 +10,23 @@ from sqlalchemy.orm import Session
 from rally.database import get_db
 from rally.models import RecurringTodo, Setting, Todo
 from rally.schemas import UNSET, RecurringTodoCreate, RecurringTodoResponse, RecurringTodoUpdate
-from rally.utils.timezone import ensure_utc
+from rally.utils.timezone import ensure_utc, now_utc
 
 router = APIRouter(prefix="/api/recurring-todos", tags=["recurring-todos"])
+
+
+def format_local_completion(completed_at: datetime, local_tz: ZoneInfo) -> str:
+    local_dt = completed_at.astimezone(local_tz)
+    today = now_utc().astimezone(local_tz).date()
+    if local_dt.date() == today:
+        date_label = "Today"
+    elif local_dt.date() == today.replace(day=today.day) - __import__("datetime").timedelta(days=1):
+        date_label = "Yesterday"
+    else:
+        suffix = "th" if 11 <= local_dt.day % 100 <= 13 else {1: "st", 2: "nd", 3: "rd"}.get(local_dt.day % 10, "th")
+        date_label = f"{local_dt.strftime('%b')} {local_dt.day}{suffix}, {local_dt.year}"
+    time_label = local_dt.strftime("%I:%M %p").lstrip("0")
+    return f"{date_label} at {time_label}"
 
 
 @router.get("", response_model=list[RecurringTodoResponse])
@@ -19,48 +34,40 @@ def list_recurring_todos(db: Session = Depends(get_db)):
     """List all recurring todo templates."""
     rts = db.query(RecurringTodo).order_by(RecurringTodo.created_at.desc()).all()
 
-    # For instances with a due_date, use it directly — it's already a local
-    # YYYY-MM-DD string, so no timezone conversion is needed.
-    due_date_rows = (
-        db.query(Todo.recurring_todo_id, func.max(Todo.due_date).label("last_due_date"))
-        .filter(
-            Todo.completed == True,  # noqa: E712
-            Todo.recurring_todo_id.isnot(None),
-            Todo.due_date.isnot(None),
+    completed_rows = (
+        db.query(
+            Todo.recurring_todo_id,
+            func.max(func.coalesce(Todo.completed_at, Todo.updated_at)).label("last_completed_at"),
         )
-        .group_by(Todo.recurring_todo_id)
-        .all()
-    )
-    # Fall back to updated_at for instances that have no due_date.
-    no_due_date_rows = (
-        db.query(Todo.recurring_todo_id, func.max(Todo.updated_at).label("last_completed_at"))
         .filter(
             Todo.completed == True,  # noqa: E712
             Todo.recurring_todo_id.isnot(None),
-            Todo.due_date.is_(None),
         )
         .group_by(Todo.recurring_todo_id)
         .all()
     )
 
-    # Convert completion timestamps to the configured local timezone so the
-    # reported date matches the day the user actually completed the task.
     tz_row = db.query(Setting).filter(Setting.key == "local_timezone").first()
     local_tz = ZoneInfo(tz_row.value if tz_row and tz_row.value else "UTC")
 
-    last_completed_map: dict[int, str] = {}
-    for row in no_due_date_rows:
-        local_dt = ensure_utc(row.last_completed_at).astimezone(local_tz)
-        last_completed_map[row.recurring_todo_id] = local_dt.date().isoformat()
-    for row in due_date_rows:
-        last_completed_map[row.recurring_todo_id] = row.last_due_date
+    last_completed_map: dict[int, datetime] = {}
+    last_completed_date_map: dict[int, str] = {}
+    for row in completed_rows:
+        completed_at = row.last_completed_at
+        if isinstance(completed_at, str):
+            completed_at = datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
+        utc_dt = ensure_utc(completed_at)
+        local_dt = utc_dt.astimezone(local_tz)
+        last_completed_map[row.recurring_todo_id] = utc_dt
+        last_completed_date_map[row.recurring_todo_id] = local_dt.date().isoformat()
 
     results = []
     for rt in rts:
         response = RecurringTodoResponse.model_validate(rt)
-        last_date = last_completed_map.get(rt.id)
-        if last_date:
-            response.last_completed_date = last_date
+        last_completed_at = last_completed_map.get(rt.id)
+        if last_completed_at:
+            response.last_completed_at = last_completed_at
+            response.last_completed_date = last_completed_date_map[rt.id]
         results.append(response)
 
     return results

--- a/src/rally/routers/todos.py
+++ b/src/rally/routers/todos.py
@@ -33,7 +33,7 @@ def list_todos(
         # Show incomplete todos OR completed today (local time)
         cutoff = now_utc() - timedelta(hours=datetime.now().time().hour, minutes=datetime.now().time().minute, seconds=datetime.now().time().second, microseconds=datetime.now().time().microsecond)
         query = query.filter(
-            (Todo.completed == False) | (Todo.updated_at > cutoff)  # noqa: E712
+            (Todo.completed == False) | (Todo.completed_at > cutoff)  # noqa: E712
         )
 
     # Sort by created_at DESC (newest first)
@@ -90,6 +90,10 @@ def update_todo(
     if todo.remind_days_before is not UNSET:
         db_todo.remind_days_before = todo.remind_days_before
     if todo.completed is not None:
+        if todo.completed and not db_todo.completed:
+            db_todo.completed_at = now_utc()
+        elif not todo.completed:
+            db_todo.completed_at = None
         db_todo.completed = todo.completed
 
     # updated_at is automatically set by SQLAlchemy via onupdate

--- a/src/rally/schemas.py
+++ b/src/rally/schemas.py
@@ -174,6 +174,7 @@ class TodoResponse(TodoBase):
     recurring_todo_id: int | None = None
     remind_days_before: int | None = None
     completed: bool
+    completed_at: datetime | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -215,6 +216,8 @@ class RecurringTodoResponse(RecurringTodoBase):
     active: bool
     last_generated_date: str | None = None
     last_completed_date: str | None = None
+    last_completed_at: datetime | None = None
+    last_completed_display: str | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Rally — Todos</title>
+    <title>Rally - Todos</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📰</text></svg>">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -435,7 +435,7 @@
                             <div class="editable-item-content">
                                 <div class="editable-item-title">${escapeHtml(rt.title)} ${assigneeHtml} ${pausedHtml}</div>
                                 <div class="recurring-schedule">${describeRecurrence(rt)} ${dueBadge}</div>
-                                <div class="recurring-schedule">Last completed: ${formatLastCompleted(rt.last_completed_date)}</div>
+                                <div class="recurring-schedule">Last completed: ${formatLastCompleted(rt.last_completed_at || rt.last_completed_date)}</div>
                             </div>
                             <div class="editable-item-actions">
                                 <button class="btn-edit" onclick="toggleRecurringActive(${rt.id}, ${rt.active})">${rt.active ? 'Pause' : 'Resume'}</button>
@@ -656,15 +656,17 @@
             return n + (s[(v-20)%10] || s[v] || s[0]);
         }
 
-        function formatLastCompleted(dateStr) {
-            if (!dateStr) return 'Never';
-            const completed = new Date(dateStr + 'T00:00:00');
+        function formatLastCompleted(value) {
+            if (!value) return 'Never';
+            const completed = value.includes('T') ? new Date(value) : new Date(value + 'T00:00:00');
             const today = new Date();
             today.setHours(0, 0, 0, 0);
             const yesterday = new Date(today);
             yesterday.setDate(today.getDate() - 1);
-            if (completed.getTime() === today.getTime()) return 'Today';
-            if (completed.getTime() === yesterday.getTime()) return 'Yesterday';
+            const completedDay = new Date(completed);
+            completedDay.setHours(0, 0, 0, 0);
+            if (completedDay.getTime() === today.getTime()) return 'Today';
+            if (completedDay.getTime() === yesterday.getTime()) return 'Yesterday';
             const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
             return `${months[completed.getMonth()]} ${ordinal(completed.getDate())}, ${completed.getFullYear()}`;
         }


### PR DESCRIPTION
- Introduce a completed_at DATETIME column and wire it through the app.
- Adds a new idempotent migration (migrate_add_completed_at.py) and registers it in run_migrations.
- Models and schemas now include completed_at/last_completed_at fields.
- API changes: list and update endpoints use completed_at for filtering and tracking completion (todos.router sets/clears completed_at on status changes; recurring_todos.router computes and returns last_completed_at with local timezone handling).
- Frontend template updated to display parsed datetime values and handle ISO datetimes; includes a small title punctuation change.
- Migration also backfills completed_at from updated_at for already completed todos.