### PR TITLE
Replace OpenWeather API with configurable NWS forecast URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -508,7 +508,7 @@ rally/
   - Todo and dinner plan date comparisons use the user's configured local timezone
 - ✅ Configuration via Settings UI (stored in DB) with config.toml fallback
 - ✅ Calendar integration (Google Calendar, iCloud) - filters to next 7 days, deduplicates, handles declined events
-- ✅ Weather integration (OpenWeather API)
+- ✅ Weather integration (configurable National Weather Service forecast URL — DWML feed)
 - ✅ Configurable LLM provider - Anthropic Claude or any OpenAI-compatible API
 - ✅ Idempotent database migrations - Run automatically on container startup
 - ✅ SQLite database with FamilyMember, Calendar, Setting, DashboardSnapshot, Todo, RecurringTodo, and DinnerPlan models
@@ -613,7 +613,7 @@ rally/
 - `/api/settings/test-llm` - LLM connectivity test
   - `POST /api/settings/test-llm` - Test LLM provider connection (sends minimal 1-token request). Returns `{success, message}` or `{success, error}`.
 - `/api/settings/test-weather` - Weather connectivity test
-  - `POST /api/settings/test-weather` - Test OpenWeather API connection (10-second timeout). Returns `{success, message}` or `{success, error}`.
+  - `POST /api/settings/test-weather` - Fetch the configured NWS forecast URL and confirm it returns DWML weather data (10-second timeout). Returns `{success, message}` or `{success, error}`.
 - `/api/calendars` - Calendar feed CRUD endpoints
   - `GET /api/calendars` - List all calendar feeds
   - `POST /api/calendars` - Create new calendar feed

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Rally helps families come together around a shared daily plan. It synthesizes ca
 ### For Production
 
 - Docker
-- OpenWeather API key (free tier)
+- A National Weather Service forecast URL for your location (free — see the Weather section of the Settings UI)
 - LLM API key (Anthropic or an OpenAI-compatible provider)
 - Calendar access — ICS feed URLs, or Google/Apple CalDAV with app-specific passwords (configured via the Settings UI)
 - Your local timezone (IANA format, e.g. "America/Chicago")

--- a/migrations/migrate_014_configurable_nws_weather.py
+++ b/migrations/migrate_014_configurable_nws_weather.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Migration to switch weather config from OpenWeather to a configurable NWS URL.
+
+Removes the legacy OpenWeather settings (weather_api_key, weather_lat,
+weather_lon) and seeds a single weather_nws_url setting if none exists.
+
+Run this once to upgrade existing databases. Safe to run multiple times (idempotent).
+"""
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+DEFAULT_NWS_URL = (
+    "https://forecast.weather.gov/MapClick.php"
+    "?lat=33.085&lon=-97.0542&unit=0&lg=english&FcstType=dwml"
+)
+
+LEGACY_KEYS = ("weather_api_key", "weather_lat", "weather_lon")
+
+
+def migrate():
+    # Get database path from environment or use default
+    db_path = os.environ.get("RALLY_DB_PATH")
+
+    if not db_path:
+        prod_path = Path("/data/rally.db")
+        dev_path = Path(__file__).parent.parent / "rally.db"
+        db_path = str(prod_path) if prod_path.exists() else str(dev_path)
+
+    db_path = Path(db_path)
+
+    if not db_path.exists():
+        print(f"✓ Database not found at {db_path}")
+        print("  No migration needed - database will be created with correct schema on first run.")
+        return True
+
+    print(f"Checking database at {db_path}...")
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    try:
+        # Settings table may not exist yet on very old databases
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='settings'")
+        if not cursor.fetchone():
+            print("✓ Migration: settings table does not exist yet (nothing to migrate)")
+            return True
+
+        # Step 1: Remove legacy OpenWeather settings
+        removed = 0
+        for key in LEGACY_KEYS:
+            cursor.execute("DELETE FROM settings WHERE key = ?", (key,))
+            removed += cursor.rowcount
+        if removed:
+            print(f"✓ Migration: removed {removed} legacy OpenWeather setting(s)")
+        else:
+            print("✓ Migration: no legacy OpenWeather settings present (idempotent check)")
+
+        # Step 2: Seed weather_nws_url if it's missing
+        cursor.execute("SELECT value FROM settings WHERE key = 'weather_nws_url'")
+        if cursor.fetchone():
+            print("✓ Migration: weather_nws_url already configured (idempotent check)")
+        else:
+            cursor.execute(
+                "INSERT INTO settings (key, value) VALUES ('weather_nws_url', ?)",
+                (DEFAULT_NWS_URL,),
+            )
+            print("✓ Migration: seeded default weather_nws_url")
+
+        conn.commit()
+        return True
+
+    except sqlite3.Error as e:
+        print(f"✗ Migration failed: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    success = migrate()
+    sys.exit(0 if success else 1)

--- a/migrations/run_migrations.py
+++ b/migrations/run_migrations.py
@@ -16,6 +16,9 @@ def run_migrations():
         from migrate_012_add_ai_settings_history import (
             migrate as migrate_012_add_ai_settings_history,
         )
+        from migrate_014_configurable_nws_weather import (
+            migrate as migrate_014_configurable_nws_weather,
+        )
         from migrate_add_completed_at import migrate as migrate_013_add_completed_at
         from migrate_add_caldav_support import migrate as migrate_008_add_caldav_support
         from migrate_add_custom_recurrence import migrate as migrate_009_add_custom_recurrence
@@ -50,6 +53,7 @@ def run_migrations():
         ("011_add_meal_reviews", migrate_011_add_meal_reviews),
         ("012_add_ai_settings_history", migrate_012_add_ai_settings_history),
         ("013_add_completed_at", migrate_013_add_completed_at),
+        ("014_configurable_nws_weather", migrate_014_configurable_nws_weather),
     ]
 
     print("=" * 60)

--- a/src/rally/cli.py
+++ b/src/rally/cli.py
@@ -108,9 +108,10 @@ def seed():
         # Create sample settings
         sample_settings = [
             Setting(key="local_timezone", value="America/Chicago"),
-            Setting(key="weather_api_key", value="your_openweather_api_key_here"),
-            Setting(key="weather_lat", value="32.7767"),
-            Setting(key="weather_lon", value="-96.7970"),
+            Setting(
+                key="weather_nws_url",
+                value="https://forecast.weather.gov/MapClick.php?lat=33.085&lon=-97.0542&unit=0&lg=english&FcstType=dwml",
+            ),
             Setting(key="llm_provider", value="local"),
             Setting(key="llm_local_base_url", value="http://localhost:1234/v1"),
             Setting(key="llm_local_model", value="your-model-name"),

--- a/src/rally/generator/generate.py
+++ b/src/rally/generator/generate.py
@@ -306,85 +306,111 @@ class SummaryGenerator:
 
         return None
 
-    def fetch_weather(self) -> dict | None:
-        """Get weather from OpenWeather."""
-        # Try DB settings first, fall back to config.toml
-        if all(k in self._db_settings for k in ("weather_api_key", "weather_lat", "weather_lon")):
-            api_key = self._db_settings["weather_api_key"]
-            lat = float(self._db_settings["weather_lat"])
-            lon = float(self._db_settings["weather_lon"])
-        else:
-            api_key = self.config["weather"]["api_key"]
-            lat = self.config["weather"]["lat"]
-            lon = self.config["weather"]["lon"]
+    def _weather_url(self) -> str | None:
+        """Resolve the configured NWS forecast URL (DB settings, then config.toml)."""
+        url = self._db_settings.get("weather_nws_url")
+        if not url:
+            url = self.config.get("weather", {}).get("nws_url")
+        return url or None
 
-        url = "https://api.openweathermap.org/data/3.0/onecall"
-        params = {
-            "lat": lat,
-            "lon": lon,
-            "appid": api_key,
-            "units": "imperial",
-            "exclude": "minutely,alerts",
-        }
+    def fetch_weather(self) -> str | None:
+        """Fetch the raw NWS forecast (DWML XML) from the configured URL."""
+        url = self._weather_url()
+        if not url:
+            print("No NWS forecast URL configured.")
+            return None
 
         try:
-            response = requests.get(url, params=params, timeout=10)
+            response = requests.get(
+                url,
+                timeout=10,
+                headers={"User-Agent": "Rally family dashboard (https://github.com/pid1/rally)"},
+            )
             response.raise_for_status()
-            return response.json()
+            return response.text
         except Exception as e:
             print(f"Error fetching weather: {e}")
             return None
 
-    def format_weather(self, weather: dict | None) -> str:
-        """Format raw OpenWeather API response into human-readable local-time text.
+    def format_weather(self, weather: str | None) -> str:
+        """Parse NWS DWML XML into clean, human-readable forecast text.
 
-        Converts UTC timestamps to local time and strips raw JSON so the LLM
-        sees only clean, unambiguous weather data.
+        The National Weather Service feed reports times already in the location's
+        local timezone and includes plain-English worded forecasts, so the LLM
+        sees unambiguous weather data without any unit or timezone conversion.
         """
         if not weather:
             return "No weather data available."
 
-        from datetime import datetime
+        import xml.etree.ElementTree as ET
 
-        def fmt_time(ts: int) -> str:
-            return datetime.fromtimestamp(ts, tz=self.local_tz).strftime("%I:%M %p").lstrip("0")
+        try:
+            root = ET.fromstring(weather)
+        except ET.ParseError as e:
+            print(f"Error parsing weather XML: {e}")
+            return "No weather data available."
 
-        def fmt_day(ts: int) -> str:
-            return datetime.fromtimestamp(ts, tz=self.local_tz).strftime("%A, %b %d")
+        def text_of(el) -> str | None:
+            return el.text.strip() if el is not None and el.text and el.text.strip() else None
 
-        lines = []
+        lines: list[str] = []
 
         # Current conditions
-        cur = weather.get("current", {})
-        if cur:
-            desc = cur["weather"][0]["description"] if cur.get("weather") else "unknown"
-            lines.append(
-                f"Current: {cur.get('temp', '?')}°F (feels like {cur.get('feels_like', '?')}°F), {desc}"
-            )
-            lines.append(
-                f"  Wind: {cur.get('wind_speed', '?')} mph, Humidity: {cur.get('humidity', '?')}%"
-            )
-            if "sunrise" in cur and "sunset" in cur:
-                lines.append(
-                    f"  Sunrise: {fmt_time(cur['sunrise'])}, Sunset: {fmt_time(cur['sunset'])}"
+        current = root.find(".//data[@type='current observations']")
+        if current is not None:
+            params = current.find("parameters")
+            if params is not None:
+                temp = text_of(params.find("temperature/value"))
+                conditions_el = params.find("weather/weather-conditions")
+                summary = (
+                    conditions_el.get("weather-summary") if conditions_el is not None else None
                 )
+                humidity = text_of(params.find("humidity/value"))
 
-        # Daily forecast
-        daily = weather.get("daily", [])
-        if daily:
-            lines.append("\nDaily forecast:")
-            for day in daily:
-                day_label = fmt_day(day["dt"])
-                temp = day.get("temp", {})
-                desc = day["weather"][0]["description"] if day.get("weather") else "unknown"
-                wind = f", wind {day.get('wind_speed', '?')} mph"
-                if day.get("wind_gust"):
-                    wind += f" (gusts {day['wind_gust']} mph)"
-                pop = day.get("pop", 0)
-                rain = f", {int(pop * 100)}% chance of rain" if pop > 0.1 else ""
-                lines.append(
-                    f"  {day_label}: High {temp.get('max', '?')}°F / Low {temp.get('min', '?')}°F, {desc}{wind}{rain}"
-                )
+                parts = []
+                if temp:
+                    parts.append(f"{temp}°F")
+                if summary:
+                    parts.append(summary)
+                if parts:
+                    line = "Current conditions: " + ", ".join(parts)
+                    if humidity:
+                        line += f". Humidity {humidity}%"
+                    lines.append(line)
+
+        # Worded forecast (Today / Tonight / weekday labels paired with text)
+        forecast = root.find(".//data[@type='forecast']")
+        if forecast is not None:
+            params = forecast.find("parameters")
+            worded = params.find("wordedForecast") if params is not None else None
+            if worded is not None:
+                layout_key = worded.get("time-layout")
+                period_names: list[str] = []
+                for time_layout in forecast.findall("time-layout"):
+                    key = time_layout.find("layout-key")
+                    if key is not None and key.text == layout_key:
+                        period_names = [
+                            svt.get("period-name", "")
+                            for svt in time_layout.findall("start-valid-time")
+                        ]
+                        break
+
+                texts = [text_of(t) for t in worded.findall("text")]
+                forecast_lines = []
+                for i, txt in enumerate(texts):
+                    if not txt:
+                        continue
+                    label = period_names[i] if i < len(period_names) and period_names[i] else None
+                    forecast_lines.append(f"  {label}: {txt}" if label else f"  {txt}")
+
+                if forecast_lines:
+                    if lines:
+                        lines.append("")
+                    lines.append("Forecast:")
+                    lines.extend(forecast_lines)
+
+        if not lines:
+            return "No weather data available."
 
         return "\n".join(lines)
 

--- a/src/rally/routers/settings.py
+++ b/src/rally/routers/settings.py
@@ -187,36 +187,54 @@ def test_llm_connection(db: Session = Depends(get_db)):
 
 @router.post("/api/settings/test-weather")
 def test_weather_connection(db: Session = Depends(get_db)):
-    """Test OpenWeather API connectivity using current DB settings."""
+    """Test NWS forecast URL connectivity using current DB settings."""
     settings = {r.key: r.value for r in db.query(Setting).all()}
 
-    api_key = settings.get("weather_api_key", "")
-    lat = settings.get("weather_lat", "")
-    lon = settings.get("weather_lon", "")
-
-    if not all([api_key, lat, lon]):
-        return {"success": False, "error": "Missing API key, latitude, or longitude"}
+    url = settings.get("weather_nws_url", "")
+    if not url:
+        return {"success": False, "error": "Missing NWS forecast URL"}
 
     try:
+        import xml.etree.ElementTree as ET
+
         import requests
 
         response = requests.get(
-            "https://api.openweathermap.org/data/3.0/onecall",
-            params={
-                "lat": lat,
-                "lon": lon,
-                "appid": api_key,
-                "units": "imperial",
-                "exclude": "minutely,hourly,daily,alerts",
-            },
+            url,
             timeout=10,
+            headers={"User-Agent": "Rally family dashboard (https://github.com/pid1/rally)"},
         )
         response.raise_for_status()
-        data = response.json()
-        temp = data.get("current", {}).get("temp", "?")
-        weather_list = data.get("current", {}).get("weather", [{}])
-        desc = weather_list[0].get("description", "") if weather_list else ""
-        return {"success": True, "message": f"Connected: {temp}\u00b0F, {desc}"}
+
+        try:
+            root = ET.fromstring(response.text)
+        except ET.ParseError:
+            return {
+                "success": False,
+                "error": "URL did not return NWS DWML weather data",
+            }
+
+        if root.tag != "dwml":
+            return {
+                "success": False,
+                "error": "URL did not return NWS DWML weather data",
+            }
+
+        # Surface the current temperature/conditions when available
+        current = root.find(".//data[@type='current observations']")
+        temp = current.find("parameters/temperature/value") if current is not None else None
+        conditions = (
+            current.find("parameters/weather/weather-conditions")
+            if current is not None
+            else None
+        )
+        detail = []
+        if temp is not None and temp.text:
+            detail.append(f"{temp.text.strip()}\u00b0F")
+        if conditions is not None and conditions.get("weather-summary"):
+            detail.append(conditions.get("weather-summary"))
+        message = "Connected: " + ", ".join(detail) if detail else "Connected to NWS forecast"
+        return {"success": True, "message": message}
     except Exception as e:
         return {"success": False, "error": str(e)}
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -59,16 +59,9 @@
         </div>
         <form id="weather-form">
             <div class="form-group">
-                <label>API Key</label>
-                <input type="password" id="weather-api-key" placeholder="OpenWeather API key" autocomplete="off">
-            </div>
-            <div class="form-group">
-                <label>Latitude</label>
-                <input type="text" id="weather-lat" placeholder="e.g. 30.2672">
-            </div>
-            <div class="form-group">
-                <label>Longitude</label>
-                <input type="text" id="weather-lon" placeholder="e.g. -97.7431">
+                <label>NWS Forecast URL</label>
+                <input type="text" id="weather-nws-url" placeholder="https://forecast.weather.gov/MapClick.php?lat=33.085&lon=-97.0542&FcstType=dwml">
+                <small>Search your location at <a href="https://forecast.weather.gov" target="_blank">forecast.weather.gov</a>, then copy the page URL and append <code>&FcstType=dwml</code>.</small>
             </div>
             <button type="submit" class="btn-save">Save</button>
         </form>
@@ -552,9 +545,7 @@
             const s = data.settings || {};
 
             // Weather
-            document.getElementById('weather-api-key').value = s.weather_api_key || '';
-            document.getElementById('weather-lat').value = s.weather_lat || '';
-            document.getElementById('weather-lon').value = s.weather_lon || '';
+            document.getElementById('weather-nws-url').value = s.weather_nws_url || '';
 
             // LLM
             const provider = s.llm_provider || 'local';
@@ -888,9 +879,7 @@
             e.preventDefault();
             try {
                 await saveSettings({
-                    weather_api_key: document.getElementById('weather-api-key').value,
-                    weather_lat: document.getElementById('weather-lat').value,
-                    weather_lon: document.getElementById('weather-lon').value
+                    weather_nws_url: document.getElementById('weather-nws-url').value
                 });
                 await verifyConnection('/api/settings/test-weather', 'weather');
             } catch (error) {


### PR DESCRIPTION
Remove all OpenWeather-specific handling (API key, lat/lon coordinates,
JSON one-call parsing) in favor of a single configurable National Weather
Service forecast URL stored in settings.

- generate.py: fetch the configured NWS DWML feed and parse it into clean,
  human-readable forecast text (current conditions + worded forecast with
  Today/Tonight/weekday period labels). NWS times are already local, so no
  timezone conversion is needed.
- settings router: test-weather now fetches the NWS URL and validates the
  DWML response instead of calling OpenWeather.
- settings.html: replace API key / latitude / longitude inputs with a single
  NWS Forecast URL field.
- cli.py: seed weather_nws_url instead of the OpenWeather settings.
- migration 014: remove legacy weather_api_key/lat/lon settings and seed a
  default weather_nws_url (idempotent).
- Update README and AGENTS docs to reflect the NWS integration.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Doowo9i7G1i8KUgGtUr84N