### PR TITLE
Fix migration 014 failing on databases with legacy weather settings

### DIFF
--- a/migrations/migrate_014_configurable_nws_weather.py
+++ b/migrations/migrate_014_configurable_nws_weather.py
@@ -10,6 +10,7 @@ Run this once to upgrade existing databases. Safe to run multiple times (idempot
 import os
 import sqlite3
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
 DEFAULT_NWS_URL = (
@@ -63,9 +64,11 @@ def migrate():
         if cursor.fetchone():
             print("✓ Migration: weather_nws_url already configured (idempotent check)")
         else:
+            # Match SQLAlchemy's SQLite datetime format (naive UTC)
+            now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")
             cursor.execute(
-                "INSERT INTO settings (key, value) VALUES ('weather_nws_url', ?)",
-                (DEFAULT_NWS_URL,),
+                "INSERT INTO settings (key, value, updated_at) VALUES ('weather_nws_url', ?, ?)",
+                (DEFAULT_NWS_URL, now),
             )
             print("✓ Migration: seeded default weather_nws_url")
 


### PR DESCRIPTION
## What changed

Migration 014's `INSERT` for the `weather_nws_url` setting omitted `updated_at`, but `settings.updated_at` is `NOT NULL` (see the `Setting` model in `src/rally/models.py`).

This commit supplies `updated_at` explicitly, using migration 012's format string (naive UTC, `%Y-%m-%d %H:%M:%S.%f`) so the value matches how SQLAlchemy writes datetimes to SQLite.

## Why

On any database that holds legacy OpenWeather keys and has no `weather_nws_url` row, the insert raised:

```
NOT NULL constraint failed: settings.updated_at
```

That aborted `run_migrations.py`, which blocked every subsequent migration — so the failure wasn't limited to weather config.

## Verification

Seeded a full-schema database (built from `Base.metadata`) with a legacy `weather_api_key` row, then ran `python3 migrations/run_migrations.py` twice:

- **Run 1** — removed 1 legacy setting, seeded `weather_nws_url`, all migrations passed.
- **Run 2** — both idempotent checks hit, all migrations passed.
- The resulting row has a populated `updated_at`.

## Notes for reviewers

Two caveats on how this was verified, both worth a look but out of scope here:

1. **`devenv shell` currently fails from a git worktree.** It won't build due to an `env.PYTHONPATH` conflict — `devenv.nix` sets it to the worktree `src` dir, while the Python language module sets its own `sitecustomize.py`. This is pre-existing and unrelated to this fix, but it meant verification ran with `PYTHONPATH=src` directly instead of inside the dev shell. Same code path, but flagging it since it affects anyone using worktrees.

2. **Verified against a seeded scratch database, not the dev `rally.db`.** Running the migration against the real dev DB would have mutated it by deleting the legacy weather rows, and a seeded copy reproduces the failing condition exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)