### PR TITLE
Add LLM config versioning with rollback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,6 +302,9 @@ Rally uses a simple, file-based migration system. All migrations live in the `mi
 - `010_add_meal_type` - Add `meal_type` to `dinner_plans`
 - `011_add_meal_reviews` - Add `rating` and `review` to `dinner_plans`
 - `012_add_ai_settings_history` - Add `ai_settings_history` table; seed it from existing `agent_voice` / `family_context` settings rows, point `current_agent_voice_history_id` / `current_family_context_history_id` settings keys at the seed rows, and remove the original settings rows
+- `013_add_completed_at` - Add `completed_at` to `todos`
+- `014_configurable_nws_weather` - Replace OpenWeather settings with configurable NWS forecast URL
+- `015_add_llm_settings_history` - Add `llm_settings_history` table; seed a coupled provider+model snapshot from the existing `llm_provider` / model settings rows and point the `current_llm_config_history_id` settings key at it (original settings rows are preserved — they remain the source of truth for the generator)
 
 ### Running Migrations
 
@@ -441,7 +444,7 @@ rally/
 │   ├── __init__.py
 │   ├── main.py           # FastAPI application
 │   ├── database.py       # SQLAlchemy database setup
-│   ├── models.py         # Database models (FamilyMember, Calendar, Setting, AISettingsHistory, DashboardSnapshot, Todo, RecurringTodo, DinnerPlan)
+│   ├── models.py         # Database models (FamilyMember, Calendar, Setting, AISettingsHistory, LLMSettingsHistory, DashboardSnapshot, Todo, RecurringTodo, DinnerPlan)
 │   ├── schemas.py        # Pydantic schemas
 │   ├── cli.py            # CLI commands (seed, etc.)
 │   ├── recurrence.py     # Recurring todo processing (template → instance generation, next-date calculation)
@@ -483,6 +486,7 @@ rally/
 │   ├── migrate_add_meal_type.py       # Migration 010: add meal_type to dinner_plans
 │   ├── migrate_011_add_meal_reviews.py # Migration 011: add rating and review to dinner_plans
 │   ├── migrate_012_add_ai_settings_history.py # Migration 012: add ai_settings_history table
+│   ├── migrate_015_add_llm_settings_history.py # Migration 015: add llm_settings_history table
 │   └── run_migrations.py              # Migration runner (executes all migrations in order)
 ├── data/                 # Mounted in container (not in git)
 │   ├── config.toml       # API keys, URLs, coordinates (optional if using Settings UI)
@@ -530,6 +534,10 @@ rally/
   - Every explicit save inserts a versioned snapshot into `ai_settings_history` (`field_name` discriminator); the active snapshot per field is referenced by the `current_agent_voice_history_id` / `current_family_context_history_id` settings keys
   - Version History modal lists snapshots newest first with a `Current` badge and in-place expandable value previews; **Change Version** rolls the field back (bumps `last_used_at`, repoints the setting, no new row) and updates the field without a page reload
   - Fields roll back independently; all snapshots are retained indefinitely
+- ✅ LLM settings snapshotting with version history and rollback
+  - The LLM section's `Provider` and `Model` are versioned as a **single coupled snapshot** (`llm_config`) — saving the LLM form records one `llm_settings_history` row whose JSON `value` captures the provider and its active model together; the active snapshot is referenced by the `current_llm_config_history_id` settings key
+  - The LLM section has one `Save` button and one `Version History` link; the shared Version History modal shows each snapshot's `Provider` / `Model` pair, and **Change Version** restores both together (select flips, provider fields toggle, model input updates — no page reload, no new row)
+  - The plain `llm_provider` / `llm_local_model` / `llm_anthropic_model` settings keys remain the source of truth read by the generator; save and rollback keep them in sync
 - ✅ Todo management - Full CRUD API and UI
   - Create, read, update, delete todos
   - Optional due dates with native HTML5 date picker
@@ -610,6 +618,11 @@ rally/
   - `PUT /api/settings/ai/{field_name}` - Explicit save: inserts a new `ai_settings_history` snapshot (`created_at` = `last_used_at` = now, UTC) and points the field's `current_<field>_history_id` setting at it
   - `GET /api/settings/ai/{field_name}/history` - List all snapshots for a field, newest first (by `created_at` descending), plus the current history ID
   - `POST /api/settings/ai/{field_name}/rollback` - Make an existing snapshot active: bumps its `last_used_at` and repoints the setting — no new row inserted. Body: `{history_id}`
+- `/api/settings/llm/config` - Versioned LLM configuration endpoints (coupled `provider` + `model` snapshot)
+  - `GET /api/settings/llm/config` - Get the currently active provider + model and history ID
+  - `PUT /api/settings/llm/config` - Explicit save: inserts a new `llm_settings_history` snapshot capturing the provider + model pair, points `current_llm_config_history_id` at it, and syncs the plain `llm_provider` / model settings keys. Body: `{provider, model}`
+  - `GET /api/settings/llm/config/history` - List all snapshots, newest first, plus the current history ID
+  - `POST /api/settings/llm/config/rollback` - Make an existing snapshot active: restores provider and model together, bumps `last_used_at`, repoints the setting, and syncs the plain settings keys — no new row inserted. Body: `{history_id}`
 - `/api/settings/test-llm` - LLM connectivity test
   - `POST /api/settings/test-llm` - Test LLM provider connection (sends minimal 1-token request). Returns `{success, message}` or `{success, error}`.
 - `/api/settings/test-weather` - Weather connectivity test
@@ -678,6 +691,7 @@ The database is automatically created when the app starts. Migrations run automa
 - `Calendar` - ICS calendar feeds linked to family members, with optional owner email
 - `Setting` - Key-value settings store (LLM provider, API keys, timezone, etc.)
 - `AISettingsHistory` - Versioned snapshots of `agent_voice` / `family_context` with field_name discriminator, value, created_at, and last_used_at; active snapshot per field referenced via `current_<field>_history_id` settings keys
+- `LLMSettingsHistory` - Versioned snapshots of the coupled LLM provider + model configuration (JSON value `{"provider": ..., "model": ...}`, field_name always `llm_config`); active snapshot referenced via the `current_llm_config_history_id` settings key
 - `DashboardSnapshot` - Stores generated dashboard data with date, timestamp, JSON data, and active flag
 - `Todo` - Task management with title, description, optional due_date (YYYY-MM-DD), assigned_to (family member), optional recurring_todo_id (link to recurring template), optional remind_days_before (reminder window), completion status, and timestamps
 - `RecurringTodo` - Recurring todo templates with title, description, recurrence_type (daily/weekly/monthly), recurrence_day, assigned_to, has_due_date, remind_days_before, last_generated_date (tracks most recently generated instance's recurrence date), active flag, and timestamps

--- a/migrations/migrate_015_add_llm_settings_history.py
+++ b/migrations/migrate_015_add_llm_settings_history.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Migration 015: Add llm_settings_history table for LLM config snapshotting.
+
+Creates the llm_settings_history table (versioned snapshots of the coupled
+LLM provider + model configuration, stored as a JSON value), seeds it from
+the existing llm_provider / provider-specific model rows in the key-value
+settings table, and points the new current_llm_config_history_id settings
+key at the seed row. Unlike migration 012, the original settings rows are
+preserved — they remain the source of truth read by the generator and the
+LLM connectivity test.
+
+Safe to run multiple times (idempotent).
+"""
+
+import json
+import os
+import sqlite3
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+POINTER_KEY = "current_llm_config_history_id"
+
+
+def migrate():
+    """Run the migration. Return True on success, False on failure."""
+    db_path = os.environ.get("RALLY_DB_PATH")
+
+    if not db_path:
+        prod_path = Path("/data/rally.db")
+        dev_path = Path(__file__).parent.parent / "rally.db"
+        db_path = str(prod_path) if prod_path.exists() else str(dev_path)
+
+    db_path = Path(db_path)
+
+    if not db_path.exists():
+        print(f"  Database not found at {db_path}")
+        print("  No migration needed - database will be created with correct schema.")
+        return True
+
+    print(f"Checking database at {db_path}...")
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    try:
+        # CREATE: history table and field_name index (idempotent)
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS llm_settings_history (
+                id INTEGER NOT NULL PRIMARY KEY,
+                field_name VARCHAR(50) NOT NULL,
+                value TEXT NOT NULL,
+                created_at DATETIME NOT NULL,
+                last_used_at DATETIME NOT NULL
+            )
+        """)
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS ix_llm_settings_history_field_name
+            ON llm_settings_history(field_name)
+        """)
+
+        # Settings table may not exist yet on a fresh database
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='settings'")
+        if not cursor.fetchone():
+            conn.commit()
+            print("  Migration 015: llm_settings_history created; no settings table to seed from")
+            return True
+
+        # CHECK: Is the config already seeded?
+        cursor.execute("SELECT value FROM settings WHERE key = ?", (POINTER_KEY,))
+        if cursor.fetchone():
+            conn.commit()
+            print(f"  Migration 015: {POINTER_KEY} already set (idempotent)")
+            return True
+
+        cursor.execute("SELECT value FROM settings WHERE key = 'llm_provider'")
+        row = cursor.fetchone()
+        if row is None:
+            conn.commit()
+            print("  Migration 015: no existing llm_provider setting to migrate")
+            return True
+
+        provider = row[0]
+        model_key = "llm_anthropic_model" if provider == "anthropic" else "llm_local_model"
+        cursor.execute("SELECT value FROM settings WHERE key = ?", (model_key,))
+        model_row = cursor.fetchone()
+        model = model_row[0] if model_row else ""
+
+        # EXECUTE: Seed a coupled snapshot and point the setting at it.
+        # The original llm_provider / model settings rows are kept as-is.
+        now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")  # SQLAlchemy naive-UTC format
+        cursor.execute(
+            """
+            INSERT INTO llm_settings_history (field_name, value, created_at, last_used_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            ("llm_config", json.dumps({"provider": provider, "model": model}), now, now),
+        )
+        history_id = cursor.lastrowid
+        cursor.execute(
+            "INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)",
+            (POINTER_KEY, str(history_id), now),
+        )
+        print(
+            f"  Migration 015: seeded llm_config ({provider} / {model or 'no model'}) "
+            f"into llm_settings_history row {history_id}"
+        )
+
+        conn.commit()
+        print("  Migration 015 complete: llm_settings_history ready")
+        return True
+
+    except sqlite3.Error as e:
+        print(f"  Migration 015 failed: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    success = migrate()
+    sys.exit(0 if success else 1)

--- a/migrations/run_migrations.py
+++ b/migrations/run_migrations.py
@@ -19,8 +19,11 @@ def run_migrations():
         from migrate_014_configurable_nws_weather import (
             migrate as migrate_014_configurable_nws_weather,
         )
-        from migrate_add_completed_at import migrate as migrate_013_add_completed_at
+        from migrate_015_add_llm_settings_history import (
+            migrate as migrate_015_add_llm_settings_history,
+        )
         from migrate_add_caldav_support import migrate as migrate_008_add_caldav_support
+        from migrate_add_completed_at import migrate as migrate_013_add_completed_at
         from migrate_add_custom_recurrence import migrate as migrate_009_add_custom_recurrence
         from migrate_add_dinner_plan_assignees import (
             migrate as migrate_005_add_dinner_plan_assignees,
@@ -54,6 +57,7 @@ def run_migrations():
         ("012_add_ai_settings_history", migrate_012_add_ai_settings_history),
         ("013_add_completed_at", migrate_013_add_completed_at),
         ("014_configurable_nws_weather", migrate_014_configurable_nws_weather),
+        ("015_add_llm_settings_history", migrate_015_add_llm_settings_history),
     ]
 
     print("=" * 60)

--- a/src/rally/models.py
+++ b/src/rally/models.py
@@ -88,6 +88,29 @@ class AISettingsHistory(Base):
     )  # Bumped whenever this row becomes the active version (save or rollback)
 
 
+class LLMSettingsHistory(Base):
+    """Versioned snapshots of the coupled LLM provider + model configuration.
+
+    A new row is inserted on every explicit save of the LLM settings, capturing
+    the provider and its model together as one unit (value is a JSON object
+    {"provider": ..., "model": ...}). The active snapshot is referenced from
+    the settings table via the 'current_llm_config_history_id' key. Rollback
+    re-points the reference and bumps last_used_at — no new row is inserted.
+    """
+
+    __tablename__ = "llm_settings_history"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    field_name: Mapped[str] = mapped_column(
+        String(50), index=True
+    )  # Always 'llm_config' (kept for parity with ai_settings_history / future fields)
+    value: Mapped[str] = mapped_column(Text)  # JSON: {"provider": ..., "model": ...}
+    created_at: Mapped[datetime] = mapped_column(default=now_utc)
+    last_used_at: Mapped[datetime] = mapped_column(
+        default=now_utc
+    )  # Bumped whenever this row becomes the active version (save or rollback)
+
+
 class DashboardSnapshot(Base):
     """Dashboard snapshot model - stores generated daily summary data."""
 

--- a/src/rally/routers/settings.py
+++ b/src/rally/routers/settings.py
@@ -1,12 +1,15 @@
 """Settings and calendars router for Rally."""
 
+import json
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from rally.database import get_db
-from rally.models import AISettingsHistory, Calendar, Setting
+from rally.models import AISettingsHistory, Calendar, LLMSettingsHistory, Setting
 from rally.schemas import (
     AI_SETTINGS_FIELDS,
+    LLM_CONFIG_FIELD,
     AISettingHistoryEntry,
     AISettingHistoryResponse,
     AISettingRollback,
@@ -15,6 +18,10 @@ from rally.schemas import (
     CalendarCreate,
     CalendarResponse,
     CalendarUpdate,
+    LLMConfigHistoryEntry,
+    LLMConfigHistoryResponse,
+    LLMConfigState,
+    LLMConfigUpdate,
     SettingsResponse,
     SettingsUpdate,
 )
@@ -37,11 +44,7 @@ def get_settings(db: Session = Depends(get_db)):
 def update_settings(payload: SettingsUpdate, db: Session = Depends(get_db)):
     """Bulk upsert settings."""
     for key, value in payload.settings.items():
-        existing = db.query(Setting).filter(Setting.key == key).first()
-        if existing:
-            existing.value = value
-        else:
-            db.add(Setting(key=key, value=value))
+        _upsert_setting(db, key, value)
     db.commit()
 
     rows = db.query(Setting).all()
@@ -69,14 +72,18 @@ def _get_current_ai_snapshot(db: Session, field_name: str) -> AISettingsHistory 
     return db.get(AISettingsHistory, int(pointer.value))
 
 
+def _upsert_setting(db: Session, key: str, value: str) -> None:
+    """Insert or update a key-value settings row."""
+    row = db.query(Setting).filter(Setting.key == key).first()
+    if row:
+        row.value = value
+    else:
+        db.add(Setting(key=key, value=value))
+
+
 def _set_ai_pointer(db: Session, field_name: str, history_id: int) -> None:
     """Upsert the settings pointer for a field to reference a history row."""
-    key = _ai_pointer_key(field_name)
-    pointer = db.query(Setting).filter(Setting.key == key).first()
-    if pointer:
-        pointer.value = str(history_id)
-    else:
-        db.add(Setting(key=key, value=str(history_id)))
+    _upsert_setting(db, _ai_pointer_key(field_name), str(history_id))
 
 
 @router.get("/api/settings/ai", response_model=dict[str, AISettingState])
@@ -140,6 +147,99 @@ def rollback_ai_setting(field_name: str, payload: AISettingRollback, db: Session
     db.commit()
     db.refresh(row)
     return AISettingState(field_name=field_name, value=row.value, history_id=row.id)
+
+
+# --- LLM Config (versioned provider + model, coupled as a single snapshot) ---
+
+LLM_CONFIG_POINTER_KEY = f"current_{LLM_CONFIG_FIELD}_history_id"
+
+
+def _get_current_llm_snapshot(db: Session) -> LLMSettingsHistory | None:
+    """Resolve the active llm_settings_history row via its settings pointer."""
+    pointer = db.query(Setting).filter(Setting.key == LLM_CONFIG_POINTER_KEY).first()
+    if not pointer:
+        return None
+    return db.get(LLMSettingsHistory, int(pointer.value))
+
+
+def _llm_config_from_row(row: LLMSettingsHistory) -> dict:
+    """Unpack a snapshot row's coupled JSON value into provider/model."""
+    config = json.loads(row.value)
+    return {"provider": config.get("provider", ""), "model": config.get("model", "")}
+
+
+def _apply_llm_config(db: Session, provider: str, model: str) -> None:
+    """Write the provider + model into the plain settings keys read by the generator."""
+    _upsert_setting(db, "llm_provider", provider)
+    model_key = "llm_anthropic_model" if provider == "anthropic" else "llm_local_model"
+    _upsert_setting(db, model_key, model)
+
+
+@router.get("/api/settings/llm/config", response_model=LLMConfigState)
+def get_llm_config(db: Session = Depends(get_db)):
+    """Get the currently active LLM provider + model configuration."""
+    row = _get_current_llm_snapshot(db)
+    if not row:
+        return LLMConfigState(provider="", model="", history_id=None)
+    return LLMConfigState(**_llm_config_from_row(row), history_id=row.id)
+
+
+@router.put("/api/settings/llm/config", response_model=LLMConfigState)
+def save_llm_config(payload: LLMConfigUpdate, db: Session = Depends(get_db)):
+    """Explicitly save the LLM provider + model pair — inserts a new history snapshot."""
+    now = now_utc()  # Single timestamp so created_at == last_used_at on insert
+    row = LLMSettingsHistory(
+        field_name=LLM_CONFIG_FIELD,
+        value=json.dumps({"provider": payload.provider, "model": payload.model}),
+        created_at=now,
+        last_used_at=now,
+    )
+    db.add(row)
+    db.flush()  # Assign row.id before pointing the setting at it
+    _upsert_setting(db, LLM_CONFIG_POINTER_KEY, str(row.id))
+    _apply_llm_config(db, payload.provider, payload.model)
+    db.commit()
+    return LLMConfigState(provider=payload.provider, model=payload.model, history_id=row.id)
+
+
+@router.get("/api/settings/llm/config/history", response_model=LLMConfigHistoryResponse)
+def get_llm_config_history(db: Session = Depends(get_db)):
+    """List all LLM configuration snapshots, newest first."""
+    rows = (
+        db.query(LLMSettingsHistory)
+        .filter(LLMSettingsHistory.field_name == LLM_CONFIG_FIELD)
+        .order_by(LLMSettingsHistory.created_at.desc(), LLMSettingsHistory.id.desc())
+        .all()
+    )
+    current = _get_current_llm_snapshot(db)
+    return LLMConfigHistoryResponse(
+        current_history_id=current.id if current else None,
+        history=[
+            LLMConfigHistoryEntry(
+                id=r.id,
+                **_llm_config_from_row(r),
+                created_at=r.created_at,
+                last_used_at=r.last_used_at,
+            )
+            for r in rows
+        ],
+    )
+
+
+@router.post("/api/settings/llm/config/rollback", response_model=LLMConfigState)
+def rollback_llm_config(payload: AISettingRollback, db: Session = Depends(get_db)):
+    """Make an existing snapshot the active version — restores provider and model together."""
+    row = db.get(LLMSettingsHistory, payload.history_id)
+    if not row or row.field_name != LLM_CONFIG_FIELD:
+        raise HTTPException(status_code=404, detail="History entry not found")
+
+    row.last_used_at = now_utc()
+    _upsert_setting(db, LLM_CONFIG_POINTER_KEY, str(row.id))
+    config = _llm_config_from_row(row)
+    _apply_llm_config(db, config["provider"], config["model"])
+    db.commit()
+    db.refresh(row)
+    return LLMConfigState(**config, history_id=row.id)
 
 
 # --- Connectivity Tests ---

--- a/src/rally/schemas.py
+++ b/src/rally/schemas.py
@@ -143,6 +143,43 @@ class AISettingHistoryResponse(BaseModel):
     history: list[AISettingHistoryEntry]
 
 
+# LLM Config (versioned provider + model, coupled as a single snapshot)
+
+LLM_CONFIG_FIELD = "llm_config"
+
+
+class LLMConfigUpdate(BaseModel):
+    """Explicit save of the LLM provider + model pair — creates a new history snapshot."""
+
+    provider: str
+    model: str
+
+
+class LLMConfigState(BaseModel):
+    """Currently active LLM provider + model configuration."""
+
+    provider: str
+    model: str
+    history_id: int | None = None  # None when no snapshot exists yet
+
+
+class LLMConfigHistoryEntry(BaseModel):
+    """One snapshot row from llm_settings_history, with the coupled value unpacked."""
+
+    id: int
+    provider: str
+    model: str
+    created_at: datetime
+    last_used_at: datetime
+
+
+class LLMConfigHistoryResponse(BaseModel):
+    """Version history for the LLM configuration, newest first."""
+
+    current_history_id: int | None = None
+    history: list[LLMConfigHistoryEntry]
+
+
 # Todos
 
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -104,7 +104,10 @@
                     <input type="text" id="llm-anthropic-model" placeholder="e.g. claude-sonnet-4-20250514">
                 </div>
             </div>
-            <button type="submit" class="btn-save">Save</button>
+            <div class="ai-field-actions">
+                <button type="submit" class="btn-save">Save</button>
+                <button type="button" class="btn-ghost" onclick="openHistoryModal('llm_config')">Version History</button>
+            </div>
         </form>
     </div>
 
@@ -586,6 +589,38 @@
             agent_voice: { label: 'Agent Voice', inputId: 'ai-agent-voice' }
         };
 
+        // Version-history metadata: AI fields plus the coupled LLM provider+model config.
+        // Each entry knows its API base URL, how to render a snapshot's value in the
+        // history modal, and how to apply a rollback response back into the form.
+        function aiHistoryMeta(field) {
+            const meta = AI_FIELD_META[field];
+            return {
+                label: meta.label,
+                baseUrl: '/api/settings/ai/' + field,
+                formatValue: entry => escapeHtml(entry.value),
+                applyRollback: data => { document.getElementById(meta.inputId).value = data.value; }
+            };
+        }
+
+        function llmModelInputId(provider) {
+            return provider === 'anthropic' ? 'llm-anthropic-model' : 'llm-local-model';
+        }
+
+        const HISTORY_FIELD_META = {
+            family_context: aiHistoryMeta('family_context'),
+            agent_voice: aiHistoryMeta('agent_voice'),
+            llm_config: {
+                label: 'LLM',
+                baseUrl: '/api/settings/llm/config',
+                formatValue: entry => escapeHtml('Provider: ' + entry.provider + '\nModel: ' + entry.model),
+                applyRollback: data => {
+                    document.getElementById('llm-provider').value = data.provider;
+                    document.getElementById(llmModelInputId(data.provider)).value = data.model;
+                    toggleLlmFields(data.provider);
+                }
+            }
+        };
+
         let historyField = null;
         let historyEntries = [];
         let currentHistoryId = null;
@@ -623,12 +658,12 @@
             selectedHistoryId = null;
             expandedHistoryIds = new Set();
 
-            document.getElementById('history-modal-title').textContent = AI_FIELD_META[field].label + ' Version History';
+            document.getElementById('history-modal-title').textContent = HISTORY_FIELD_META[field].label + ' Version History';
             document.getElementById('history-list').innerHTML = '<div class="container-loading-state">Loading version history...</div>';
             document.getElementById('history-modal-overlay').style.display = 'flex';
 
             try {
-                const response = await fetch('/api/settings/ai/' + field + '/history');
+                const response = await fetch(HISTORY_FIELD_META[field].baseUrl + '/history');
                 if (!response.ok) throw new Error('Failed to load history');
                 const data = await response.json();
                 historyEntries = data.history;
@@ -663,6 +698,7 @@
                 return;
             }
 
+            const formatValue = HISTORY_FIELD_META[historyField].formatValue;
             container.innerHTML = historyEntries.map(entry => {
                 const selected = entry.id === selectedHistoryId;
                 const expanded = expandedHistoryIds.has(entry.id);
@@ -677,7 +713,7 @@
                             ${currentBadge}
                         </div>
                         <button type="button" class="history-value-toggle" onclick="toggleHistoryValue(event, ${entry.id})">${expanded ? '▼' : '►'} Value</button>
-                        <div class="history-value" style="display: ${expanded ? 'block' : 'none'}">${escapeHtml(entry.value)}</div>
+                        <div class="history-value" style="display: ${expanded ? 'block' : 'none'}">${formatValue(entry)}</div>
                     </div>
                 `;
             }).join('');
@@ -703,16 +739,16 @@
                 closeHistoryModal();
                 return;
             }
-            const field = historyField;
+            const meta = HISTORY_FIELD_META[historyField];
             try {
-                const response = await fetch('/api/settings/ai/' + field + '/rollback', {
+                const response = await fetch(meta.baseUrl + '/rollback', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ history_id: selectedHistoryId })
                 });
                 if (!response.ok) throw new Error('Failed to change version');
                 const data = await response.json();
-                document.getElementById(AI_FIELD_META[field].inputId).value = data.value;
+                meta.applyRollback(data);
                 closeHistoryModal();
             } catch (error) {
                 console.error('Error changing version:', error);
@@ -891,15 +927,26 @@
         // LLM form
         document.getElementById('llm-form').addEventListener('submit', async (e) => {
             e.preventDefault();
+            const provider = document.getElementById('llm-provider').value;
             try {
                 await saveSettings({
-                    llm_provider: document.getElementById('llm-provider').value,
+                    llm_provider: provider,
                     llm_local_base_url: document.getElementById('llm-local-base-url').value,
                     llm_local_api_key: document.getElementById('llm-local-api-key').value,
                     llm_local_model: document.getElementById('llm-local-model').value,
                     llm_anthropic_api_key: document.getElementById('llm-anthropic-api-key').value,
                     llm_anthropic_model: document.getElementById('llm-anthropic-model').value
                 });
+                // Snapshot the coupled provider + model pair for version history
+                const response = await fetch('/api/settings/llm/config', {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        provider: provider,
+                        model: document.getElementById(llmModelInputId(provider)).value
+                    })
+                });
+                if (!response.ok) throw new Error('Failed to save LLM config snapshot');
                 await verifyConnection('/api/settings/test-llm', 'LLM');
             } catch (error) {
                 console.error('Error saving LLM settings:', error);


### PR DESCRIPTION
Implement version history for LLM provider+model configuration, parallel to AI settings snapshotting (Issue #82).

- Add `llm_settings_history` table to store coupled provider+model snapshots
- Create migration 015 to initialize table and seed from existing settings
- Add versioned endpoints: GET/PUT/rollback for LLM configuration
- Extend Settings UI with Version History modal for LLM config
- Maintain source-of-truth settings keys (llm_provider, model) in sync with snapshots