### PR TITLE
Add read-only page for previously completed tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -454,7 +454,7 @@ rally/
 │   │   └── __main__.py   # CLI entry point
 │   ├── utils/
 │   │   ├── __init__.py
-│   │   └── timezone.py   # Timezone helpers (now_utc, today_utc, ensure_utc)
+│   │   └── timezone.py   # Timezone helpers (now_utc, today_utc, today_local, ensure_utc)
 │   └── routers/
 │       ├── __init__.py
 │       ├── dashboard.py     # Dashboard routes
@@ -468,6 +468,7 @@ rally/
 ├── templates/
 │   ├── dashboard.html       # Generated dashboard template
 │   ├── todo.html            # Todo management page
+│   ├── todo_completed.html  # Read-only previously-completed tasks page
 │   ├── dinner_planner.html  # Dinner planner page
 │   └── settings.html        # Settings, family member, and calendar management page
 ├── config.toml.example   # Example configuration file
@@ -545,9 +546,16 @@ rally/
   - Configurable reminder window (`remind_days_before`) — controls when a todo appears in LLM briefings relative to its due date. Uses local timezone (not UTC) for date comparisons.
   - AI formats due dates with day-of-week (e.g., "[Due Friday, Feb 20]")
   - Overdue styling for past-due items
-  - Completion tracking with 24-hour visibility window
+  - Completion tracking — a completed todo stays on `/todo` until the end of the local day it was completed
   - Integrated into LLM generator for schedule optimization
   - Luxury UI with inline editing
+- ✅ Completed tasks history (`/todo/completed`)
+  - Read-only archive of todos completed before today: no add, edit, delete, or completion checkbox
+  - Mirrors the `/todo` layout (same heading, toolbar, and list styles) minus the Recurring Tasks section
+  - Two extra sort options — `Completion Date (Most Recent)` (default) and `Completion Date (Oldest)` — alongside the `/todo` sorts
+  - Assignee filter chips behave as on `/todo`; each row shows its completion date beneath the due date
+  - Paginated 50 at a time via a `Load more` button; changing sort or filter resets to the first page
+  - The two pages **partition** all todos — the local-midnight boundary comes from the shared `today_start_utc()` helper in `routers/todos.py`, so every todo appears on exactly one of them
 - ✅ Recurring todos - Full CRUD API and UI
   - Define recurring templates (daily, weekly, monthly)
   - Configurable recurrence day (day-of-week for weekly, day-of-month for monthly)
@@ -580,13 +588,15 @@ rally/
 - `/` - Redirects to `/dashboard`
 - `/dashboard` - Serves the generated daily summary from cached snapshot (shows error if missing)
 - `/todo` - Todo management page with full CRUD interface
+- `/todo/completed` - Read-only page of todos completed before today (local time); reachable only via the `View completed tasks` link on `/todo`, not from the nav bar
 - `/dinner-planner` - Dinner planning page with date picker and plan management
 - `/settings` - Settings, family member, and calendar management page
 
 ### API Routes
 - `/api/dashboard/regenerate` - Force dashboard regeneration and save new snapshot
 - `/api/todos` - Todo CRUD endpoints
-  - `GET /api/todos` - List todos (24-hour visibility filter for completed)
+  - `GET /api/todos` - List todos (incomplete, plus those completed since local midnight today)
+  - `GET /api/todos/completed` - List todos completed **before** local midnight today — the exact complement of the above. Query params: `sort` (one of `completed-newest` (default), `completed-oldest`, `due-soonest`, `due-furthest`, `assignee`, `newest`, `oldest`), repeatable `assignee` (family member ID and/or `unassigned`; OR semantics, empty means all), `limit` (default 50, max 200), `offset`. Returns `{items, has_more}`. Sorting, filtering and paging are server-side; recurring processing is deliberately **not** run here.
   - `POST /api/todos` - Create new todo
   - `GET /api/todos/{id}` - Get specific todo
   - `PUT /api/todos/{id}` - Update todo

--- a/src/rally/main.py
+++ b/src/rally/main.py
@@ -70,6 +70,12 @@ def todo_page(request: Request):
     return templates.TemplateResponse("todo.html", {"request": request})
 
 
+@app.get("/todo/completed", response_class=HTMLResponse)
+def todo_completed_page(request: Request):
+    """Serve the read-only page of previously completed tasks."""
+    return templates.TemplateResponse("todo_completed.html", {"request": request})
+
+
 @app.get("/dinner-planner", response_class=HTMLResponse)
 def dinner_planner_page(request: Request):
     """Serve the meal planner page."""

--- a/src/rally/recurrence.py
+++ b/src/rally/recurrence.py
@@ -12,7 +12,6 @@ from sqlalchemy.orm import Session
 from rally.models import RecurringTodo, Todo
 from rally.utils.timezone import today_utc
 
-
 # ── Custom rule helpers ──────────────────────────────────────────────────────
 
 

--- a/src/rally/routers/todos.py
+++ b/src/rally/routers/todos.py
@@ -1,22 +1,49 @@
 """Todos router for Rally."""
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, time
+from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import false, nullslast, or_
 from sqlalchemy.orm import Session
 
 from rally.database import get_db
-from rally.models import Todo
+from rally.models import FamilyMember, Setting, Todo
 from rally.recurrence import process_recurring_todos
-from rally.schemas import UNSET, TodoCreate, TodoResponse, TodoUpdate
-from rally.utils.timezone import now_utc
+from rally.schemas import UNSET, CompletedTodoPage, TodoCreate, TodoResponse, TodoUpdate
+from rally.utils.timezone import now_utc, today_local
 
 router = APIRouter(prefix="/api/todos", tags=["todos"])
+
+COMPLETED_SORTS = (
+    "completed-newest",
+    "completed-oldest",
+    "due-soonest",
+    "due-furthest",
+    "assignee",
+    "newest",
+    "oldest",
+)
+
+
+def today_start_utc(db: Session) -> datetime:
+    """UTC instant of local midnight today, in the user's configured timezone.
+
+    This is the boundary between "current" todos (shown on /todo) and
+    "previously completed" todos (shown on /todo/completed). Both views must
+    use this same helper or todos would appear on both pages or neither.
+    """
+    setting = db.query(Setting).filter(Setting.key == "local_timezone").first()
+    tz_name = setting.value if setting and setting.value else "UTC"
+    local_midnight = datetime.combine(today_local(tz_name), time.min, tzinfo=ZoneInfo(tz_name))
+    return local_midnight.astimezone(UTC)
 
 
 @router.get("", response_model=list[TodoResponse])
 def list_todos(
-    include_hidden: bool = Query(False, description="Include completed todos older than today (local time)"),
+    include_hidden: bool = Query(
+        False, description="Include completed todos older than today (local time)"
+    ),
     db: Session = Depends(get_db),
 ):
     """List all todos with local time visibility for completed items.
@@ -31,14 +58,80 @@ def list_todos(
 
     if not include_hidden:
         # Show incomplete todos OR completed today (local time)
-        cutoff = now_utc() - timedelta(hours=datetime.now().time().hour, minutes=datetime.now().time().minute, seconds=datetime.now().time().second, microseconds=datetime.now().time().microsecond)
+        cutoff = today_start_utc(db)
         query = query.filter(
-            (Todo.completed == False) | (Todo.completed_at > cutoff)  # noqa: E712
+            (Todo.completed == False) | (Todo.completed_at >= cutoff)  # noqa: E712
         )
 
     # Sort by created_at DESC (newest first)
     todos = query.order_by(Todo.created_at.desc()).all()
     return todos
+
+
+@router.get("/completed", response_model=CompletedTodoPage)
+def list_completed_todos(
+    sort: str = Query("completed-newest", pattern=f"^({'|'.join(COMPLETED_SORTS)})$"),
+    assignee: list[str] = Query(
+        default=[],
+        description='Family member IDs to filter to, and/or "unassigned". Empty means all.',
+    ),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db),
+):
+    """List todos completed before today (local time), newest completion first.
+
+    This is the exact complement of the default `GET /api/todos` listing: a todo
+    completed today stays on the current tasks page and appears here only once
+    the local date rolls over. Read-only — recurring processing is deliberately
+    not run here.
+
+    Sorting and pagination are server-side because the client only ever holds
+    one page of results.
+    """
+    cutoff = today_start_utc(db)
+
+    query = db.query(Todo).filter(
+        Todo.completed == True,  # noqa: E712
+        # A completed todo with no completed_at (pre-migration-013 data that the
+        # backfill missed) is already hidden from the current tasks page, so it
+        # belongs here rather than falling through the gap between the two views.
+        (Todo.completed_at < cutoff) | (Todo.completed_at.is_(None)),
+    )
+
+    # Assignee filter: multi-select OR, matching the current tasks page. Filtering
+    # is server-side because the client only holds the pages it has loaded.
+    if assignee:
+        member_ids = [int(a) for a in assignee if a.isdigit()]
+        clauses = []
+        if "unassigned" in assignee:
+            clauses.append(Todo.assigned_to.is_(None))
+        if member_ids:
+            clauses.append(Todo.assigned_to.in_(member_ids))
+        query = query.filter(or_(*clauses)) if clauses else query.filter(false())
+
+    newest_completed_first = (nullslast(Todo.completed_at.desc()), Todo.id.desc())
+
+    if sort == "completed-oldest":
+        query = query.order_by(nullslast(Todo.completed_at.asc()), Todo.id.asc())
+    elif sort == "due-soonest":
+        query = query.order_by(nullslast(Todo.due_date.asc()), *newest_completed_first)
+    elif sort == "due-furthest":
+        query = query.order_by(nullslast(Todo.due_date.desc()), *newest_completed_first)
+    elif sort == "assignee":
+        query = query.outerjoin(FamilyMember, Todo.assigned_to == FamilyMember.id).order_by(
+            nullslast(FamilyMember.name.asc()), *newest_completed_first
+        )
+    elif sort == "newest":
+        query = query.order_by(Todo.created_at.desc(), Todo.id.desc())
+    elif sort == "oldest":
+        query = query.order_by(Todo.created_at.asc(), Todo.id.asc())
+    else:  # completed-newest (default)
+        query = query.order_by(*newest_completed_first)
+
+    # Fetch one extra row to determine whether another page exists.
+    rows = query.offset(offset).limit(limit + 1).all()
+    return CompletedTodoPage(items=rows[:limit], has_more=len(rows) > limit)
 
 
 @router.post("", response_model=TodoResponse, status_code=201)

--- a/src/rally/schemas.py
+++ b/src/rally/schemas.py
@@ -218,6 +218,13 @@ class TodoResponse(TodoBase):
     model_config = ConfigDict(from_attributes=True)
 
 
+class CompletedTodoPage(BaseModel):
+    """One page of previously completed todos."""
+
+    items: list[TodoResponse]
+    has_more: bool  # True when another page exists beyond this one
+
+
 # Recurring Todos
 
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -585,6 +585,59 @@ footer a:hover {
     font-weight: 600;
 }
 
+.todo-completed-date {
+    font-size: 0.85rem;
+    color: var(--light-gray);
+    letter-spacing: 0.02em;
+    font-style: italic;
+    margin-top: 4px;
+}
+
+/* Toggle between the current tasks page and the completed tasks page.
+   Sits directly above the toolbar, in the same spot on both pages. */
+.todo-view-switch {
+    display: inline-block;
+    font-family: var(--body-font);
+    font-size: 0.9rem;
+    color: var(--medium-gray);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    margin-top: 4px;
+}
+
+.todo-view-switch:hover {
+    color: var(--charcoal);
+}
+
+.load-more-container {
+    display: flex;
+    justify-content: center;
+    margin-top: 24px;
+}
+
+.btn-load-more {
+    font-family: var(--body-font);
+    font-size: 0.9rem;
+    padding: 8px 24px;
+    border: 1px solid var(--pale-gray);
+    background: var(--white);
+    color: var(--charcoal);
+    cursor: pointer;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    transition: border-color 0.15s, background 0.15s;
+}
+
+.btn-load-more:hover:not(:disabled) {
+    border-color: var(--medium-gray);
+    background: var(--off-white);
+}
+
+.btn-load-more:disabled {
+    color: var(--light-gray);
+    cursor: default;
+}
+
 
 .todo-toolbar {
     display: flex;

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -35,7 +35,9 @@
                 <button class="btn-add" id="btn-add-task">Add Task</button>
             </div>
         </div>
-        
+
+        <a class="todo-view-switch" href="/todo/completed">View completed tasks</a>
+
         <div class="todo-toolbar">
             <div class="toolbar-group">
                 <label>Assignee</label>

--- a/templates/todo_completed.html
+++ b/templates/todo_completed.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Rally - Todos</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📰</text></svg>">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="/static/styles.css?v={{ css_version }}" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <h1>Rally</h1>
+        <div class="subtitle">Todo Management</div>
+    </header>
+
+    <nav>
+        <a href="/dashboard">Dashboard</a>
+        <a href="/todo" class="active">Tasks</a>
+        <div class="nav-dropdown" id="meal-dropdown">
+            <button class="nav-dropdown-btn" onclick="toggleMealDropdown(event)">Meal Planner</button>
+            <div class="nav-dropdown-content">
+                <a href="/dinner-planner">Current &amp; Upcoming</a>
+                <a href="/meal-history">Previous Meals</a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="section-container">
+        <div class="header-container">
+            <h2>Tasks</h2>
+        </div>
+
+        <a class="todo-view-switch" href="/todo">Back to current tasks</a>
+
+        <div class="todo-toolbar">
+            <div class="toolbar-group">
+                <label>Assignee</label>
+                <div class="filter-chips" id="filter-assignee-chips">
+                    <button type="button" class="filter-chip" data-value="unassigned">Unassigned</button>
+                </div>
+                <button type="button" class="filter-clear" id="filter-clear">Clear Filters</button>
+            </div>
+            <div class="toolbar-group">
+                <label for="sort-by">Sort</label>
+                <select id="sort-by">
+                    <option value="completed-newest">Completion Date (Most Recent)</option>
+                    <option value="completed-oldest">Completion Date (Oldest)</option>
+                    <option value="due-soonest">Due Date (Soonest)</option>
+                    <option value="due-furthest">Due Date (Furthest Out)</option>
+                    <option value="assignee">Assignee</option>
+                    <option value="newest">Newest First</option>
+                    <option value="oldest">Oldest First</option>
+                </select>
+            </div>
+        </div>
+
+        <div class="list-container" id="list-container">
+            <div class="container-loading-state">Loading completed tasks...</div>
+        </div>
+
+        <div class="load-more-container" id="load-more-container" style="display:none;">
+            <button type="button" class="btn-load-more" id="btn-load-more">Load more</button>
+        </div>
+    </div>
+
+    <script>
+        const PAGE_SIZE = 50;
+
+        // State
+        let todos = [];          // every page loaded so far, in server order
+        let familyMembers = [];
+        let hasMore = false;
+        let loading = false;
+        // Guards against a slow earlier request overwriting a newer one's results
+        let requestToken = 0;
+
+        // Track selected assignee filter values
+        let selectedFilters = new Set();
+
+        async function fetchFamilyMembers() {
+            const response = await fetch('/api/family');
+            familyMembers = await response.json();
+            populateAssigneeDropdown();
+        }
+
+        function populateAssigneeDropdown() {
+            const chips = document.getElementById('filter-assignee-chips');
+            chips.innerHTML = '<button type="button" class="filter-chip" data-value="unassigned">Unassigned</button>';
+            familyMembers.forEach(m => {
+                chips.innerHTML += `<button type="button" class="filter-chip" data-value="${m.id}">${escapeHtml(m.name)}</button>`;
+            });
+            // Re-apply active state from selectedFilters
+            chips.querySelectorAll('.filter-chip').forEach(chip => {
+                if (selectedFilters.has(chip.dataset.value)) {
+                    chip.classList.add('active');
+                }
+            });
+        }
+
+        function clearFilters() {
+            selectedFilters.clear();
+            document.querySelectorAll('#filter-assignee-chips .filter-chip').forEach(chip => {
+                chip.classList.remove('active');
+            });
+            reload();
+        }
+
+        function getMemberById(id) {
+            return familyMembers.find(m => m.id === id);
+        }
+
+        // API calls
+        //
+        // Sorting, filtering and paging all happen server-side: the client only
+        // ever holds the pages it has loaded, so it can't sort or filter the
+        // full set itself.
+        function buildQuery(offset) {
+            const params = new URLSearchParams({
+                sort: document.getElementById('sort-by').value,
+                limit: PAGE_SIZE,
+                offset: offset
+            });
+            selectedFilters.forEach(value => params.append('assignee', value));
+            return params;
+        }
+
+        async function fetchPage(offset) {
+            const token = ++requestToken;
+            loading = true;
+            updateLoadMore();
+            try {
+                const response = await fetch(`/api/todos/completed?${buildQuery(offset)}`);
+                if (!response.ok) throw new Error('Failed to load completed tasks');
+                const page = await response.json();
+                if (token !== requestToken) return; // superseded by a newer request
+                todos = offset === 0 ? page.items : todos.concat(page.items);
+                hasMore = page.has_more;
+                renderTodos();
+            } catch (error) {
+                if (token !== requestToken) return;
+                console.error('Error loading completed tasks:', error);
+                document.getElementById('list-container').innerHTML =
+                    '<div class="container-empty-state">Could not load completed tasks. Please try again.</div>';
+                hasMore = false;
+            } finally {
+                if (token === requestToken) {
+                    loading = false;
+                    updateLoadMore();
+                }
+            }
+        }
+
+        function reload() {
+            todos = [];
+            document.getElementById('list-container').innerHTML =
+                '<div class="container-loading-state">Loading completed tasks...</div>';
+            fetchPage(0);
+        }
+
+        function loadMore() {
+            if (loading || !hasMore) return;
+            fetchPage(todos.length);
+        }
+
+        // Render
+        function renderTodos() {
+            const container = document.getElementById('list-container');
+
+            if (todos.length === 0) {
+                container.innerHTML = selectedFilters.size > 0
+                    ? '<div class="container-empty-state">No completed tasks match the current filter.</div>'
+                    : '<div class="container-empty-state">No completed tasks yet. Tasks appear here the day after you finish them.</div>';
+                return;
+            }
+
+            container.innerHTML = todos.map(todo => {
+                const dueDateHtml = todo.due_date ? formatDueDate(todo.due_date) : '';
+                const completedHtml = formatCompletedDate(todo.completed_at);
+                const member = todo.assigned_to ? getMemberById(todo.assigned_to) : null;
+                const assigneeHtml = member
+                    ? `<span class="assignee-label">— ${escapeHtml(member.name)}</span>`
+                    : '';
+                const recurringIcon = todo.recurring_todo_id ? '<span class="recurring-indicator">↻</span>' : '';
+                return `
+                    <div class="editable-item" data-id="${todo.id}">
+                        <div class="editable-item-content">
+                            <div class="editable-item-title">${escapeHtml(todo.title)} ${recurringIcon} ${assigneeHtml}</div>
+                            ${todo.description ? `<div class="editable-item-description">${escapeHtml(todo.description)}</div>` : ''}
+                            ${dueDateHtml}
+                            ${completedHtml}
+                        </div>
+                    </div>
+                `;
+            }).join('');
+        }
+
+        function updateLoadMore() {
+            const container = document.getElementById('load-more-container');
+            const button = document.getElementById('btn-load-more');
+            container.style.display = hasMore ? '' : 'none';
+            button.disabled = loading;
+            button.textContent = loading ? 'Loading…' : 'Load more';
+        }
+
+        // Every task here is finished, so due dates render in their neutral
+        // style — no overdue emphasis.
+        function formatDueDate(dateStr) {
+            if (!dateStr) return '';
+            const date = new Date(dateStr + 'T00:00:00');
+            return `<div class="todo-due-date">Due ${formatDayMonth(date)}</div>`;
+        }
+
+        function formatCompletedDate(value) {
+            if (!value) return '';
+            const date = new Date(value.endsWith('Z') || value.includes('+') ? value : value + 'Z');
+            if (isNaN(date)) return '';
+            return `<div class="todo-completed-date">Completed ${formatDayMonth(date)}</div>`;
+        }
+
+        function formatDayMonth(date) {
+            const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+            const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+            return `${dayNames[date.getDay()]}, ${monthNames[date.getMonth()]} ${date.getDate()}`;
+        }
+
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        // Event handlers
+        document.getElementById('filter-assignee-chips').addEventListener('click', (e) => {
+            const chip = e.target.closest('.filter-chip');
+            if (!chip) return;
+            const value = chip.dataset.value;
+            if (selectedFilters.has(value)) {
+                selectedFilters.delete(value);
+                chip.classList.remove('active');
+            } else {
+                selectedFilters.add(value);
+                chip.classList.add('active');
+            }
+            reload();
+        });
+        document.getElementById('filter-clear').addEventListener('click', clearFilters);
+        document.getElementById('sort-by').addEventListener('change', reload);
+        document.getElementById('btn-load-more').addEventListener('click', loadMore);
+
+        // Initialize
+        fetchFamilyMembers().then(reload);
+
+        // Nav dropdown toggle (for touch devices)
+        function toggleMealDropdown(e) {
+            e.stopPropagation();
+            document.getElementById('meal-dropdown').classList.toggle('open');
+        }
+        document.addEventListener('click', function() {
+            document.getElementById('meal-dropdown').classList.remove('open');
+        });
+    </script>
+
+    <footer>
+        <a href="/settings">Settings</a>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
Closes #86.

## What changed

Adds **`/todo/completed`**, a read-only archive of tasks completed before today.

Previously a completed task was visible on `/todo` only until the end of the local day it was completed, after which it became unreachable from the UI — the rows stayed in the database but nothing ever requested them. Recurring templates surfaced a single `Last completed` date; one-off tasks left no trace at all.

The new page mirrors the `/todo` layout — same `Tasks` heading, toolbar, and list styles — minus the `Add Task` button, `Edit` buttons, completion checkbox, and Recurring Tasks section. It's reachable only through a link above the `Assignee` filter that toggles between the two pages (`View completed tasks` ⇄ `Back to current tasks`); no new nav entry.

- Two new sort options, `Completion Date (Most Recent)` (default here) and `Completion Date (Oldest)`, alongside the five existing ones. `/todo` keeps its own `Due Date (Soonest)` default and does not gain the new options.
- Each row shows its completion date beneath the due date; with no due date, the completion line is simply the last line.
- Paginated 50 at a time via `Load more`; changing sort or filter resets to the first page.

Backed by a new `GET /api/todos/completed` returning `{items, has_more}`. Sorting, assignee filtering, and paging are **server-side** — the client only ever holds the pages it has loaded, so it can't order or filter the full set itself. The existing `include_hidden=true` param returns current and historical rows together, so it wasn't usable directly. Recurring processing is deliberately not run on this read-only path.

## Reviewer notes

The two views are designed to be exact complements — every task on exactly one page, never both, never neither. Pinning that down required three changes to existing behavior:

1. **Timezone fix.** The old cutoff subtracted the *server-local* time-of-day from a *UTC* instant, computing the wrong midnight on any non-UTC server. Extracted into a shared `today_start_utc()` that resolves local midnight via the configured IANA timezone, consistent with `today_local()` usage elsewhere. Both listings now use it — if they diverged, tasks would double-appear or vanish.
2. **`>` → `>=`** on the current-tasks cutoff, so a task completed exactly at midnight lands on one page rather than neither. Minor behavior change to `GET /api/todos`.
3. **Completed rows with a null `completed_at`** are treated as historical. Migration 013's backfill should have covered these, but any stragglers are already hidden from `/todo`, so this stops them falling through the gap.

Two deliberate UI departures from `/todo`: due dates render **without** the `overdue` emphasis, and rows are **not** dimmed via the `.completed` class. Every task here is finished, so both cues cost legibility without adding meaning.

The second commit is an unrelated one-line ruff `I001` fix in `recurrence.py`, which makes `lint` pass repo-wide. Note `ruff format` still flags 5 pre-existing files (including `recurrence.py`); I left those alone to keep this diff scoped.

## Testing

Verified by running the app against a dev database (17 tasks, 10 completed, tz `America/Chicago`):

- **Partition invariant**: current ∪ completed = all tasks, zero overlap, nothing missing.
- **Boundary behavior**, using a real task created and then deleted — completed today → current page only; un-completed → current page only; backdated two days → completed page only.
- All 7 sorts, `nullslast` ordering, paging (4→8→10 rows, no duplicates, button hides at the end), sort/filter resetting pagination, assignee OR-filter, empty states, and `422` on an invalid sort value.
- Completed page renders 0 checkboxes, edit buttons, modals, or dimmed rows; `/todo` still has all of its controls and its original 5 sort options.
- Route ordering confirmed: `/api/todos/completed` isn't swallowed by `/api/todos/{todo_id}`.

`lint` passes repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)