### PR TITLE
Interpret family-context times in the family's local timezone

### DIFF
--- a/src/rally/generator/generate.py
+++ b/src/rally/generator/generate.py
@@ -94,6 +94,7 @@ class SummaryGenerator:
 
         # Get local timezone: DB setting > config.toml > UTC
         tz_name = db_settings.get("local_timezone", self.config.get("local_timezone", "UTC"))
+        self.local_tz_name = tz_name
         self.local_tz = ZoneInfo(tz_name)
 
         # Store DB settings for use by other methods
@@ -870,6 +871,19 @@ class SummaryGenerator:
 
         today = now_utc().astimezone(self.local_tz).strftime("%A, %B %d, %Y")
 
+        # Human-readable label for the family's configured timezone. Any bare
+        # time in FAMILY CONTEXT (e.g. "7PM") is assumed to be in this zone, so
+        # the LLM must not silently reinterpret it as UTC or anything else.
+        local_now = now_utc().astimezone(self.local_tz)
+        tz_abbrev = local_now.strftime("%Z")
+        tz_offset = local_now.strftime("%z")
+        if tz_offset:
+            tz_offset = f"UTC{tz_offset[:3]}:{tz_offset[3:]}"
+        tz_label = self.local_tz_name
+        tz_detail = ", ".join(part for part in (tz_abbrev, tz_offset) if part)
+        if tz_detail:
+            tz_label = f"{self.local_tz_name} (currently {tz_detail})"
+
         # Optional STEM "concept of the day" — schema block + guideline, only when enabled
         stem_schema = ""
         stem_guideline = ""
@@ -901,6 +915,13 @@ AGENT VOICE:
 
 FAMILY CONTEXT:
 {context}
+
+TIMEZONE:
+The family's local timezone is {tz_label}. Interpret every time mentioned in
+FAMILY CONTEXT (and anywhere else without an explicit zone) as local time in
+this timezone. For example, "7PM" means 7:00 PM local. Only use a different
+timezone when the text states one explicitly (e.g. "7PM UTC" or "2100 Eastern"),
+in which case convert it to the family's local timezone before using it.
 
 Respond with ONLY a JSON object (no markdown fences) using this exact schema:
 {{


### PR DESCRIPTION
## Problem

A reminder written in the FAMILY CONTEXT as "remind me at 7PM" was surfacing on the dashboard as **2PM**. The times in the family context were being sent to the LLM with no timezone anchor, so the model interpreted a bare "7PM" inconsistently (effectively as UTC) rather than as the family's configured local time.

## Fix

The generation prompt already localizes calendar and weather data to the dashboard's configured timezone, but never told the LLM how to read the free-text times in FAMILY CONTEXT. This change closes that gap:

- Store the configured timezone name (`local_tz_name`) alongside the existing `ZoneInfo` object.
- Build a human-readable timezone label (e.g. `America/Chicago (currently CDT, UTC-05:00)`) at prompt-build time.
- Add a **TIMEZONE** section to the generation system prompt instructing the model to interpret every unqualified time in FAMILY CONTEXT as local time in the family's timezone — so "7PM" means 7:00 PM local.
- Preserve explicit overrides: when the text names a zone (e.g. "7PM UTC" or "2100 Eastern"), the model converts from that zone to local time instead of assuming local.

## Notes

- No behavior change for calendar/weather data, which were already localized.
- No test suite exists in the repo; verified the module parses and the timezone label renders correctly across `America/Chicago`, `America/New_York`, and `UTC`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S28i5KiC4LTB8y1sKB8kci

---
_Generated by [Claude Code](https://claude.ai/code/session_01S28i5KiC4LTB8y1sKB8kci)_