### PR TITLE
Add keyword search to completed tasks page

### DIFF
--- a/src/rally/routers/todos.py
+++ b/src/rally/routers/todos.py
@@ -75,6 +75,9 @@ def list_completed_todos(
         default=[],
         description='Family member IDs to filter to, and/or "unassigned". Empty means all.',
     ),
+    search: str | None = Query(
+        None, description="Case-insensitive keyword matched against title and description."
+    ),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: Session = Depends(get_db),
@@ -86,8 +89,8 @@ def list_completed_todos(
     the local date rolls over. Read-only — recurring processing is deliberately
     not run here.
 
-    Sorting and pagination are server-side because the client only ever holds
-    one page of results.
+    Sorting, searching and pagination are server-side because the client only
+    ever holds one page of results.
     """
     cutoff = today_start_utc(db)
 
@@ -110,6 +113,16 @@ def list_completed_todos(
             clauses.append(Todo.assigned_to.in_(member_ids))
         query = query.filter(or_(*clauses)) if clauses else query.filter(false())
 
+    # Keyword search: case-insensitive match against title OR description.
+    if search and search.strip():
+        term = f"%{search.strip()}%"
+        query = query.filter(or_(Todo.title.ilike(term), Todo.description.ilike(term)))
+
+    # Total matches for the current query, computed before ordering/joining so the
+    # count is unaffected by the assignee-sort outer join. Drives the search
+    # results-count indicator on the client.
+    total = query.count()
+
     newest_completed_first = (nullslast(Todo.completed_at.desc()), Todo.id.desc())
 
     if sort == "completed-oldest":
@@ -131,7 +144,7 @@ def list_completed_todos(
 
     # Fetch one extra row to determine whether another page exists.
     rows = query.offset(offset).limit(limit + 1).all()
-    return CompletedTodoPage(items=rows[:limit], has_more=len(rows) > limit)
+    return CompletedTodoPage(items=rows[:limit], has_more=len(rows) > limit, total=total)
 
 
 @router.post("", response_model=TodoResponse, status_code=201)

--- a/src/rally/schemas.py
+++ b/src/rally/schemas.py
@@ -223,6 +223,7 @@ class CompletedTodoPage(BaseModel):
 
     items: list[TodoResponse]
     has_more: bool  # True when another page exists beyond this one
+    total: int  # Total matches across all pages for the current query (search + filters)
 
 
 # Recurring Todos

--- a/static/styles.css
+++ b/static/styles.css
@@ -787,6 +787,62 @@ footer a:hover {
     color: var(--medium-gray);
 }
 
+/* Keyword search: its own full-width row at the bottom of the toolbar, below
+   both the assignee filters and the sort control. */
+.toolbar-search {
+    flex-basis: 100%;
+}
+
+.search-input {
+    box-sizing: border-box;
+    min-height: 2.25rem;
+    min-width: 240px;
+    padding: 4px 10px;
+    border: 1px solid var(--pale-gray);
+    border-radius: 0;
+    background: var(--white);
+    font-family: var(--body-font);
+    font-size: 1rem;
+    color: var(--charcoal);
+}
+
+.search-input:focus {
+    outline: none;
+    border-color: var(--medium-gray);
+}
+
+.search-btn {
+    font-family: var(--body-font);
+    font-size: 0.9rem;
+    padding: 8px 24px;
+    border: 1px solid var(--pale-gray);
+    background: var(--white);
+    color: var(--charcoal);
+    cursor: pointer;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    transition: border-color 0.15s, background 0.15s;
+}
+
+.search-btn:hover:not(:disabled) {
+    border-color: var(--medium-gray);
+}
+
+.search-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* Deemphasized match count, shown only while a search is active. Sits on its
+   own row below the search bar and above the toolbar's bottom divider. */
+.search-results-count {
+    flex-basis: 100%;
+    font-family: var(--body-font);
+    font-size: 0.85rem;
+    color: var(--medium-gray);
+    font-style: italic;
+}
+
 .header-actions {
     display: flex;
     gap: 12px;

--- a/templates/todo_completed.html
+++ b/templates/todo_completed.html
@@ -55,6 +55,14 @@
                     <option value="oldest">Oldest First</option>
                 </select>
             </div>
+            <div class="toolbar-group toolbar-search">
+                <label for="search-input">Search</label>
+                <input type="text" id="search-input" class="search-input"
+                       placeholder="Search completed tasks" autocomplete="off">
+                <button type="button" class="search-btn" id="search-btn" disabled>Search</button>
+                <button type="button" class="filter-clear" id="search-clear">Clear Search</button>
+            </div>
+            <div class="search-results-count" id="search-results-count" hidden></div>
         </div>
 
         <div class="list-container" id="list-container">
@@ -79,6 +87,10 @@
 
         // Track selected assignee filter values
         let selectedFilters = new Set();
+
+        // The currently submitted search term ('' when no search is active).
+        // Search runs only on submit (button click or Enter), never on keystroke.
+        let searchTerm = '';
 
         async function fetchFamilyMembers() {
             const response = await fetch('/api/family');
@@ -108,6 +120,53 @@
             reload();
         }
 
+        function clearAssigneeChips() {
+            selectedFilters.clear();
+            document.querySelectorAll('#filter-assignee-chips .filter-chip').forEach(chip => {
+                chip.classList.remove('active');
+            });
+        }
+
+        // The Search button is disabled unless the field holds non-whitespace text.
+        function updateSearchButton() {
+            const hasText = document.getElementById('search-input').value.trim().length > 0;
+            document.getElementById('search-btn').disabled = !hasText;
+        }
+
+        // Submitting a search clears any applied filters and resets sort to the
+        // default, then loads a fresh result set for the new term.
+        function submitSearch() {
+            const value = document.getElementById('search-input').value.trim();
+            if (!value) return;
+            searchTerm = value;
+            clearAssigneeChips();
+            document.getElementById('sort-by').value = 'completed-newest';
+            reload();
+        }
+
+        // Reset the page to its default state: no search, no filters, default sort.
+        function clearSearch() {
+            searchTerm = '';
+            document.getElementById('search-input').value = '';
+            updateSearchButton();
+            clearAssigneeChips();
+            document.getElementById('sort-by').value = 'completed-newest';
+            reload();
+        }
+
+        // Deemphasized count shown only while a search is active. Reflects the
+        // total matches for the current query (search plus any filters applied
+        // to the results afterward), across all pages — not just what's loaded.
+        function updateSearchCount(total) {
+            const el = document.getElementById('search-results-count');
+            if (!searchTerm) {
+                el.hidden = true;
+                return;
+            }
+            el.hidden = false;
+            el.textContent = total === 1 ? '1 matching task.' : `${total} matching tasks.`;
+        }
+
         function getMemberById(id) {
             return familyMembers.find(m => m.id === id);
         }
@@ -124,6 +183,7 @@
                 offset: offset
             });
             selectedFilters.forEach(value => params.append('assignee', value));
+            if (searchTerm) params.set('search', searchTerm);
             return params;
         }
 
@@ -138,6 +198,7 @@
                 if (token !== requestToken) return; // superseded by a newer request
                 todos = offset === 0 ? page.items : todos.concat(page.items);
                 hasMore = page.has_more;
+                updateSearchCount(page.total);
                 renderTodos();
             } catch (error) {
                 if (token !== requestToken) return;
@@ -170,9 +231,15 @@
             const container = document.getElementById('list-container');
 
             if (todos.length === 0) {
-                container.innerHTML = selectedFilters.size > 0
-                    ? '<div class="container-empty-state">No completed tasks match the current filter.</div>'
-                    : '<div class="container-empty-state">No completed tasks yet. Tasks appear here the day after you finish them.</div>';
+                let message;
+                if (searchTerm) {
+                    message = 'No completed tasks match the current search.';
+                } else if (selectedFilters.size > 0) {
+                    message = 'No completed tasks match the current filter.';
+                } else {
+                    message = 'No completed tasks yet. Tasks appear here the day after you finish them.';
+                }
+                container.innerHTML = `<div class="container-empty-state">${message}</div>`;
                 return;
             }
 
@@ -249,6 +316,15 @@
         document.getElementById('filter-clear').addEventListener('click', clearFilters);
         document.getElementById('sort-by').addEventListener('change', reload);
         document.getElementById('btn-load-more').addEventListener('click', loadMore);
+        document.getElementById('search-btn').addEventListener('click', submitSearch);
+        document.getElementById('search-clear').addEventListener('click', clearSearch);
+        document.getElementById('search-input').addEventListener('input', updateSearchButton);
+        document.getElementById('search-input').addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                submitSearch();
+            }
+        });
 
         // Initialize
         fetchFamilyMembers().then(reload);


### PR DESCRIPTION
## Summary

Adds keyword search to the previously completed tasks page (`/todo/completed`), implementing #90.

A `Search` field, `Search` button, and `Clear Search` link appear as the last toolbar row, beneath both the `Assignee` filters and the `Sort` control. Search runs **only** on button click or `Enter`, matches `title` and `description` case-insensitively, clears any applied filters, and resets sort to the default. Once results return, the existing sort and assignee filters operate on the result set. A deemphasized count appears above the divider, and a zero-result search shows a dedicated empty state.

## Changes

**Backend**
- `GET /api/todos/completed` gains an optional `search` query param — case-insensitive `ILIKE` over `Todo.title` **OR** `Todo.description`.
- `CompletedTodoPage` gains a `total` field (match count for the current query, across all pages) to drive the results-count indicator. Computed before ordering/joining so the assignee-sort outer join can't affect it.

**Frontend** (`templates/todo_completed.html`, `static/styles.css`)
- New search row below the Assignee filters and Sort control.
- `Search` button disabled while the field is empty/whitespace; submit on click or `Enter`.
- Submitting clears assignee filters and resets sort to `Completion Date (Most Recent)`.
- `Clear Search` resets the page to defaults (field, filters, sort).
- Deemphasized count: `1 matching task.` (singular) / `# matching tasks.` (all other cases), shown only while a search is active.
- Zero-result search shows `No completed tasks match the current search.`, taking precedence over the filter empty state.

## Testing

Verified manually against a running instance (the repo currently has no automated test suite):

- Search on button click and `Enter`
- Title match and description-only match, case-insensitive
- Submit clears an active assignee filter and resets a non-default sort
- Count indicator: singular vs plural; deemphasized; above the divider
- Zero results → `No completed tasks match the current search.`
- Filtering narrows search results and the count updates while the search term persists
- `Clear Search` restores the full default list; no console errors

`ruff check` and `ruff format --check` pass on the changed Python files.

Closes #90
