### PR TITLE
Establish the repo's first automated test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run tests
+        run: uv run pytest
+
+      - name: Lint
+        run: uv run ruff check .
+
+      - name: Check formatting
+        run: uv run ruff format --check .

--- a/migrations/migrate_add_meal_type.py
+++ b/migrations/migrate_add_meal_type.py
@@ -34,7 +34,9 @@ def migrate():
     try:
         cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='dinner_plans'")
         if not cursor.fetchone():
-            print("✓ Migration: dinner_plans table does not exist yet (will be created on first run)")
+            print(
+                "✓ Migration: dinner_plans table does not exist yet (will be created on first run)"
+            )
             return True
 
         cursor.execute("PRAGMA table_info(dinner_plans)")
@@ -45,7 +47,9 @@ def migrate():
             cursor.execute(
                 "ALTER TABLE dinner_plans ADD COLUMN meal_type VARCHAR(20) NOT NULL DEFAULT 'Dinner'"
             )
-            print("✓ Migration: dinner_plans.meal_type column added (existing records set to 'Dinner')")
+            print(
+                "✓ Migration: dinner_plans.meal_type column added (existing records set to 'Dinner')"
+            )
         else:
             print("✓ Migration: dinner_plans.meal_type column already exists (idempotent check)")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,17 @@ dependencies = [
 [project.scripts]
 seed = "rally.cli:seed"
 
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# The app is a src-layout package that runs with src on PYTHONPATH rather than
+# being installed, so make `import rally` resolve the same way under pytest.
+pythonpath = ["src"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py314"

--- a/src/rally/generator/generate.py
+++ b/src/rally/generator/generate.py
@@ -473,7 +473,7 @@ class SummaryGenerator:
                         window_start = due - timedelta(days=todo.remind_days_before)
                         if today < window_start:
                             continue
-                    except (ValueError, TypeError, OverflowError):
+                    except ValueError, TypeError, OverflowError:
                         pass  # If date is unparseable or calculation fails, include the todo
 
                 line = f"{todo.title}"

--- a/src/rally/recurrence.py
+++ b/src/rally/recurrence.py
@@ -33,7 +33,11 @@ def _find_nth_weekday_in_month(year: int, month: int, ordinal: str, weekday: int
     exist (e.g. "fifth Monday").
     """
     num_days = cal_module.monthrange(year, month)[1]
-    occurrences = [date(year, month, d) for d in range(1, num_days + 1) if date(year, month, d).weekday() == weekday]
+    occurrences = [
+        date(year, month, d)
+        for d in range(1, num_days + 1)
+        if date(year, month, d).weekday() == weekday
+    ]
 
     ordinal_map = {"first": 0, "second": 1, "third": 2, "fourth": 3, "last": -1}
     idx = ordinal_map.get(ordinal, 0)
@@ -82,7 +86,9 @@ def _next_custom(rule: dict, after_date: date) -> date:
         if mode == "weekday":
             ordinal = rule["ordinal"]
             weekday = int(rule["weekday"])
-            candidate = _find_nth_weekday_in_month(after_date.year, after_date.month, ordinal, weekday)
+            candidate = _find_nth_weekday_in_month(
+                after_date.year, after_date.month, ordinal, weekday
+            )
             if candidate > after_date:
                 return candidate
             ny, nm = _advance_months(after_date.year, after_date.month, interval)
@@ -119,7 +125,9 @@ def _last_custom(rule: dict, today: date) -> date:
                 return today.replace(day=clamped)
             first = today.replace(day=1)
             prev_end = first - timedelta(days=1)
-            return prev_end.replace(day=min(day, cal_module.monthrange(prev_end.year, prev_end.month)[1]))
+            return prev_end.replace(
+                day=min(day, cal_module.monthrange(prev_end.year, prev_end.month)[1])
+            )
 
         if mode == "weekday":
             ordinal = rule["ordinal"]

--- a/src/rally/routers/recurring_todos.py
+++ b/src/rally/routers/recurring_todos.py
@@ -23,7 +23,11 @@ def format_local_completion(completed_at: datetime, local_tz: ZoneInfo) -> str:
     elif local_dt.date() == today.replace(day=today.day) - __import__("datetime").timedelta(days=1):
         date_label = "Yesterday"
     else:
-        suffix = "th" if 11 <= local_dt.day % 100 <= 13 else {1: "st", 2: "nd", 3: "rd"}.get(local_dt.day % 10, "th")
+        suffix = (
+            "th"
+            if 11 <= local_dt.day % 100 <= 13
+            else {1: "st", 2: "nd", 3: "rd"}.get(local_dt.day % 10, "th")
+        )
         date_label = f"{local_dt.strftime('%b')} {local_dt.day}{suffix}, {local_dt.year}"
     time_label = local_dt.strftime("%I:%M %p").lstrip("0")
     return f"{date_label} at {time_label}"

--- a/src/rally/routers/settings.py
+++ b/src/rally/routers/settings.py
@@ -324,9 +324,7 @@ def test_weather_connection(db: Session = Depends(get_db)):
         current = root.find(".//data[@type='current observations']")
         temp = current.find("parameters/temperature/value") if current is not None else None
         conditions = (
-            current.find("parameters/weather/weather-conditions")
-            if current is not None
-            else None
+            current.find("parameters/weather/weather-conditions") if current is not None else None
         )
         detail = []
         if temp is not None and temp.text:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,56 @@
+"""Shared test fixtures: an isolated in-memory database and a test client.
+
+Every test gets a fresh SQLite database that lives only in memory, wired into
+the app by overriding the ``get_db`` dependency. The app's real database
+(``rally.db``) is never touched: the ``get_db`` override replaces it for request
+handling, and the ``TestClient`` is used without its lifespan context manager so
+the startup ``init_db()`` (which would create tables on the real engine) never
+runs.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from rally.database import Base, get_db
+from rally.main import app
+
+
+@pytest.fixture
+def db_session():
+    """A fresh in-memory database for a single test.
+
+    ``StaticPool`` keeps every connection pointed at the same in-memory
+    database, so rows a test seeds are visible to the request handlers (which
+    each open their own session on the same engine).
+    """
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    testing_session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = testing_session_local()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture
+def client(db_session: Session):
+    """A ``TestClient`` whose ``get_db`` dependency uses the test database."""
+
+    def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_completed_todos.py
+++ b/tests/test_completed_todos.py
@@ -1,0 +1,252 @@
+"""Tests for ``GET /api/todos/completed`` — the previously-completed-tasks API.
+
+Covers the keyword search added in #90 plus the pre-existing filtering, sorting,
+and pagination behaviour that search rides on (this is the endpoint's first
+automated coverage).
+
+The completed page shows todos completed *before* today's local-midnight cutoff.
+Seed data uses two fixed reference points so tests stay deterministic regardless
+of when they run:
+
+- ``PAST`` — a long-ago instant, always before the cutoff (appears on the page).
+- ``TODAY_NOON`` — noon today (UTC), always within [today-midnight, tomorrow),
+  i.e. "completed today", so it is excluded from the page.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from rally.models import FamilyMember, Todo
+
+PAST = datetime(2020, 1, 1, 12, 0, 0)
+TODAY_NOON = datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0, tzinfo=None)
+
+
+def make_member(db: Session, name: str) -> FamilyMember:
+    member = FamilyMember(name=name)
+    db.add(member)
+    db.commit()
+    db.refresh(member)
+    return member
+
+
+def make_todo(
+    db: Session,
+    title: str,
+    *,
+    description: str | None = None,
+    completed: bool = True,
+    completed_at: datetime | None = PAST,
+    assigned_to: int | None = None,
+    due_date: str | None = None,
+    created_at: datetime | None = None,
+) -> Todo:
+    todo = Todo(
+        title=title,
+        description=description,
+        completed=completed,
+        completed_at=completed_at,
+        assigned_to=assigned_to,
+        due_date=due_date,
+    )
+    if created_at is not None:
+        todo.created_at = created_at
+    db.add(todo)
+    db.commit()
+    db.refresh(todo)
+    return todo
+
+
+def get_completed(client: TestClient, **params):
+    response = client.get("/api/todos/completed", params=params)
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def titles(payload) -> list[str]:
+    return [item["title"] for item in payload["items"]]
+
+
+# --- Search (from #90) ---------------------------------------------------------
+
+
+def test_search_matches_title(client, db_session):
+    make_todo(db_session, "Allergy shot")
+    make_todo(db_session, "Buy groceries")
+
+    payload = get_completed(client, search="shot")
+
+    assert payload["total"] == 1
+    assert titles(payload) == ["Allergy shot"]
+
+
+def test_search_matches_description(client, db_session):
+    make_todo(db_session, "Finish reading chapter 3", description="Book club meets next week")
+    make_todo(db_session, "Buy groceries", description="Milk and eggs")
+
+    payload = get_completed(client, search="club")
+
+    assert payload["total"] == 1
+    assert titles(payload) == ["Finish reading chapter 3"]
+
+
+def test_search_is_case_insensitive(client, db_session):
+    make_todo(db_session, "Allergy SHOT")
+
+    payload = get_completed(client, search="shot")
+
+    assert payload["total"] == 1
+    assert titles(payload) == ["Allergy SHOT"]
+
+
+def test_search_no_match_returns_empty_and_zero_total(client, db_session):
+    make_todo(db_session, "Allergy shot")
+
+    payload = get_completed(client, search="zzznomatch")
+
+    assert payload["total"] == 0
+    assert payload["items"] == []
+    assert payload["has_more"] is False
+
+
+def test_whitespace_only_search_is_treated_as_no_search(client, db_session):
+    make_todo(db_session, "Allergy shot")
+    make_todo(db_session, "Buy groceries")
+
+    payload = get_completed(client, search="   ")
+
+    assert payload["total"] == 2
+
+
+def test_search_combined_with_assignee_filter_is_and(client, db_session):
+    dad = make_member(db_session, "Dad")
+    mom = make_member(db_session, "Mom")
+    make_todo(db_session, "Allergy shot", assigned_to=dad.id)
+    make_todo(db_session, "Flu shot", assigned_to=mom.id)
+
+    # "shot" matches both todos, but the assignee filter narrows to Dad's only.
+    payload = get_completed(client, search="shot", assignee=str(dad.id))
+
+    assert payload["total"] == 1
+    assert titles(payload) == ["Allergy shot"]
+
+
+def test_search_respects_sort(client, db_session):
+    make_todo(db_session, "Shot A", completed_at=datetime(2021, 1, 1))
+    make_todo(db_session, "Shot B", completed_at=datetime(2022, 1, 1))
+
+    newest = get_completed(client, search="shot", sort="completed-newest")
+    oldest = get_completed(client, search="shot", sort="completed-oldest")
+
+    assert titles(newest) == ["Shot B", "Shot A"]
+    assert titles(oldest) == ["Shot A", "Shot B"]
+
+
+def test_total_reflects_all_matches_across_pages(client, db_session):
+    for i in range(55):
+        make_todo(db_session, f"Shot {i:02d}")
+
+    first = get_completed(client, search="shot", limit=50, offset=0)
+    assert first["total"] == 55
+    assert len(first["items"]) == 50
+    assert first["has_more"] is True
+
+    second = get_completed(client, search="shot", limit=50, offset=50)
+    assert second["total"] == 55
+    assert len(second["items"]) == 5
+    assert second["has_more"] is False
+
+
+# --- Pre-existing completed-endpoint behaviour (first coverage) ----------------
+
+
+def test_excludes_todos_completed_today(client, db_session):
+    make_todo(db_session, "Done long ago", completed_at=PAST)
+    make_todo(db_session, "Done today", completed_at=TODAY_NOON)
+
+    payload = get_completed(client)
+
+    assert titles(payload) == ["Done long ago"]
+
+
+def test_excludes_incomplete_todos(client, db_session):
+    make_todo(db_session, "Completed", completed=True, completed_at=PAST)
+    make_todo(db_session, "Still open", completed=False, completed_at=None)
+
+    payload = get_completed(client)
+
+    assert titles(payload) == ["Completed"]
+
+
+def test_includes_completed_todo_with_null_completed_at(client, db_session):
+    # Pre-migration data: completed but no completed_at. It is hidden from the
+    # current-tasks page, so it must appear here rather than nowhere.
+    make_todo(db_session, "Legacy done", completed=True, completed_at=None)
+
+    payload = get_completed(client)
+
+    assert titles(payload) == ["Legacy done"]
+
+
+def test_filter_unassigned(client, db_session):
+    dad = make_member(db_session, "Dad")
+    make_todo(db_session, "Unassigned task", assigned_to=None)
+    make_todo(db_session, "Dad task", assigned_to=dad.id)
+
+    payload = get_completed(client, assignee="unassigned")
+
+    assert payload["total"] == 1
+    assert titles(payload) == ["Unassigned task"]
+
+
+def test_filter_single_member(client, db_session):
+    dad = make_member(db_session, "Dad")
+    mom = make_member(db_session, "Mom")
+    make_todo(db_session, "Dad task", assigned_to=dad.id)
+    make_todo(db_session, "Mom task", assigned_to=mom.id)
+
+    payload = get_completed(client, assignee=str(dad.id))
+
+    assert titles(payload) == ["Dad task"]
+
+
+def test_filter_multiple_members_is_or(client, db_session):
+    dad = make_member(db_session, "Dad")
+    mom = make_member(db_session, "Mom")
+    kid = make_member(db_session, "Kid")
+    make_todo(db_session, "Dad task", assigned_to=dad.id)
+    make_todo(db_session, "Mom task", assigned_to=mom.id)
+    make_todo(db_session, "Kid task", assigned_to=kid.id)
+
+    payload = get_completed(client, assignee=[str(dad.id), str(mom.id)])
+
+    assert payload["total"] == 2
+    assert set(titles(payload)) == {"Dad task", "Mom task"}
+
+
+def test_default_sort_is_completed_newest(client, db_session):
+    make_todo(db_session, "Older", completed_at=datetime(2021, 1, 1))
+    make_todo(db_session, "Newer", completed_at=datetime(2022, 1, 1))
+
+    payload = get_completed(client)
+
+    assert titles(payload) == ["Newer", "Older"]
+
+
+def test_pagination_limit_offset_and_has_more(client, db_session):
+    # Distinct completion times so ordering is stable across pages.
+    base = datetime(2021, 1, 1)
+    for i in range(3):
+        make_todo(db_session, f"Task {i}", completed_at=base + timedelta(days=i))
+
+    first = get_completed(client, limit=2, offset=0)
+    assert len(first["items"]) == 2
+    assert first["has_more"] is True
+    assert first["total"] == 3
+
+    second = get_completed(client, limit=2, offset=2)
+    assert len(second["items"]) == 1
+    assert second["has_more"] is False
+    assert second["total"] == 3

--- a/uv.lock
+++ b/uv.lock
@@ -381,6 +381,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jh2"
 version = "5.0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -593,6 +602,24 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -685,6 +712,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -800,6 +843,11 @@ dependencies = [
     { name = "sqlalchemy" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.52.0" },
@@ -814,6 +862,9 @@ requires-dist = [
     { name = "ruff", specifier = ">=0.15.1" },
     { name = "sqlalchemy", specifier = ">=2.0.46" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0" }]
 
 [[package]]
 name = "recurring-ical-events"


### PR DESCRIPTION
## Summary

Establishes the repo's **first automated test suite** using `pytest`, seeded with API-level tests for the completed-tasks endpoint (including the #90 keyword search), plus a CI workflow that runs it on every PR. Implements #92. Purely additive — no application behavior changes.

## Changes

**Test harness** (`tests/conftest.py`)
- Per-test in-memory SQLite via `StaticPool` (so request handlers see rows the test seeds), wired in through a `get_db` dependency override.
- The `TestClient` is used **without** its lifespan, so startup's `init_db()` never runs and the real `rally.db` is never touched.

**First test module** (`tests/test_completed_todos.py`) — 16 cases over `GET /api/todos/completed`:
- **Search (#90):** title match, description match, case-insensitivity, no-match → `total: 0`, whitespace-only ignored, AND with assignee filter, respects sort, and `total` across paginated results.
- **Pre-existing behavior (first coverage):** completed-today cutoff exclusion, incomplete excluded, null-`completed_at` legacy rows included, unassigned/single/multi assignee filters, default sort, pagination + `has_more`.

**CI** (`.github/workflows/tests.yml`)
- On every pull request and push to `main`: `uv sync` → `uv run pytest` → `ruff check .` → `ruff format --check .`. Any failure blocks the check.

**Config**
- Added `pytest` as a dev dependency with `pythonpath = ["src"]` and `testpaths = ["tests"]` (`pyproject.toml`); regenerated `uv.lock` (additive — pytest + 3 transitive deps).

## Testing

- **16 passed in 0.27s** locally.
- `ruff check` and `ruff format --check` pass on the new files.
- The GitHub Actions workflow itself (`uv sync` / `setup-uv` / Python 3.14 provisioning) can only be fully exercised on GitHub's runners — the first CI run on this PR is the real confirmation. The commands it invokes all pass locally.

## Scope

Deliberately scoped to the completed-tasks/search endpoint plus harness and CI, per #92. Frontend/browser tests (Playwright) and coverage of other routers are explicitly out of scope and left as follow-ups.

Closes #92
