### PR TITLE
Test coverage — Phase 0: harness extensions + coverage reporting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         run: uv sync
 
       - name: Run tests
-        run: uv run pytest
+        run: uv run pytest --cov=rally --cov-report=term-missing --cov-report=xml
 
       - name: Lint
         run: uv run ruff check .

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Python
 __pycache__/
+.pytest_cache/
+.coverage
+coverage.xml
+htmlcov/
 *.py[cod]
 *$py.class
 *.so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ seed = "rally.cli:seed"
 [dependency-groups]
 dev = [
     "pytest>=8.0",
+    "pytest-cov>=5.0",
 ]
 
 [tool.pytest.ini_options]
@@ -31,6 +32,10 @@ testpaths = ["tests"]
 # The app is a src-layout package that runs with src on PYTHONPATH rather than
 # being installed, so make `import rally` resolve the same way under pytest.
 pythonpath = ["src"]
+
+[tool.coverage.run]
+source = ["rally"]
+omit = ["*/tests/*"]
 
 [tool.ruff]
 line-length = 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,19 @@
-"""Shared test fixtures: an isolated in-memory database and a test client.
+"""Shared test fixtures.
 
-Every test gets a fresh SQLite database that lives only in memory, wired into
-the app by overriding the ``get_db`` dependency. The app's real database
-(``rally.db``) is never touched: the ``get_db`` override replaces it for request
-handling, and the ``TestClient`` is used without its lifespan context manager so
-the startup ``init_db()`` (which would create tables on the real engine) never
-runs.
+Provides an isolated in-memory database and test client, seed factories for the
+core models, a deterministic-time fixture, a timezone-setting fixture, and
+fixtures that stub the external boundaries (HTTP, LLM clients, CalDAV) so no
+test ever touches the network.
+
+The app's real database (``rally.db``) is never touched: the ``get_db`` override
+replaces it for request handling, and the ``TestClient`` is used without its
+lifespan context manager so the startup ``init_db()`` (which would create tables
+on the real engine) never runs.
 """
+
+import importlib
+from datetime import UTC, datetime
+from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
@@ -16,6 +23,9 @@ from sqlalchemy.pool import StaticPool
 
 from rally.database import Base, get_db
 from rally.main import app
+from rally.models import DinnerPlan, FamilyMember, RecurringTodo, Setting, Todo
+
+# --- Database + client ---------------------------------------------------------
 
 
 @pytest.fixture
@@ -54,3 +64,300 @@ def client(db_session: Session):
         yield TestClient(app)
     finally:
         app.dependency_overrides.clear()
+
+
+# --- Seed factories ------------------------------------------------------------
+#
+# Each returns a callable so a test can seed several rows with per-call overrides,
+# e.g. `make_todo("Buy milk", completed_at=PAST)`. All commit and refresh so the
+# returned instance has its primary key populated.
+
+
+@pytest.fixture
+def make_member(db_session: Session):
+    def _make(name: str = "Alex", **kwargs) -> FamilyMember:
+        member = FamilyMember(name=name, **kwargs)
+        db_session.add(member)
+        db_session.commit()
+        db_session.refresh(member)
+        return member
+
+    return _make
+
+
+@pytest.fixture
+def make_todo(db_session: Session):
+    def _make(
+        title: str = "A task",
+        *,
+        description: str | None = None,
+        completed: bool = True,
+        completed_at: datetime | None = datetime(2020, 1, 1, 12, 0, 0),
+        assigned_to: int | None = None,
+        due_date: str | None = None,
+        created_at: datetime | None = None,
+        **kwargs,
+    ) -> Todo:
+        todo = Todo(
+            title=title,
+            description=description,
+            completed=completed,
+            completed_at=completed_at,
+            assigned_to=assigned_to,
+            due_date=due_date,
+            **kwargs,
+        )
+        if created_at is not None:
+            todo.created_at = created_at
+        db_session.add(todo)
+        db_session.commit()
+        db_session.refresh(todo)
+        return todo
+
+    return _make
+
+
+@pytest.fixture
+def make_recurring_todo(db_session: Session):
+    def _make(
+        title: str = "Recurring task",
+        *,
+        recurrence_type: str = "daily",
+        recurrence_day: int | None = None,
+        custom_rule: dict | None = None,
+        active: bool = True,
+        **kwargs,
+    ) -> RecurringTodo:
+        rt = RecurringTodo(
+            title=title,
+            recurrence_type=recurrence_type,
+            recurrence_day=recurrence_day,
+            custom_rule=custom_rule,
+            active=active,
+            **kwargs,
+        )
+        db_session.add(rt)
+        db_session.commit()
+        db_session.refresh(rt)
+        return rt
+
+    return _make
+
+
+@pytest.fixture
+def make_dinner_plan(db_session: Session):
+    def _make(
+        date: str = "2026-01-01",
+        *,
+        plan: str = "Pasta",
+        meal_type: str = "Dinner",
+        rating: int | None = None,
+        **kwargs,
+    ) -> DinnerPlan:
+        dp = DinnerPlan(date=date, plan=plan, meal_type=meal_type, rating=rating, **kwargs)
+        db_session.add(dp)
+        db_session.commit()
+        db_session.refresh(dp)
+        return dp
+
+    return _make
+
+
+@pytest.fixture
+def make_setting(db_session: Session):
+    def _make(key: str, value: str) -> Setting:
+        row = db_session.get(Setting, key)
+        if row is None:
+            row = Setting(key=key, value=value)
+            db_session.add(row)
+        else:
+            row.value = value
+        db_session.commit()
+        return row
+
+    return _make
+
+
+# --- Deterministic time --------------------------------------------------------
+#
+# `today_utc()`/`today_local()` resolve `now_utc` from the timezone module at call
+# time, so patching the canonical function covers them transitively. Modules that
+# did `from rally.utils.timezone import now_utc` and *call it directly* each hold
+# their own binding, so those must be patched individually. (Module-level column
+# defaults like `default=now_utc` capture the function at class-definition time
+# and are not affected — seed timestamps explicitly when they matter.)
+_NOW_UTC_IMPORTERS = (
+    "rally.routers.recurring_todos",
+    "rally.routers.todos",
+    "rally.routers.dashboard",
+    "rally.routers.settings",
+    "rally.generator.generate",
+)
+
+
+@pytest.fixture
+def frozen_now(monkeypatch):
+    """Freeze `now_utc` to a chosen instant for the duration of a test.
+
+    Returns a callable: ``frozen_now(datetime(2026, 7, 22, 12, tzinfo=UTC))``.
+    A naive datetime is assumed to be UTC.
+    """
+    import rally.utils.timezone as tz
+
+    def freeze(instant: datetime) -> datetime:
+        if instant.tzinfo is None:
+            instant = instant.replace(tzinfo=UTC)
+
+        def fake_now_utc() -> datetime:
+            return instant
+
+        monkeypatch.setattr(tz, "now_utc", fake_now_utc)
+        for name in _NOW_UTC_IMPORTERS:
+            module = importlib.import_module(name)
+            if getattr(module, "now_utc", None) is not None:
+                monkeypatch.setattr(module, "now_utc", fake_now_utc)
+        return instant
+
+    return freeze
+
+
+@pytest.fixture
+def local_timezone(make_setting):
+    """Set the ``local_timezone`` setting; returns a setter.
+
+    Defaults to a non-UTC zone so timezone-dependent code paths are actually
+    exercised rather than collapsing to the UTC no-op.
+    """
+
+    def set_tz(tz_name: str = "America/Chicago") -> str:
+        make_setting("local_timezone", tz_name)
+        return tz_name
+
+    return set_tz
+
+
+# --- External boundary stubs ---------------------------------------------------
+#
+# All LLM/HTTP/CalDAV calls are reached via lazy in-function imports, so patching
+# the module attribute (requests.get, anthropic.Anthropic, openai.OpenAI,
+# caldav.DAVClient) intercepts them regardless of how the caller imported them.
+
+
+class FakeResponse:
+    """Minimal stand-in for a ``requests`` response."""
+
+    def __init__(self, *, text: str = "", status_code: int = 200, json_data=None):
+        self.text = text
+        self.status_code = status_code
+        self._json = json_data
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import requests
+
+            raise requests.HTTPError(f"HTTP {self.status_code}")
+
+
+@pytest.fixture
+def mock_requests(monkeypatch):
+    """Stub ``requests.get``. Configure via ``.set_response(...)`` or
+    ``.set_handler(fn)``; inspect ``.calls``."""
+    import requests
+
+    calls: list[dict] = []
+    holder = {"response": FakeResponse()}
+
+    def fake_get(url, *args, **kwargs):
+        calls.append({"url": url, "kwargs": kwargs})
+        resp = holder["response"]
+        return resp(url, *args, **kwargs) if callable(resp) else resp
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    class MockRequests:
+        def __init__(self):
+            self.calls = calls
+
+        def set_response(self, **kwargs):
+            holder["response"] = FakeResponse(**kwargs)
+
+        def set_handler(self, fn):
+            holder["response"] = fn
+
+    return MockRequests()
+
+
+@pytest.fixture
+def mock_llm(monkeypatch):
+    """Stub the ``anthropic`` and ``openai`` client classes so no LLM is called.
+
+    Both fakes record their ``create`` kwargs in ``.calls`` and return a canned
+    completion shaped like the real client responses.
+    """
+    import anthropic
+    import openai
+
+    calls: list[tuple] = []
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            calls.append(("anthropic", kwargs))
+            return SimpleNamespace(content=[SimpleNamespace(text="ok")])
+
+    class FakeAnthropic:
+        def __init__(self, **kwargs):
+            self.init_kwargs = kwargs
+            self.messages = FakeMessages()
+
+    class FakeCompletions:
+        def create(self, **kwargs):
+            calls.append(("openai", kwargs))
+            return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            self.init_kwargs = kwargs
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    monkeypatch.setattr(anthropic, "Anthropic", FakeAnthropic)
+    monkeypatch.setattr(openai, "OpenAI", FakeOpenAI)
+    return SimpleNamespace(calls=calls)
+
+
+@pytest.fixture
+def mock_caldav(monkeypatch):
+    """Stub ``caldav.DAVClient`` so CalDAV connections are never opened.
+
+    Records interactions in ``.calls`` and returns configurable events from
+    ``.search()`` (set via ``.set_events([...])``).
+    """
+    import caldav
+
+    calls: list[tuple] = []
+    holder = {"events": []}
+
+    class FakeCalendar:
+        def search(self, **kwargs):
+            calls.append(("search", kwargs))
+            return list(holder["events"])
+
+    class FakePrincipal:
+        def calendars(self):
+            calls.append(("calendars", {}))
+            return [FakeCalendar()]
+
+    class FakeDAVClient:
+        def __init__(self, **kwargs):
+            calls.append(("client", kwargs))
+
+        def principal(self):
+            return FakePrincipal()
+
+    monkeypatch.setattr(caldav, "DAVClient", FakeDAVClient)
+
+    controller = SimpleNamespace(calls=calls)
+    controller.set_events = lambda events: holder.__setitem__("events", events)
+    return controller

--- a/tests/test_completed_todos.py
+++ b/tests/test_completed_todos.py
@@ -1,65 +1,28 @@
 """Tests for ``GET /api/todos/completed`` — the previously-completed-tasks API.
 
 Covers the keyword search added in #90 plus the pre-existing filtering, sorting,
-and pagination behaviour that search rides on (this is the endpoint's first
-automated coverage).
+and pagination behaviour that search rides on.
 
 The completed page shows todos completed *before* today's local-midnight cutoff.
 Seed data uses two fixed reference points so tests stay deterministic regardless
 of when they run:
 
-- ``PAST`` — a long-ago instant, always before the cutoff (appears on the page).
+- ``PAST`` — a long-ago instant, always before the cutoff (appears on the page);
+  this is also the ``make_todo`` factory's default ``completed_at``.
 - ``TODAY_NOON`` — noon today (UTC), always within [today-midnight, tomorrow),
   i.e. "completed today", so it is excluded from the page.
+
+Seeding uses the shared ``make_todo`` / ``make_member`` factory fixtures from
+conftest.
 """
 
 from datetime import UTC, datetime, timedelta
-
-from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
-
-from rally.models import FamilyMember, Todo
 
 PAST = datetime(2020, 1, 1, 12, 0, 0)
 TODAY_NOON = datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0, tzinfo=None)
 
 
-def make_member(db: Session, name: str) -> FamilyMember:
-    member = FamilyMember(name=name)
-    db.add(member)
-    db.commit()
-    db.refresh(member)
-    return member
-
-
-def make_todo(
-    db: Session,
-    title: str,
-    *,
-    description: str | None = None,
-    completed: bool = True,
-    completed_at: datetime | None = PAST,
-    assigned_to: int | None = None,
-    due_date: str | None = None,
-    created_at: datetime | None = None,
-) -> Todo:
-    todo = Todo(
-        title=title,
-        description=description,
-        completed=completed,
-        completed_at=completed_at,
-        assigned_to=assigned_to,
-        due_date=due_date,
-    )
-    if created_at is not None:
-        todo.created_at = created_at
-    db.add(todo)
-    db.commit()
-    db.refresh(todo)
-    return todo
-
-
-def get_completed(client: TestClient, **params):
+def get_completed(client, **params):
     response = client.get("/api/todos/completed", params=params)
     assert response.status_code == 200, response.text
     return response.json()
@@ -72,9 +35,9 @@ def titles(payload) -> list[str]:
 # --- Search (from #90) ---------------------------------------------------------
 
 
-def test_search_matches_title(client, db_session):
-    make_todo(db_session, "Allergy shot")
-    make_todo(db_session, "Buy groceries")
+def test_search_matches_title(client, make_todo):
+    make_todo("Allergy shot")
+    make_todo("Buy groceries")
 
     payload = get_completed(client, search="shot")
 
@@ -82,9 +45,9 @@ def test_search_matches_title(client, db_session):
     assert titles(payload) == ["Allergy shot"]
 
 
-def test_search_matches_description(client, db_session):
-    make_todo(db_session, "Finish reading chapter 3", description="Book club meets next week")
-    make_todo(db_session, "Buy groceries", description="Milk and eggs")
+def test_search_matches_description(client, make_todo):
+    make_todo("Finish reading chapter 3", description="Book club meets next week")
+    make_todo("Buy groceries", description="Milk and eggs")
 
     payload = get_completed(client, search="club")
 
@@ -92,8 +55,8 @@ def test_search_matches_description(client, db_session):
     assert titles(payload) == ["Finish reading chapter 3"]
 
 
-def test_search_is_case_insensitive(client, db_session):
-    make_todo(db_session, "Allergy SHOT")
+def test_search_is_case_insensitive(client, make_todo):
+    make_todo("Allergy SHOT")
 
     payload = get_completed(client, search="shot")
 
@@ -101,8 +64,8 @@ def test_search_is_case_insensitive(client, db_session):
     assert titles(payload) == ["Allergy SHOT"]
 
 
-def test_search_no_match_returns_empty_and_zero_total(client, db_session):
-    make_todo(db_session, "Allergy shot")
+def test_search_no_match_returns_empty_and_zero_total(client, make_todo):
+    make_todo("Allergy shot")
 
     payload = get_completed(client, search="zzznomatch")
 
@@ -111,20 +74,20 @@ def test_search_no_match_returns_empty_and_zero_total(client, db_session):
     assert payload["has_more"] is False
 
 
-def test_whitespace_only_search_is_treated_as_no_search(client, db_session):
-    make_todo(db_session, "Allergy shot")
-    make_todo(db_session, "Buy groceries")
+def test_whitespace_only_search_is_treated_as_no_search(client, make_todo):
+    make_todo("Allergy shot")
+    make_todo("Buy groceries")
 
     payload = get_completed(client, search="   ")
 
     assert payload["total"] == 2
 
 
-def test_search_combined_with_assignee_filter_is_and(client, db_session):
-    dad = make_member(db_session, "Dad")
-    mom = make_member(db_session, "Mom")
-    make_todo(db_session, "Allergy shot", assigned_to=dad.id)
-    make_todo(db_session, "Flu shot", assigned_to=mom.id)
+def test_search_combined_with_assignee_filter_is_and(client, make_todo, make_member):
+    dad = make_member("Dad")
+    mom = make_member("Mom")
+    make_todo("Allergy shot", assigned_to=dad.id)
+    make_todo("Flu shot", assigned_to=mom.id)
 
     # "shot" matches both todos, but the assignee filter narrows to Dad's only.
     payload = get_completed(client, search="shot", assignee=str(dad.id))
@@ -133,9 +96,9 @@ def test_search_combined_with_assignee_filter_is_and(client, db_session):
     assert titles(payload) == ["Allergy shot"]
 
 
-def test_search_respects_sort(client, db_session):
-    make_todo(db_session, "Shot A", completed_at=datetime(2021, 1, 1))
-    make_todo(db_session, "Shot B", completed_at=datetime(2022, 1, 1))
+def test_search_respects_sort(client, make_todo):
+    make_todo("Shot A", completed_at=datetime(2021, 1, 1))
+    make_todo("Shot B", completed_at=datetime(2022, 1, 1))
 
     newest = get_completed(client, search="shot", sort="completed-newest")
     oldest = get_completed(client, search="shot", sort="completed-oldest")
@@ -144,9 +107,9 @@ def test_search_respects_sort(client, db_session):
     assert titles(oldest) == ["Shot A", "Shot B"]
 
 
-def test_total_reflects_all_matches_across_pages(client, db_session):
+def test_total_reflects_all_matches_across_pages(client, make_todo):
     for i in range(55):
-        make_todo(db_session, f"Shot {i:02d}")
+        make_todo(f"Shot {i:02d}")
 
     first = get_completed(client, search="shot", limit=50, offset=0)
     assert first["total"] == 55
@@ -159,41 +122,41 @@ def test_total_reflects_all_matches_across_pages(client, db_session):
     assert second["has_more"] is False
 
 
-# --- Pre-existing completed-endpoint behaviour (first coverage) ----------------
+# --- Pre-existing completed-endpoint behaviour ---------------------------------
 
 
-def test_excludes_todos_completed_today(client, db_session):
-    make_todo(db_session, "Done long ago", completed_at=PAST)
-    make_todo(db_session, "Done today", completed_at=TODAY_NOON)
+def test_excludes_todos_completed_today(client, make_todo):
+    make_todo("Done long ago", completed_at=PAST)
+    make_todo("Done today", completed_at=TODAY_NOON)
 
     payload = get_completed(client)
 
     assert titles(payload) == ["Done long ago"]
 
 
-def test_excludes_incomplete_todos(client, db_session):
-    make_todo(db_session, "Completed", completed=True, completed_at=PAST)
-    make_todo(db_session, "Still open", completed=False, completed_at=None)
+def test_excludes_incomplete_todos(client, make_todo):
+    make_todo("Completed", completed=True, completed_at=PAST)
+    make_todo("Still open", completed=False, completed_at=None)
 
     payload = get_completed(client)
 
     assert titles(payload) == ["Completed"]
 
 
-def test_includes_completed_todo_with_null_completed_at(client, db_session):
+def test_includes_completed_todo_with_null_completed_at(client, make_todo):
     # Pre-migration data: completed but no completed_at. It is hidden from the
     # current-tasks page, so it must appear here rather than nowhere.
-    make_todo(db_session, "Legacy done", completed=True, completed_at=None)
+    make_todo("Legacy done", completed=True, completed_at=None)
 
     payload = get_completed(client)
 
     assert titles(payload) == ["Legacy done"]
 
 
-def test_filter_unassigned(client, db_session):
-    dad = make_member(db_session, "Dad")
-    make_todo(db_session, "Unassigned task", assigned_to=None)
-    make_todo(db_session, "Dad task", assigned_to=dad.id)
+def test_filter_unassigned(client, make_todo, make_member):
+    dad = make_member("Dad")
+    make_todo("Unassigned task", assigned_to=None)
+    make_todo("Dad task", assigned_to=dad.id)
 
     payload = get_completed(client, assignee="unassigned")
 
@@ -201,24 +164,24 @@ def test_filter_unassigned(client, db_session):
     assert titles(payload) == ["Unassigned task"]
 
 
-def test_filter_single_member(client, db_session):
-    dad = make_member(db_session, "Dad")
-    mom = make_member(db_session, "Mom")
-    make_todo(db_session, "Dad task", assigned_to=dad.id)
-    make_todo(db_session, "Mom task", assigned_to=mom.id)
+def test_filter_single_member(client, make_todo, make_member):
+    dad = make_member("Dad")
+    mom = make_member("Mom")
+    make_todo("Dad task", assigned_to=dad.id)
+    make_todo("Mom task", assigned_to=mom.id)
 
     payload = get_completed(client, assignee=str(dad.id))
 
     assert titles(payload) == ["Dad task"]
 
 
-def test_filter_multiple_members_is_or(client, db_session):
-    dad = make_member(db_session, "Dad")
-    mom = make_member(db_session, "Mom")
-    kid = make_member(db_session, "Kid")
-    make_todo(db_session, "Dad task", assigned_to=dad.id)
-    make_todo(db_session, "Mom task", assigned_to=mom.id)
-    make_todo(db_session, "Kid task", assigned_to=kid.id)
+def test_filter_multiple_members_is_or(client, make_todo, make_member):
+    dad = make_member("Dad")
+    mom = make_member("Mom")
+    kid = make_member("Kid")
+    make_todo("Dad task", assigned_to=dad.id)
+    make_todo("Mom task", assigned_to=mom.id)
+    make_todo("Kid task", assigned_to=kid.id)
 
     payload = get_completed(client, assignee=[str(dad.id), str(mom.id)])
 
@@ -226,20 +189,20 @@ def test_filter_multiple_members_is_or(client, db_session):
     assert set(titles(payload)) == {"Dad task", "Mom task"}
 
 
-def test_default_sort_is_completed_newest(client, db_session):
-    make_todo(db_session, "Older", completed_at=datetime(2021, 1, 1))
-    make_todo(db_session, "Newer", completed_at=datetime(2022, 1, 1))
+def test_default_sort_is_completed_newest(client, make_todo):
+    make_todo("Older", completed_at=datetime(2021, 1, 1))
+    make_todo("Newer", completed_at=datetime(2022, 1, 1))
 
     payload = get_completed(client)
 
     assert titles(payload) == ["Newer", "Older"]
 
 
-def test_pagination_limit_offset_and_has_more(client, db_session):
+def test_pagination_limit_offset_and_has_more(client, make_todo):
     # Distinct completion times so ordering is stable across pages.
     base = datetime(2021, 1, 1)
     for i in range(3):
-        make_todo(db_session, f"Task {i}", completed_at=base + timedelta(days=i))
+        make_todo(f"Task {i}", completed_at=base + timedelta(days=i))
 
     first = get_completed(client, limit=2, offset=0)
     assert len(first["items"]) == 2

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1,0 +1,131 @@
+"""Self-tests for the shared harness fixtures (conftest.py).
+
+These prove the fixtures behave as the rest of the suite will rely on: the seed
+factories persist rows, `frozen_now` freezes time everywhere it matters, the
+timezone setter takes effect, and the external-boundary stubs intercept calls so
+no network happens.
+"""
+
+from datetime import UTC, datetime
+
+from rally.models import DinnerPlan, FamilyMember, RecurringTodo, Setting, Todo
+
+# --- Seed factories ------------------------------------------------------------
+
+
+def test_seed_factories_persist_rows(
+    db_session, make_member, make_todo, make_recurring_todo, make_dinner_plan, make_setting
+):
+    member = make_member("Dad")
+    todo = make_todo("Buy milk", assigned_to=member.id)
+    rt = make_recurring_todo("Water plants", recurrence_type="weekly", recurrence_day=1)
+    dp = make_dinner_plan("2026-02-01", plan="Tacos", rating=5)
+    make_setting("local_timezone", "America/Chicago")
+
+    assert member.id is not None and todo.id is not None
+    assert rt.id is not None and dp.id is not None
+    assert db_session.query(FamilyMember).count() == 1
+    assert db_session.query(Todo).count() == 1
+    assert db_session.query(RecurringTodo).count() == 1
+    assert db_session.query(DinnerPlan).count() == 1
+    assert db_session.get(Setting, "local_timezone").value == "America/Chicago"
+
+
+def test_make_setting_upserts(make_setting, db_session):
+    make_setting("k", "v1")
+    make_setting("k", "v2")
+
+    assert db_session.get(Setting, "k").value == "v2"
+    assert db_session.query(Setting).filter(Setting.key == "k").count() == 1
+
+
+# --- Deterministic time --------------------------------------------------------
+
+
+def test_frozen_now_patches_canonical_and_derived(frozen_now):
+    import rally.utils.timezone as tz
+
+    instant = frozen_now(datetime(2026, 3, 15, 9, 30, tzinfo=UTC))
+
+    assert tz.now_utc() == instant
+    assert tz.today_utc() == instant.date()
+    # today_local resolves now_utc at call time, so it follows the freeze too.
+    assert tz.today_local("America/Chicago") == datetime(2026, 3, 15, 4, 30).date()
+
+
+def test_frozen_now_reaches_by_name_importers(client, make_todo, frozen_now):
+    # todos.py imported now_utc by name; PUT sets completed_at = now_utc() on the
+    # completed transition. If the binding weren't patched, this would use real time.
+    frozen_now(datetime(2026, 3, 15, 9, 30, tzinfo=UTC))
+    todo = make_todo("Reopen me", completed=False, completed_at=None)
+
+    resp = client.put(f"/api/todos/{todo.id}", json={"completed": True})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["completed_at"].startswith("2026-03-15T09:30")
+
+
+# --- Timezone setter -----------------------------------------------------------
+
+
+def test_local_timezone_fixture_sets_setting(client, local_timezone):
+    local_timezone("America/New_York")
+
+    settings = client.get("/api/settings").json()["settings"]
+    assert settings["local_timezone"] == "America/New_York"
+
+
+# --- External boundary stubs ---------------------------------------------------
+
+_DWML = (
+    "<dwml><data type='current observations'><parameters>"
+    "<temperature type='apparent'><value>72</value></temperature>"
+    "<weather><weather-conditions weather-summary='Sunny'/></weather>"
+    "</parameters></data></dwml>"
+)
+
+
+def test_mock_requests_intercepts_weather(client, make_setting, mock_requests):
+    make_setting("weather_nws_url", "https://forecast.example/nws")
+    mock_requests.set_response(text=_DWML, status_code=200)
+
+    resp = client.post("/api/settings/test-weather").json()
+
+    assert resp["success"] is True
+    assert "72" in resp["message"]
+    assert mock_requests.calls[0]["url"] == "https://forecast.example/nws"
+
+
+def test_mock_llm_intercepts_anthropic(client, make_setting, mock_llm):
+    make_setting("llm_provider", "anthropic")
+    make_setting("llm_anthropic_api_key", "sk-test")
+    make_setting("llm_anthropic_model", "claude-test")
+
+    resp = client.post("/api/settings/test-llm").json()
+
+    assert resp["success"] is True
+    assert mock_llm.calls and mock_llm.calls[0][0] == "anthropic"
+
+
+def test_mock_llm_intercepts_openai_local(client, make_setting, mock_llm):
+    make_setting("llm_provider", "local")
+    make_setting("llm_local_base_url", "http://localhost:1234/v1")
+    make_setting("llm_local_model", "local-model")
+
+    resp = client.post("/api/settings/test-llm").json()
+
+    assert resp["success"] is True
+    assert mock_llm.calls and mock_llm.calls[0][0] == "openai"
+
+
+def test_mock_caldav_intercepts_client(mock_caldav):
+    import caldav
+
+    sentinel = object()
+    mock_caldav.set_events([sentinel])
+
+    calendars = caldav.DAVClient(url="https://dav.example").principal().calendars()
+    events = calendars[0].search(event=True)
+
+    assert events == [sentinel]
+    assert ("client", {"url": "https://dav.example"}) in mock_caldav.calls

--- a/uv.lock
+++ b/uv.lock
@@ -126,6 +126,45 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.15.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d0/55fe630f4cf94e3fcba868240fad8c8cdd1f764e2a932f8926347e6ec4cd/coverage-7.15.2.tar.gz", hash = "sha256:3df60dc267f0a2ca23cb7a9ab1109c62b9335ffbf519fcfe167157c28c09b81d", size = 927741, upload-time = "2026-07-15T18:56:19.558Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/5f/aed265fd7a3551a394f36dfe41868aee709b7f95db4052205b4ad1563ac3/coverage-7.15.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f633c5c5fc783732f6312280122e859538fa24461235597c13d803ea9a108a", size = 221650, upload-time = "2026-07-15T18:55:14.527Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/2c/222ba12a545189017120f8eddfc1a0bd4616b47d5d4a8d99421edb2fe4c6/coverage-7.15.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:075560438765b7a2ef43bf7aa7758661b53d889df47f062a31bda6c1ade553a2", size = 221988, upload-time = "2026-07-15T18:55:16.674Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/38/304b5877ab46e6c290b4292cfcf3fe28245f0e5597cad7f6acc91fc7e0a4/coverage-7.15.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:25fd15dd40a0a2c51a500d664ca29053c09c3259d998407bf982b6e114696138", size = 253029, upload-time = "2026-07-15T18:55:18.856Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/58/821b533b8db9e44cf1d8a97bd525149ced40dde1d0093da02cb78e715244/coverage-7.15.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9a6367e4aff723e8ee8190836836124284e8fcd4265e307c844010cfa074f3f", size = 255536, upload-time = "2026-07-15T18:55:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f2/7aa06604c389d32ea7f0a6a988359a7eafc3cd3f8e7bc2e88cd2fdf0b877/coverage-7.15.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9854ca62c152874b2060772503535be2e8f53f70b8aaa7686b094888d872f984", size = 256881, upload-time = "2026-07-15T18:55:23.125Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/4f/1ef342339c7916d0096bc5888cc0f653882cc7bc8f897d5cb89143287c9b/coverage-7.15.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:913b6c56e110da40e035bbd168353bf7aaa2544a5eaccea5d98a4629aac156c7", size = 259196, upload-time = "2026-07-15T18:55:25.099Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f4/7ed055d7a9c5ec13b161773a115a5ccc6b0081d568c31fad830806306cc7/coverage-7.15.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aaccad4129d735a8a4d526f26929894c9a4e8ef7034566f210b176749d6906e3", size = 253036, upload-time = "2026-07-15T18:55:27.018Z" },
+    { url = "https://files.pythonhosted.org/packages/14/79/ea82cca18c242a3a38b6c017da39726aa62dcb64aa635abf79b92009975c/coverage-7.15.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a164b50081fc7357331c4024ef4d17b78ba325f8380d05f5a69599a7e05257ee", size = 254887, upload-time = "2026-07-15T18:55:29.084Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ba/a136db3c0d9562b00e10b72540dbf3a33cd3bc5b95060c9308e247494623/coverage-7.15.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:bfd341ccf78128e72c094bc70cc25b3ef309c33c7c2c66ba3ed4309549e02de1", size = 252852, upload-time = "2026-07-15T18:55:31.184Z" },
+    { url = "https://files.pythonhosted.org/packages/17/17/ea334246b16b7d059953fad6fdefa11e33c68efbd3fe37b1098120a1fac2/coverage-7.15.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1473b3ba8e7ee0f076117b1a72c23f579a2b9e2bb742f48a8d86ea27ca93f91a", size = 257128, upload-time = "2026-07-15T18:55:33.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c3/074fb66d46d607855f710876b117cbda562c5ab08363528e78820449f937/coverage-7.15.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:17c432b5f73ad52ef46fb06019f6fa7c66ce381961cf0f7dfd1d3a4bd3a98145", size = 252668, upload-time = "2026-07-15T18:55:35.063Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c1/f620850ada9b36435921c9a3a8057013422b1d964eb4bf37fe138724d192/coverage-7.15.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:77f0ef5011df53a4bd1b35211ab122287f8d9b8d7aa1c4553e5c2deb24b1d446", size = 254325, upload-time = "2026-07-15T18:55:37.125Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/31/a729ca3689404493af82ef8e6ff70bd88bdda8da89aeef6ca9b387aeb2b4/coverage-7.15.2-cp314-cp314-win32.whl", hash = "sha256:f653e5d7248c1191ec988a85c72edeab46c3ff44f90639a4ed4874ec0be90243", size = 223844, upload-time = "2026-07-15T18:55:39.078Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/83/5d809dc808fb1698c671f3e372259bb9158e64b7ea526fc6ab7de64de9fe/coverage-7.15.2-cp314-cp314-win_amd64.whl", hash = "sha256:9911f31aad8906abe337c271343485cf20df5e70df5d2f57f9f136e7b55f26bc", size = 224331, upload-time = "2026-07-15T18:55:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/16/4e/35e488548e952795829e129995c4174df33bf432b591d1aa42c8d9e4e7ad/coverage-7.15.2-cp314-cp314-win_arm64.whl", hash = "sha256:e38def96ad59853824c97953fdcd2c320a84ba3ce99b417db78af8bb6c3db635", size = 223760, upload-time = "2026-07-15T18:55:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/49/dd2c86cd6374038f6e415fb5bfb86db5218553209c081384a020369dee79/coverage-7.15.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:835ec4e20b45f0a7f63ed78f94065aca00de033403df8377bfe8b9c6abc0a7be", size = 222384, upload-time = "2026-07-15T18:55:45.569Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/173ff17a1c0808e5a438f549f6f145d5ac7528f2791310b63523e3200ac7/coverage-7.15.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7466cc7ab6dc0db871d264bf99e8779f0917ee63d40730af0552f71535a6e072", size = 222647, upload-time = "2026-07-15T18:55:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f8/b8cba872162356fb44ac79c10309d987206a4461e32072fc29228dad7331/coverage-7.15.2-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e370c12133095ff18432de8c044962be85a5a96d90c6fcbce8e17e76236d2328", size = 264013, upload-time = "2026-07-15T18:55:49.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/67/a807a7586d0b8cae485308ddd55756f0806c92f8e0b411bacbf23c48edf3/coverage-7.15.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fe41909c9515c3bfdb5f02c4d1f857dba322d9a9a1178069b91eea77889df63a", size = 266135, upload-time = "2026-07-15T18:55:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/cd78771dc985f7e4ebdcc82b1a96d9a932af9e806f01f2f91a89f4c72e80/coverage-7.15.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6aa28cfb6488e5453b5b762d65f73aa586380f6693a04d58078ce228a29b06c0", size = 268555, upload-time = "2026-07-15T18:55:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3e/10134cf81275188c58568f324fc74aedff32c63ca4d5bbc513a91944a6f0/coverage-7.15.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcc0aae933921d03096f53b0b03eeb702129fd406dee59f08d2efacc68681fa5", size = 269674, upload-time = "2026-07-15T18:55:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/771b77de446cba985dc414bbc5844bd21604da05dbc044286df8318a48a7/coverage-7.15.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7c63387e21ab21f512c69c9756a8c7dadd322c7275edb064064433c9a09c3743", size = 263101, upload-time = "2026-07-15T18:55:58.107Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b5/70a7011da15f4071943361183aefa27847f3e3aec4fd335f1cb3d3a622b1/coverage-7.15.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e55510bc98ae943cece9e667a6c0fe94c6a92913720dea34243657a17993d0c", size = 266007, upload-time = "2026-07-15T18:56:00.468Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/f9547e804ce7ad49646ffeffac26699510efbe6c0f751b66fdc960c4e825/coverage-7.15.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2ff08701be2d1556fc78b326c80a3e8042da09352ecb3819105f8e386c8a3071", size = 263611, upload-time = "2026-07-15T18:56:02.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/59/f576a396659c0efd351f5c1544f67c3560e89c7761cabf7f65e412beeda5/coverage-7.15.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:38c9518b7103826c403a461544e3c2e77151e8676d06eaed85911a97e962584a", size = 267344, upload-time = "2026-07-15T18:56:04.622Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/5d/c2e4fce3579c0cb635024293f1a32bbe26df101b3e3a69f22243d1352b6c/coverage-7.15.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:dee88b1ed88587abd8c0269a1fc1f4cc77f7750d1dfde2869e2a123af420e67d", size = 262456, upload-time = "2026-07-15T18:56:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/956287d69436b66094bc4b57ac2da71e43bfd2a5524e958900b9f582fcf8/coverage-7.15.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fbeeeecea279727f8ac16c8e1133ddfeee793e985c86ae343d6a5ce744eef8c", size = 264771, upload-time = "2026-07-15T18:56:08.795Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5a/6f979530c2734c575de77cf58f5f28d51f7123a94b5030fd9156fe5f363c/coverage-7.15.2-cp314-cp314t-win32.whl", hash = "sha256:cb0fddaa6884be6aae36ced9544b5e90f7d5f03845a2853bf47a14953a4e8688", size = 224151, upload-time = "2026-07-15T18:56:10.856Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7e/27f6b2a74d484742f4017553e710b01e396b23d809df3e95ca0bb9a2824b/coverage-7.15.2-cp314-cp314t-win_amd64.whl", hash = "sha256:77f091ea3a9cc611cd29f433565476bc1936c084ac8eee00ea0e7e70c27e4199", size = 224981, upload-time = "2026-07-15T18:56:12.928Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/48/284863423aa474240f6842bd00d680da22f4e6ea2e466618ef7c9c9e69a9/coverage-7.15.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6fc448c377d6eeb00a47c673494bd9bae29280ca53987e1869e67ebedfe20658", size = 224294, upload-time = "2026-07-15T18:56:15.156Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/82/32e3bd191d498e64f6f911ad55d14006a0861e54869d2d32452326399e65/coverage-7.15.2-py3-none-any.whl", hash = "sha256:eb6bcae8d1a9d305351ecb108232441d11c5cfe9de840a04388ba5d2db8d735c", size = 213375, upload-time = "2026-07-15T18:56:17.305Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -731,6 +770,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -846,6 +899,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -864,7 +918,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.0" }]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-cov", specifier = ">=5.0" },
+]
 
 [[package]]
 name = "recurring-ical-events"


### PR DESCRIPTION
## Summary

**Phase 0** of the test-coverage expansion ([milestone](https://github.com/pid1/rally/milestone/1)). Extends the harness so later phases can seed data, control time, and stub external services without touching the network. Implements #94.

## Changes

**Seed factories** (fixtures in `tests/conftest.py`)
- `make_member`, `make_todo`, `make_recurring_todo`, `make_dinner_plan`, `make_setting` — each returns a callable with per-call overrides that commits and refreshes.
- Promotes the local helpers out of `tests/test_completed_todos.py` and refactors that file to use the shared fixtures.

**`frozen_now`**
- Freezes `rally.utils.timezone.now_utc` to a chosen instant. `today_utc`/`today_local` resolve `now_utc` at call time (covered by patching the canonical function); the five modules that import `now_utc` **by name** and call it directly are patched individually. Column defaults (`default=now_utc`) capture the function at class-definition time and are intentionally not affected — seed timestamps explicitly when they matter.

**`local_timezone`**
- Sets the `local_timezone` setting (non-UTC default) so timezone-dependent paths are actually exercised.

**External-boundary stubs**
- `mock_requests` (`requests.get`), `mock_llm` (`anthropic.Anthropic` / `openai.OpenAI`), `mock_caldav` (`caldav.DAVClient`). Each records calls and returns canned payloads; all patch the module attribute, which works because the app reaches these via lazy in-function imports.

**Coverage reporting**
- Adds `pytest-cov` (dev dep) + `[tool.coverage.run]` config; CI runs `pytest --cov=rally --cov-report=term-missing --cov-report=xml`; coverage artifacts gitignored. No hard gate yet — this establishes the baseline.

**`tests/test_harness.py`**
- Self-tests validating every fixture end-to-end (seed factories persist, `frozen_now` reaches the by-name importers via the todos `PUT` path, the timezone setter takes effect, and each external stub intercepts its boundary).

## Testing

- **25 passed** (16 refactored completed-todos tests + 9 harness self-tests).
- `ruff check` and `ruff format --check` pass; `uv.lock` regenerated for `pytest-cov`.
- **Baseline coverage: 30%** — the measurement point Phase 0 was meant to establish. The report already highlights the high-yield targets for later phases (`recurrence.py` and `generate.py` at 7%).

Closes #94
EOF
