### PR TITLE
Add PR template and PR-format guidance for agents

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+<!--
+One short paragraph: what this PR changes and why. Note any existing behavior it
+modifies and what is preserved or unaffected.
+-->
+
+## Changes
+
+<!--
+Bulleted list of the concrete changes, grouped by area (backend / frontend /
+config / tests) when that helps. Wrap identifiers, file paths, option names, and
+labels in `backticks`.
+-->
+
+## Notes for reviewers
+
+<!--
+Optional. Anything non-obvious: design decisions, trade-offs, follow-ups
+deliberately deferred, or areas that need extra scrutiny. Delete this section if
+there is nothing to add.
+-->
+
+## Testing
+
+<!--
+How the change was verified: tests added/run, coverage delta, manual checks.
+State failures honestly — if something wasn't run or is still failing, say so.
+-->
+
+<!-- Link the issue this resolves so it auto-closes on merge (e.g. "Closes #12"). -->
+Closes #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,38 @@ logs-tail
 # Not logs (that follows and blocks)
 ```
 
+### 7. Pull Request Format
+
+Open PRs with `gh pr create` and follow the template at
+`.github/pull_request_template.md`. **`gh pr create` does not auto-apply the
+template**, so fill the sections in yourself and pass them with `--body-file`.
+
+Every PR body must have these sections (in this order):
+
+- **Summary** — one short paragraph on what changes and why.
+- **Changes** — a bulleted list of the concrete changes, grouped by area
+  (backend / frontend / config / tests) when helpful; identifiers and paths in
+  `backticks`.
+- **Notes for reviewers** — *optional*; non-obvious decisions, trade-offs, or
+  follow-ups deliberately deferred. Omit the section when there is nothing to add.
+- **Testing** — what was run and verified (tests, coverage delta, manual checks),
+  stated honestly.
+- **Closes #\<issue\>** — the issue this resolves, so it auto-closes on merge.
+
+Workflow conventions:
+
+- Write a concise, imperative title that summarizes the change.
+- Open as a **draft** (`gh pr create --draft`) and mark it ready
+  (`gh pr ready <n>`) only once CI is green.
+- Apply the appropriate label (`enhancement`, `bug`, `documentation`, …), assign
+  the author, and set the milestone when the work belongs to one.
+- Run the test suite before opening (see the testing note below); PR CI runs
+  `pytest`, `ruff check`, and `ruff format --check` and must pass.
+
+> **Running the suite:** tests run under the project's Python 3.14 env, so use
+> `uv run pytest` (or `.devenv/state/venv/bin/pytest`) — a bare `pytest` may be
+> shadowed by another interpreter on your `PATH` and fail to import.
+
 ## Example Workflows
 
 ### Setting Up Development Environment


### PR DESCRIPTION
## Summary

Codifies the pull-request format used across the test-coverage work (Phases 0–4) so future contributors — and agents — follow it consistently. No application code changes.

## Changes

- **`.github/pull_request_template.md`** (new) — the canonical PR structure with guidance comments: **Summary**, **Changes**, **Notes for reviewers** (optional), **Testing**, and **Closes #\<issue\>**.
- **`AGENTS.md`** — new rule **"7. Pull Request Format"** under *For AI Agents* that points at the template and spells out:
  - the required body sections,
  - that `gh pr create` does **not** auto-apply the template (fill sections in and pass via `--body-file`),
  - the draft-then-ready workflow, label/assignee/milestone conventions, and
  - the `uv run pytest` note (a bare `pytest` can be shadowed by another interpreter on `PATH`).

## Notes for reviewers

- The GitHub template benefits human contributors (auto-populated in the PR form); the `AGENTS.md` rule is what makes agents "always" follow it, since `gh` overrides the template when a body is supplied.

## Testing

- No code changed; the suite is unaffected. CI (`pytest`, `ruff check`, `ruff format --check`) runs on this PR and should pass.

Closes #107
