### PR TITLE
Test coverage — Phase 5: family/dinner_planner CRUD + connectivity tests

### DIFF
--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -1,0 +1,220 @@
+"""Tests for the connectivity-test endpoints using the external-boundary stubs.
+
+Covers POST /api/settings/test-llm, /api/settings/test-weather, and
+/api/calendars/{id}/test — none of which touch the network here.
+"""
+
+_DWML = (
+    "<dwml><data type='current observations'><parameters>"
+    "<temperature type='apparent'><value>72</value></temperature>"
+    "<weather><weather-conditions weather-summary='Sunny'/></weather>"
+    "</parameters></data></dwml>"
+)
+
+
+def _make_calendar(client, member_id, **overrides):
+    payload = {"label": "Cal", "url": "https://ex/c.ics", "family_member_id": member_id}
+    payload.update(overrides)
+    resp = client.post("/api/calendars", json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# --- test-llm ------------------------------------------------------------------
+
+
+def test_llm_anthropic_success(client, make_setting, mock_llm):
+    make_setting("llm_provider", "anthropic")
+    make_setting("llm_anthropic_api_key", "sk-test")
+    make_setting("llm_anthropic_model", "claude-x")
+
+    body = client.post("/api/settings/test-llm").json()
+
+    assert body["success"] is True
+    assert "claude-x" in body["message"]
+    assert mock_llm.calls[0][0] == "anthropic"
+
+
+def test_llm_local_success(client, make_setting, mock_llm):
+    make_setting("llm_provider", "local")
+    make_setting("llm_local_base_url", "http://localhost:1234/v1")
+    make_setting("llm_local_model", "llama")
+
+    body = client.post("/api/settings/test-llm").json()
+
+    assert body["success"] is True
+    assert mock_llm.calls[0][0] == "openai"
+
+
+def test_llm_missing_config_returns_failure(client, make_setting):
+    make_setting("llm_provider", "anthropic")  # no key/model
+
+    body = client.post("/api/settings/test-llm").json()
+
+    assert body["success"] is False
+    assert "Missing" in body["error"]
+
+
+def test_llm_local_missing_config_returns_failure(client, make_setting):
+    make_setting("llm_provider", "local")  # no base URL / model
+
+    body = client.post("/api/settings/test-llm").json()
+
+    assert body["success"] is False
+    assert "Missing" in body["error"]
+
+
+def test_llm_client_error_returns_failure(client, make_setting, monkeypatch):
+    make_setting("llm_provider", "anthropic")
+    make_setting("llm_anthropic_api_key", "sk-test")
+    make_setting("llm_anthropic_model", "claude-x")
+
+    import anthropic
+
+    class Boom:
+        def __init__(self, **kwargs):
+            raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(anthropic, "Anthropic", Boom)
+
+    body = client.post("/api/settings/test-llm").json()
+
+    assert body["success"] is False
+    assert "connection refused" in body["error"]
+
+
+# --- test-weather --------------------------------------------------------------
+
+
+def test_weather_success(client, make_setting, mock_requests):
+    make_setting("weather_nws_url", "https://forecast.example/nws")
+    mock_requests.set_response(text=_DWML, status_code=200)
+
+    body = client.post("/api/settings/test-weather").json()
+
+    assert body["success"] is True
+    assert "72" in body["message"]
+
+
+def test_weather_missing_url(client):
+    body = client.post("/api/settings/test-weather").json()
+    assert body["success"] is False
+    assert "Missing" in body["error"]
+
+
+def test_weather_non_dwml_document(client, make_setting, mock_requests):
+    make_setting("weather_nws_url", "https://forecast.example/nws")
+    mock_requests.set_response(text="<html>nope</html>", status_code=200)
+
+    body = client.post("/api/settings/test-weather").json()
+
+    assert body["success"] is False
+    assert "DWML" in body["error"]
+
+
+def test_weather_unparseable_xml(client, make_setting, mock_requests):
+    make_setting("weather_nws_url", "https://forecast.example/nws")
+    mock_requests.set_response(text="not xml <<<", status_code=200)
+
+    body = client.post("/api/settings/test-weather").json()
+
+    assert body["success"] is False
+    assert "DWML" in body["error"]
+
+
+def test_weather_request_error_returns_failure(client, make_setting, mock_requests):
+    make_setting("weather_nws_url", "https://forecast.example/nws")
+    mock_requests.set_response(status_code=500)  # raise_for_status -> HTTPError
+
+    body = client.post("/api/settings/test-weather").json()
+
+    assert body["success"] is False
+
+
+# --- calendars/{id}/test -------------------------------------------------------
+
+
+def test_calendar_test_ics_success(client, make_member, mock_requests):
+    member = make_member("Dad")
+    cal = _make_calendar(client, member.id, cal_type="ics")
+    mock_requests.set_response(text="BEGIN:VCALENDAR\nVERSION:2.0\nEND:VCALENDAR", status_code=200)
+
+    body = client.post(f"/api/calendars/{cal['id']}/test").json()
+
+    assert body["success"] is True
+
+
+def test_calendar_test_ics_invalid_body(client, make_member, mock_requests):
+    member = make_member("Dad")
+    cal = _make_calendar(client, member.id, cal_type="ics")
+    mock_requests.set_response(text="not a calendar", status_code=200)
+
+    body = client.post(f"/api/calendars/{cal['id']}/test").json()
+
+    assert body["success"] is False
+
+
+def test_calendar_test_caldav_success(client, make_member, mock_caldav):
+    member = make_member("Dad")
+    cal = _make_calendar(
+        client,
+        member.id,
+        url="https://dav.example",
+        cal_type="caldav_apple",
+        username="user",
+        password="secret",
+    )
+
+    body = client.post(f"/api/calendars/{cal['id']}/test").json()
+
+    assert body["success"] is True
+    assert "1 calendar" in body["message"]  # FakePrincipal returns one calendar
+
+
+def test_calendar_test_caldav_missing_credentials(client, make_member):
+    member = make_member("Dad")
+    cal = _make_calendar(client, member.id, cal_type="caldav_apple")  # no username/password
+
+    body = client.post(f"/api/calendars/{cal['id']}/test").json()
+
+    assert body["success"] is False
+    assert "credentials" in body["error"].lower()
+
+
+def test_calendar_test_unknown_type(client, make_member):
+    member = make_member("Dad")
+    cal = _make_calendar(client, member.id, cal_type="mystery")
+
+    body = client.post(f"/api/calendars/{cal['id']}/test").json()
+
+    assert body["success"] is False
+    assert "Unknown calendar type" in body["error"]
+
+
+def test_calendar_test_caldav_error_returns_failure(client, make_member, monkeypatch):
+    member = make_member("Dad")
+    cal = _make_calendar(
+        client,
+        member.id,
+        url="https://dav.example",
+        cal_type="caldav_apple",
+        username="user",
+        password="secret",
+    )
+
+    import caldav
+
+    class Boom:
+        def __init__(self, **kwargs):
+            raise RuntimeError("dav down")
+
+    monkeypatch.setattr(caldav, "DAVClient", Boom)
+
+    body = client.post(f"/api/calendars/{cal['id']}/test").json()
+
+    assert body["success"] is False
+    assert "dav down" in body["error"]
+
+
+def test_calendar_test_404(client):
+    assert client.post("/api/calendars/9999/test").status_code == 404

--- a/tests/test_dinner_planner.py
+++ b/tests/test_dinner_planner.py
@@ -1,0 +1,232 @@
+"""Tests for the dinner/meal planner router: CRUD, reviews, meal history, and
+the meal-type sort order, plus the DB-level rating check constraint.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from rally.models import DinnerPlan
+
+
+def _create(client, date="2026-05-01", **fields):
+    payload = {"date": date, "plan": "A meal"}
+    payload.update(fields)
+    resp = client.post("/api/dinner-plans", json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# --- CRUD ----------------------------------------------------------------------
+
+
+def test_create_defaults_meal_type_dinner(client):
+    body = _create(client, plan="Tacos")
+    assert body["meal_type"] == "Dinner"
+    assert body["plan"] == "Tacos"
+    assert body["date"] == "2026-05-01"
+
+
+def test_create_with_attendees_and_cook(client, make_member):
+    dad = make_member("Dad")
+    mom = make_member("Mom")
+
+    body = _create(client, meal_type="Lunch", attendee_ids=[dad.id, mom.id], cook_id=dad.id)
+
+    assert body["meal_type"] == "Lunch"
+    assert body["attendee_ids"] == [dad.id, mom.id]
+    assert body["cook_id"] == dad.id
+
+
+def test_list_ordered_by_date_then_meal_type(client):
+    _create(client, date="2026-05-01", meal_type="Dinner")
+    _create(client, date="2026-05-01", meal_type="Breakfast")
+    _create(client, date="2026-04-30", meal_type="Lunch")
+
+    got = [(p["date"], p["meal_type"]) for p in client.get("/api/dinner-plans").json()]
+
+    assert got == [
+        ("2026-04-30", "Lunch"),
+        ("2026-05-01", "Breakfast"),
+        ("2026-05-01", "Dinner"),
+    ]
+
+
+def test_get_by_date_ordered_by_meal_type(client):
+    _create(client, date="2026-05-01", meal_type="Dinner")
+    _create(client, date="2026-05-01", meal_type="Breakfast")
+    _create(client, date="2026-05-02", meal_type="Dinner")
+
+    types = [p["meal_type"] for p in client.get("/api/dinner-plans/date/2026-05-01").json()]
+
+    assert types == ["Breakfast", "Dinner"]
+
+
+def test_get_found_and_404(client):
+    plan = _create(client)
+    assert client.get(f"/api/dinner-plans/{plan['id']}").json()["id"] == plan["id"]
+    assert client.get("/api/dinner-plans/9999").status_code == 404
+
+
+def test_update_unset_semantics(client, make_member):
+    dad = make_member("Dad")
+    plan = _create(client, cook_id=dad.id, attendee_ids=[dad.id])
+
+    # Omitted -> untouched.
+    body = client.put(f"/api/dinner-plans/{plan['id']}", json={"plan": "New"}).json()
+    assert body["plan"] == "New"
+    assert body["cook_id"] == dad.id
+    assert body["attendee_ids"] == [dad.id]
+
+    # Explicit null -> cleared.
+    body = client.put(
+        f"/api/dinner-plans/{plan['id']}", json={"cook_id": None, "attendee_ids": None}
+    ).json()
+    assert body["cook_id"] is None
+    assert body["attendee_ids"] is None
+
+
+def test_update_date_and_meal_type(client):
+    plan = _create(client, date="2026-05-01", meal_type="Dinner")
+
+    body = client.put(
+        f"/api/dinner-plans/{plan['id']}", json={"date": "2026-06-01", "meal_type": "Lunch"}
+    ).json()
+
+    assert body["date"] == "2026-06-01"
+    assert body["meal_type"] == "Lunch"
+
+
+def test_update_404(client):
+    assert client.put("/api/dinner-plans/9999", json={"plan": "x"}).status_code == 404
+
+
+def test_delete_and_404(client, db_session):
+    plan = _create(client)
+
+    assert client.delete(f"/api/dinner-plans/{plan['id']}").status_code == 204
+    assert db_session.get(DinnerPlan, plan["id"]) is None
+
+    assert client.delete("/api/dinner-plans/9999").status_code == 404
+
+
+# --- Reviews -------------------------------------------------------------------
+
+
+def test_review_sets_rating_and_text(client):
+    plan = _create(client)
+
+    body = client.put(
+        f"/api/dinner-plans/{plan['id']}/review", json={"rating": 5, "review": "Great"}
+    ).json()
+
+    assert body["rating"] == 5
+    assert body["review"] == "Great"
+
+
+@pytest.mark.parametrize("bad", [0, 6, -1, 99])
+def test_review_rating_out_of_range_422(client, bad):
+    plan = _create(client)
+    resp = client.put(f"/api/dinner-plans/{plan['id']}/review", json={"rating": bad})
+    assert resp.status_code == 422
+
+
+def test_review_clear_rating_via_null(client):
+    plan = _create(client)
+    client.put(f"/api/dinner-plans/{plan['id']}/review", json={"rating": 4})
+
+    body = client.put(f"/api/dinner-plans/{plan['id']}/review", json={"rating": None}).json()
+
+    assert body["rating"] is None
+
+
+def test_review_omitting_rating_leaves_it(client):
+    plan = _create(client)
+    client.put(f"/api/dinner-plans/{plan['id']}/review", json={"rating": 4})
+
+    # Omit rating, set review only -> rating stays.
+    body = client.put(f"/api/dinner-plans/{plan['id']}/review", json={"review": "ok"}).json()
+
+    assert body["rating"] == 4
+    assert body["review"] == "ok"
+
+
+def test_review_clear_review_via_null(client):
+    plan = _create(client)
+    client.put(f"/api/dinner-plans/{plan['id']}/review", json={"review": "tasty"})
+
+    body = client.put(f"/api/dinner-plans/{plan['id']}/review", json={"review": None}).json()
+
+    assert body["review"] is None
+
+
+def test_review_404(client):
+    assert client.put("/api/dinner-plans/9999/review", json={"rating": 5}).status_code == 404
+
+
+# --- Meal history --------------------------------------------------------------
+
+TODAY = datetime(2026, 5, 10, 12, tzinfo=UTC)
+
+
+def test_history_filters_past_only_and_rating_desc(client, make_dinner_plan, frozen_now):
+    frozen_now(TODAY)
+    make_dinner_plan("2026-05-01", plan="A", rating=5)
+    make_dinner_plan("2026-05-02", plan="B", rating=3)
+    make_dinner_plan("2026-05-03", plan="C", rating=None)
+    make_dinner_plan("2026-05-10", plan="Today", rating=5)  # not before today -> excluded
+    make_dinner_plan("2026-05-15", plan="Future", rating=5)  # excluded
+
+    hist = client.get("/api/dinner-plans/history").json()  # default rating_desc
+
+    assert [(p["date"], p["rating"]) for p in hist] == [
+        ("2026-05-01", 5),
+        ("2026-05-02", 3),
+        ("2026-05-03", None),  # nulls last
+    ]
+
+
+def test_history_min_rating_filter(client, make_dinner_plan, frozen_now):
+    frozen_now(TODAY)
+    make_dinner_plan("2026-05-01", plan="A", rating=5)
+    make_dinner_plan("2026-05-02", plan="B", rating=2)
+
+    hist = client.get("/api/dinner-plans/history", params={"min_rating": 3}).json()
+
+    assert [p["date"] for p in hist] == ["2026-05-01"]
+
+
+def test_history_sort_date_asc_and_desc(client, make_dinner_plan, frozen_now):
+    frozen_now(TODAY)
+    make_dinner_plan("2026-05-01", plan="A", rating=1)
+    make_dinner_plan("2026-05-05", plan="B", rating=1)
+
+    asc = client.get("/api/dinner-plans/history", params={"sort": "date_asc"}).json()
+    desc = client.get("/api/dinner-plans/history", params={"sort": "date_desc"}).json()
+
+    assert [p["date"] for p in asc] == ["2026-05-01", "2026-05-05"]
+    assert [p["date"] for p in desc] == ["2026-05-05", "2026-05-01"]
+
+
+def test_history_respects_local_timezone(client, make_dinner_plan, frozen_now, local_timezone):
+    # At 02:00Z the local date in Kolkata (+05:30) is already the next day, so a
+    # plan dated that local day counts as "today" and is excluded from history.
+    frozen_now(datetime(2026, 5, 10, 2, 0, tzinfo=UTC))
+    local_timezone("Asia/Kolkata")  # local date is 2026-05-10
+    make_dinner_plan("2026-05-09", plan="Yesterday", rating=4)
+    make_dinner_plan("2026-05-10", plan="LocalToday", rating=4)
+
+    dates = [p["date"] for p in client.get("/api/dinner-plans/history").json()]
+
+    assert dates == ["2026-05-09"]
+
+
+# --- DB-level rating constraint ------------------------------------------------
+
+
+def test_rating_check_constraint_rejects_out_of_range(db_session):
+    db_session.add(DinnerPlan(date="2026-05-01", plan="X", rating=6))
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()

--- a/tests/test_family.py
+++ b/tests/test_family.py
@@ -1,0 +1,57 @@
+"""Tests for the family members router — straightforward CRUD + ordering."""
+
+from rally.models import FamilyMember
+
+
+def test_create_defaults_color(client):
+    body = client.post("/api/family", json={"name": "Dad"}).json()
+    assert body["name"] == "Dad"
+    assert body["color"] == "#333333"
+    assert body["id"] > 0
+
+
+def test_create_with_color(client):
+    body = client.post("/api/family", json={"name": "Mom", "color": "#ff0000"}).json()
+    assert body["color"] == "#ff0000"
+
+
+def test_list_ordered_by_name(client):
+    client.post("/api/family", json={"name": "Zoe"})
+    client.post("/api/family", json={"name": "Amy"})
+
+    names = [m["name"] for m in client.get("/api/family").json()]
+
+    assert names == ["Amy", "Zoe"]
+
+
+def test_get_found_and_404(client):
+    member = client.post("/api/family", json={"name": "Dad"}).json()
+
+    assert client.get(f"/api/family/{member['id']}").json()["id"] == member["id"]
+    assert client.get("/api/family/9999").status_code == 404
+
+
+def test_update_fields(client):
+    member = client.post("/api/family", json={"name": "Dad", "color": "#111111"}).json()
+
+    body = client.put(
+        f"/api/family/{member['id']}", json={"name": "Daddy", "color": "#222222"}
+    ).json()
+
+    assert body["name"] == "Daddy"
+    assert body["color"] == "#222222"
+
+
+def test_update_404(client):
+    assert client.put("/api/family/9999", json={"name": "x"}).status_code == 404
+
+
+def test_delete(client, db_session):
+    member = client.post("/api/family", json={"name": "Dad"}).json()
+
+    assert client.delete(f"/api/family/{member['id']}").status_code == 204
+    assert db_session.get(FamilyMember, member["id"]) is None
+
+
+def test_delete_404(client):
+    assert client.delete("/api/family/9999").status_code == 404


### PR DESCRIPTION
## Summary

**Phase 5** of the test-coverage expansion ([milestone](https://github.com/pid1/rally/milestone/1)). Covers the remaining CRUD routers (family, dinner planner) and the connectivity-test endpoints, the latter driven by the external-boundary stubs so no test touches the network. Implements #99.

## Changes

- **`tests/test_family.py`** — full CRUD + 404s + name ordering → `family.py` **100%**.
- **`tests/test_dinner_planner.py`** — CRUD; `UNSET` partial-update semantics; reviews (set, out-of-range **422** parametrized over `[0, 6, -1, 99]`, clear-vs-omit for both rating and review); meal `/history` date filter (`frozen_now` + a non-UTC `local_timezone` boundary case), `min_rating`, and all three sort modes; meal-type case ordering; and the **DB-level rating `CheckConstraint`** (1–5) → `dinner_planner.py` **100%**.
- **`tests/test_connectivity.py`** — the three connectivity endpoints via the Phase 0 mock fixtures:
  - `test-llm` (anthropic/local success, missing config, client error) via `mock_llm`;
  - `test-weather` (success + missing-URL / non-DWML / unparseable / request-error branches) via `mock_requests`;
  - `calendars/{id}/test` (ICS ok/invalid, CalDAV ok/missing-creds/error, unknown type, 404) via `mock_requests` / `mock_caldav`.

  These push `settings.py` to **100%**.

## Notes for reviewers

- This is the first phase to exercise the `mock_requests` / `mock_llm` / `mock_caldav` fixtures against real endpoints, confirming the Phase 0 external-boundary design holds end-to-end.
- All three routers touched (`family`, `dinner_planner`, `settings`) are now at 100% coverage.
- First PR to follow the template merged in #106.

## Testing

- **172 passed** across the full suite; `ruff check` and `ruff format --check` clean.
- Total coverage **47% → 64%**.

Closes #99
