### PR TITLE
Test coverage — Phase 6: pages, dashboard, utils, cli, caldav_client

### DIFF
--- a/tests/test_caldav_client.py
+++ b/tests/test_caldav_client.py
@@ -1,0 +1,129 @@
+"""Tests for the CalDAV client: declined-event detection, event parsing, and the
+Google/Apple fetch wrappers (with caldav.DAVClient stubbed)."""
+
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
+from icalendar import Event, vCalAddress
+
+from rally.caldav_client import (
+    _is_event_declined,
+    _parse_caldav_events,
+    fetch_apple_caldav,
+    fetch_google_caldav,
+)
+
+_ICS = (
+    b"BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\n"
+    b"SUMMARY:Meeting\r\nDTSTART:20260315T100000Z\r\n"
+    b"END:VEVENT\r\nEND:VCALENDAR"
+)
+_ICS_CANCELLED = (
+    b"BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\n"
+    b"SUMMARY:Dead\r\nDTSTART:20260315T100000Z\r\nSTATUS:CANCELLED\r\n"
+    b"END:VEVENT\r\nEND:VCALENDAR"
+)
+
+
+def _attendee(email, partstat=None):
+    addr = vCalAddress(f"mailto:{email}")
+    if partstat:
+        addr.params["PARTSTAT"] = partstat
+    return addr
+
+
+# --- _is_event_declined --------------------------------------------------------
+
+
+def test_declined_when_cancelled():
+    ev = Event()
+    ev.add("status", "CANCELLED")
+    assert _is_event_declined(ev) is True
+
+
+def test_declined_when_owner_partstat_declined():
+    ev = Event()
+    ev.add("attendee", _attendee("me@example.com", "DECLINED"))
+    assert _is_event_declined(ev, owner_email="me@example.com") is True
+
+
+def test_declined_when_all_attendees_declined():
+    ev = Event()
+    ev.add("attendee", _attendee("a@example.com", "DECLINED"))
+    ev.add("attendee", _attendee("b@example.com", "DECLINED"))
+    assert _is_event_declined(ev) is True
+
+
+def test_not_declined_when_accepted():
+    ev = Event()
+    ev.add("attendee", _attendee("a@example.com", "ACCEPTED"))
+    assert _is_event_declined(ev) is False
+
+
+# --- _parse_caldav_events ------------------------------------------------------
+
+
+class _FakeItem:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeCalendar:
+    def __init__(self, items, name="Cal"):
+        self._items = items
+        self.name = name
+
+    def search(self, **kwargs):
+        return self._items
+
+
+class _FakeClient:
+    def __init__(self, calendars):
+        self._calendars = calendars
+
+    def principal(self):
+        return SimpleNamespace(calendars=lambda: self._calendars)
+
+
+def test_parse_returns_event_dicts():
+    client = _FakeClient([_FakeCalendar([_FakeItem(_ICS)])])
+
+    events = _parse_caldav_events(client, ZoneInfo("UTC"))
+
+    assert len(events) == 1
+    assert events[0]["summary"] == "Meeting"
+    assert events[0]["date"] == "2026-03-15"
+
+
+def test_parse_skips_declined_events():
+    client = _FakeClient([_FakeCalendar([_FakeItem(_ICS_CANCELLED)])])
+    assert _parse_caldav_events(client, ZoneInfo("UTC")) == []
+
+
+# --- fetch wrappers ------------------------------------------------------------
+
+
+def test_fetch_google_missing_credentials_returns_empty():
+    record = SimpleNamespace(username=None, password=None, label="G", url=None, owner_email=None)
+    assert fetch_google_caldav(record, ZoneInfo("UTC")) == []
+
+
+def test_fetch_apple_missing_credentials_returns_empty():
+    record = SimpleNamespace(username=None, password=None, label="A", url=None, owner_email=None)
+    assert fetch_apple_caldav(record, ZoneInfo("UTC")) == []
+
+
+def test_fetch_google_success(monkeypatch):
+    import caldav
+
+    monkeypatch.setattr(
+        caldav, "DAVClient", lambda **kwargs: _FakeClient([_FakeCalendar([_FakeItem(_ICS)])])
+    )
+    record = SimpleNamespace(
+        username="user", password="secret", label="G", url="https://dav.example", owner_email=None
+    )
+
+    events = fetch_google_caldav(record, ZoneInfo("UTC"))
+
+    assert len(events) == 1
+    assert events[0]["summary"] == "Meeting"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,61 @@
+"""Tests for the seed CLI: it populates sample data and is idempotent."""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from rally import cli
+from rally.database import Base
+from rally.models import Calendar, DashboardSnapshot, DinnerPlan, FamilyMember, Setting, Todo
+
+EXPECTED_COUNTS = {
+    "family": 4,
+    "calendars": 3,
+    "settings": 5,
+    "todos": 6,
+    "dinner": 6,
+    "snapshots": 1,
+}
+
+
+@pytest.fixture
+def cli_db(monkeypatch):
+    """Point cli.SessionLocal at an isolated in-memory DB and stub init_db."""
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    Base.metadata.create_all(bind=engine)
+    testing_session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    monkeypatch.setattr(cli, "SessionLocal", testing_session_local)
+    monkeypatch.setattr(cli, "init_db", lambda: None)
+    session = testing_session_local()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+def _counts(session):
+    return {
+        "family": session.query(FamilyMember).count(),
+        "calendars": session.query(Calendar).count(),
+        "settings": session.query(Setting).count(),
+        "todos": session.query(Todo).count(),
+        "dinner": session.query(DinnerPlan).count(),
+        "snapshots": session.query(DashboardSnapshot).count(),
+    }
+
+
+def test_seed_populates_sample_data(cli_db):
+    cli.seed()
+    assert _counts(cli_db) == EXPECTED_COUNTS
+
+
+def test_seed_is_idempotent(cli_db):
+    cli.seed()
+    cli.seed()
+    # seed() clears before inserting, so a second run yields the same counts.
+    assert _counts(cli_db) == EXPECTED_COUNTS

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,48 @@
+"""Tests for the dashboard router: snapshot rendering and the STEM card builder."""
+
+from rally.models import DashboardSnapshot
+from rally.routers.dashboard import _build_stem_section
+
+
+def test_dashboard_without_snapshot_shows_placeholder(client):
+    resp = client.get("/dashboard")
+    assert resp.status_code == 200
+    assert "No dashboard data available" in resp.text
+
+
+def test_dashboard_renders_most_recent_active_snapshot(client, db_session):
+    db_session.add(
+        DashboardSnapshot(
+            date="2026-03-15", data={"greeting": "Hello Fam", "schedule": []}, is_active=True
+        )
+    )
+    db_session.commit()
+
+    resp = client.get("/dashboard")
+
+    assert resp.status_code == 200
+    assert "Hello Fam" in resp.text
+
+
+def test_build_stem_section_empty_without_dict_or_title():
+    assert _build_stem_section(None) == ""
+    assert _build_stem_section({}) == ""
+    assert _build_stem_section({"title": "   "}) == ""
+
+
+def test_build_stem_section_escapes_injected_markup():
+    html = _build_stem_section(
+        {
+            "title": "<script>alert(1)</script>",
+            "field": "Biology",
+            "explanation": "x & y",
+            "activities": [{"idea": "<b>build</b>", "audience": "kids"}],
+        }
+    )
+
+    assert "STEM Concept of the Day" in html
+    # Injected values are escaped, never rendered as raw markup.
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+    assert "<b>build</b>" not in html
+    assert "&lt;b&gt;build&lt;/b&gt;" in html

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1,0 +1,31 @@
+"""Smoke tests for the HTML page routes, redirects, and the no-cache static mount."""
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/todo", "/todo/completed", "/dinner-planner", "/meal-history", "/settings"],
+)
+def test_page_renders_html(client, path):
+    resp = client.get(path)
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+
+
+def test_root_redirects_to_dashboard(client):
+    resp = client.get("/", follow_redirects=False)
+    assert resp.status_code in (307, 308)
+    assert resp.headers["location"] == "/dashboard"
+
+
+def test_meal_planner_redirects_to_dinner_planner(client):
+    resp = client.get("/meal-planner", follow_redirects=False)
+    assert resp.status_code in (307, 308)
+    assert resp.headers["location"] == "/dinner-planner"
+
+
+def test_static_css_sets_no_cache(client):
+    resp = client.get("/static/styles.css")
+    assert resp.status_code == 200
+    assert resp.headers["cache-control"] == "no-cache"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,58 @@
+"""Tests for static_version, timezone helpers, and the UNSET schema sentinel."""
+
+import hashlib
+from datetime import UTC, date, datetime
+from zoneinfo import ZoneInfo
+
+import rally.utils.timezone as tz
+from rally.schemas import UNSET, TodoUpdate
+from rally.utils import static_version
+
+# --- static_version ------------------------------------------------------------
+
+
+def test_compute_version_missing_file_returns_zero(tmp_path, monkeypatch):
+    monkeypatch.setattr(static_version, "STATIC_DIR", tmp_path)
+    assert static_version._compute_version() == "0"
+
+
+def test_compute_version_hashes_stylesheet(tmp_path, monkeypatch):
+    (tmp_path / "styles.css").write_bytes(b"body{color:red}")
+    monkeypatch.setattr(static_version, "STATIC_DIR", tmp_path)
+
+    expected = hashlib.md5(b"body{color:red}").hexdigest()[:12]
+    assert static_version._compute_version() == expected
+
+
+# --- timezone ------------------------------------------------------------------
+
+
+def test_ensure_utc_treats_naive_as_utc():
+    assert tz.ensure_utc(datetime(2026, 1, 1, 12, 0)) == datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+
+
+def test_ensure_utc_converts_aware_to_utc():
+    aware = datetime(2026, 1, 1, 12, 0, tzinfo=ZoneInfo("Asia/Kolkata"))  # +05:30
+    assert tz.ensure_utc(aware) == datetime(2026, 1, 1, 6, 30, tzinfo=UTC)
+
+
+def test_now_utc_and_today_utc_follow_frozen_clock(frozen_now):
+    instant = frozen_now(datetime(2026, 3, 15, 9, 30, tzinfo=UTC))
+    assert tz.now_utc() == instant
+    assert tz.today_utc() == date(2026, 3, 15)
+
+
+def test_today_local_uses_configured_timezone(frozen_now):
+    frozen_now(datetime(2026, 3, 15, 2, 0, tzinfo=UTC))
+    # 02:00Z is next-day-morning in Kolkata but still the previous evening on the US west coast.
+    assert tz.today_local("Asia/Kolkata") == date(2026, 3, 15)
+    assert tz.today_local("America/Los_Angeles") == date(2026, 3, 14)
+
+
+# --- UNSET sentinel ------------------------------------------------------------
+
+
+def test_unset_distinguishes_omitted_from_explicit_null():
+    assert TodoUpdate().due_date is UNSET
+    assert TodoUpdate(due_date=None).due_date is None
+    assert TodoUpdate(due_date="2026-01-01").due_date == "2026-01-01"


### PR DESCRIPTION
## Summary

**Phase 6** — the final phase of the test-coverage expansion ([milestone](https://github.com/pid1/rally/milestone/1)). Adds smoke/unit coverage for the remaining modules: page routes, the dashboard router, `static_version`, `timezone`, the seed CLI, `caldav_client`, and the `UNSET` sentinel. Implements #100.

## Changes

- **`tests/test_pages.py`** — HTML smoke tests for `/todo`, `/todo/completed`, `/dinner-planner`, `/meal-history`, `/settings`; the `/` and `/meal-planner` redirects; and the `no-cache` header on `/static/styles.css`.
- **`tests/test_dashboard.py`** — renders the most-recent active snapshot; placeholder when none; `_build_stem_section` returns `""` without a dict/title and **HTML-escapes injected markup**.
- **`tests/test_utils.py`** — `static_version` (md5 hash + `"0"` when missing → **100%**); `timezone` (`ensure_utc` naive/aware, `now_utc`/`today_utc`/`today_local` under a frozen clock → **100%**); and the `UNSET` sentinel (omitted vs. explicit null).
- **`tests/test_cli.py`** — `seed()` populates the expected sample-data counts and is idempotent.
- **`tests/test_caldav_client.py`** — `_is_event_declined`, `_parse_caldav_events` (event dicts + declined-skip), and the Google/Apple fetch wrappers (missing creds → `[]`; success via a stubbed `caldav.DAVClient`).

## Notes for reviewers

- The DB-touching helpers (`cli.seed`, `_parse_caldav_events` wrappers) use the same "point `SessionLocal` / `DAVClient` at a stub" approach established in earlier phases.
- **Heads-up (pre-existing, not fixed here):** these page-route tests surface a Starlette `DeprecationWarning` — the handlers call `TemplateResponse("name", {"request": request})`, which newer Starlette wants as `TemplateResponse(request, "name")`. Out of scope for a test-only PR; flagged as a follow-up.
- This is the last phase in the milestone — all of #94–#100 will be complete once this merges.

## Testing

- **202 passed** across the full suite; `ruff check` and `ruff format --check` clean.
- Total coverage **64% → 74%** (up from the 30% baseline at the start of the milestone).

Closes #100
