### PR TITLE
Test coverage — Phase 10: CalDAV client Apple path + error handling

### DIFF
--- a/tests/test_caldav_client.py
+++ b/tests/test_caldav_client.py
@@ -60,6 +60,21 @@ def test_not_declined_when_accepted():
     assert _is_event_declined(ev) is False
 
 
+def test_owner_not_in_attendees_is_not_declined():
+    # Owner isn't listed (they may be the organizer) -> treated as not declined.
+    ev = Event()
+    ev.add("attendee", _attendee("someone@else.com", "DECLINED"))
+    assert _is_event_declined(ev, owner_email="me@example.com") is False
+
+
+def test_outlook_busystatus_free_with_declined_attendee():
+    ev = Event()
+    ev.add("X-MICROSOFT-CDO-BUSYSTATUS", "FREE")
+    ev.add("attendee", _attendee("a@example.com", "DECLINED"))
+    ev.add("attendee", _attendee("b@example.com", "ACCEPTED"))
+    assert _is_event_declined(ev) is True
+
+
 # --- _parse_caldav_events ------------------------------------------------------
 
 
@@ -100,6 +115,29 @@ def test_parse_skips_declined_events():
     assert _parse_caldav_events(client, ZoneInfo("UTC")) == []
 
 
+class _RaisingSearchCalendar:
+    name = "Bad"
+
+    def search(self, **kwargs):
+        raise RuntimeError("search failed")
+
+
+def test_parse_skips_calendar_when_search_raises():
+    client = _FakeClient([_RaisingSearchCalendar()])
+    assert _parse_caldav_events(client, ZoneInfo("UTC")) == []
+
+
+def test_parse_skips_unparseable_item():
+    client = _FakeClient([_FakeCalendar([_FakeItem(b"this is not iCalendar data")])])
+    assert _parse_caldav_events(client, ZoneInfo("UTC")) == []
+
+
+def test_parse_skips_event_without_dtstart():
+    ics = b"BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nSUMMARY:NoStart\r\nEND:VEVENT\r\nEND:VCALENDAR"
+    client = _FakeClient([_FakeCalendar([_FakeItem(ics)])])
+    assert _parse_caldav_events(client, ZoneInfo("UTC")) == []
+
+
 # --- fetch wrappers ------------------------------------------------------------
 
 
@@ -127,3 +165,44 @@ def test_fetch_google_success(monkeypatch):
 
     assert len(events) == 1
     assert events[0]["summary"] == "Meeting"
+
+
+def test_fetch_apple_success(monkeypatch):
+    import caldav
+
+    monkeypatch.setattr(
+        caldav, "DAVClient", lambda **kwargs: _FakeClient([_FakeCalendar([_FakeItem(_ICS)])])
+    )
+    record = SimpleNamespace(
+        username="user", password="secret", label="A", url="https://dav.example", owner_email=None
+    )
+
+    events = fetch_apple_caldav(record, ZoneInfo("UTC"))
+
+    assert len(events) == 1
+    assert events[0]["summary"] == "Meeting"
+
+
+class _RaisingPrincipalClient:
+    def principal(self):
+        raise RuntimeError("dav connection failed")
+
+
+def test_fetch_google_error_returns_empty(monkeypatch):
+    import caldav
+
+    monkeypatch.setattr(caldav, "DAVClient", lambda **kwargs: _RaisingPrincipalClient())
+    record = SimpleNamespace(
+        username="user", password="secret", label="G", url="https://dav.example", owner_email=None
+    )
+    assert fetch_google_caldav(record, ZoneInfo("UTC")) == []
+
+
+def test_fetch_apple_error_returns_empty(monkeypatch):
+    import caldav
+
+    monkeypatch.setattr(caldav, "DAVClient", lambda **kwargs: _RaisingPrincipalClient())
+    record = SimpleNamespace(
+        username="user", password="secret", label="A", url="https://dav.example", owner_email=None
+    )
+    assert fetch_apple_caldav(record, ZoneInfo("UTC")) == []


### PR DESCRIPTION
## Summary

**Phase 10** of the test-coverage expansion ([milestone](https://github.com/pid1/rally/milestone/1)). Finishes `caldav_client.py` — the Apple fetch path and the error/edge branches (the Google happy path was covered in Phase 6, and the generator tests already exercised the rest). Implements #113.

## Changes

**`tests/test_caldav_client.py`** — extends the existing file, taking `caldav_client.py` from **84% → 100%**:

- **`_is_event_declined`** — owner-not-in-attendees → not declined; Outlook `X-MICROSOFT-CDO-BUSYSTATUS=FREE` with a declined attendee → declined.
- **`_parse_caldav_events`** — a calendar whose `search()` raises is skipped; an unparseable item is skipped; an event without `DTSTART` is skipped.
- **`fetch_apple_caldav`** success (mirror of the Google test), and both Google **and** Apple error paths (`principal()` raising) returning `[]`.

## Notes for reviewers

- Everything uses stubbed `caldav.DAVClient` / fake calendars — no network.
- `caldav_client.py` is now at 100%.

## Testing

- **265 passed** across the full suite; `ruff check` and `ruff format --check` clean.
- Total coverage **93% → 94%**.

Closes #113
