### PR TITLE
Test coverage — Phase 11: close remaining branch gaps

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,3 +59,16 @@ def test_seed_is_idempotent(cli_db):
     cli.seed()
     # seed() clears before inserting, so a second run yields the same counts.
     assert _counts(cli_db) == EXPECTED_COUNTS
+
+
+def test_seed_handles_error_and_rolls_back(cli_db, monkeypatch, capsys):
+    def boom(*args, **kwargs):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(cli, "FamilyMember", boom)
+
+    cli.seed()  # the error is caught, not raised
+
+    assert "Error seeding" in capsys.readouterr().out
+    # The aborted insert rolled back, so nothing was seeded.
+    assert _counts(cli_db)["family"] == 0

--- a/tests/test_completed_todos.py
+++ b/tests/test_completed_todos.py
@@ -28,6 +28,38 @@ def get_completed(client, **params):
     return response.json()
 
 
+def test_completed_sort_due_soonest(client, make_todo):
+    make_todo("Near", due_date="2026-01-01")
+    make_todo("Far", due_date="2026-12-01")
+    assert titles(get_completed(client, sort="due-soonest")) == ["Near", "Far"]
+
+
+def test_completed_sort_due_furthest(client, make_todo):
+    make_todo("Near", due_date="2026-01-01")
+    make_todo("Far", due_date="2026-12-01")
+    assert titles(get_completed(client, sort="due-furthest")) == ["Far", "Near"]
+
+
+def test_completed_sort_by_assignee(client, make_todo, make_member):
+    zoe = make_member("Zoe")
+    amy = make_member("Amy")
+    make_todo("Zoe task", assigned_to=zoe.id)
+    make_todo("Amy task", assigned_to=amy.id)
+    assert titles(get_completed(client, sort="assignee")) == ["Amy task", "Zoe task"]
+
+
+def test_completed_sort_newest(client, make_todo):
+    make_todo("Old", created_at=datetime(2026, 1, 1))
+    make_todo("New", created_at=datetime(2026, 2, 1))
+    assert titles(get_completed(client, sort="newest")) == ["New", "Old"]
+
+
+def test_completed_sort_oldest(client, make_todo):
+    make_todo("Old", created_at=datetime(2026, 1, 1))
+    make_todo("New", created_at=datetime(2026, 2, 1))
+    assert titles(get_completed(client, sort="oldest")) == ["Old", "New"]
+
+
 def titles(payload) -> list[str]:
     return [item["title"] for item in payload["items"]]
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -46,3 +46,45 @@ def test_build_stem_section_escapes_injected_markup():
     assert "&lt;script&gt;" in html
     assert "<b>build</b>" not in html
     assert "&lt;b&gt;build&lt;/b&gt;" in html
+
+
+def test_build_stem_section_renders_and_filters_activities():
+    html = _build_stem_section(
+        {
+            "title": "Buoyancy",
+            "field": "Science",
+            "explanation": "Some things float.",
+            "activities": [
+                {"idea": "Float toys in the tub", "audience": "kids"},
+                "not a dict",  # skipped
+                {"idea": "   "},  # empty idea skipped
+                {"idea": "Guess sink or float"},  # no audience
+            ],
+        }
+    )
+
+    assert "Float toys in the tub" in html
+    assert "kids" in html
+    assert "Guess sink or float" in html
+    assert "not a dict" not in html
+
+
+def test_dashboard_renders_schedule_notes_and_briefing(client, db_session):
+    data = {
+        "greeting": "Morning!",
+        "weather_summary": "Sunny",
+        "briefing": "Pack an umbrella",
+        "schedule": [
+            {"time": "8:00 AM", "title": "School", "notes": "early release"},
+            {"time": "9:00 AM", "title": "Gym"},
+        ],
+    }
+    db_session.add(DashboardSnapshot(date="2026-03-15", data=data, is_active=True))
+    db_session.commit()
+
+    html = client.get("/dashboard").text
+
+    assert "early release" in html  # schedule item notes
+    assert "Pack an umbrella" in html  # briefing section
+    assert "School" in html
+    assert "Gym" in html

--- a/tests/test_recurrence.py
+++ b/tests/test_recurrence.py
@@ -230,6 +230,101 @@ def test_first_custom_monthly_weekday_current_month():
     assert _first_custom(rule, date(2026, 1, 1)) == date(2026, 1, 12)
 
 
+# --- fallthroughs and remaining custom branches --------------------------------
+
+
+def test_next_custom_daily_weekdays_only_sunday_to_monday():
+    rule = {"freq": "daily", "interval": 1, "weekdays_only": True}
+    # after Sat Jan 3 -> Sun Jan 4 -> pushed forward to Mon Jan 5.
+    assert _next_custom(rule, date(2026, 1, 3)) == date(2026, 1, 5)
+
+
+def test_next_custom_monthly_weekday_this_month():
+    rule = {"freq": "monthly", "mode": "weekday", "ordinal": "third", "weekday": 0, "interval": 1}
+    # after Jan 5, the third Monday of Jan (19th) is still ahead -> returned directly.
+    assert _next_custom(rule, date(2026, 1, 5)) == date(2026, 1, 19)
+
+
+def test_first_custom_monthly_weekday_advances_when_passed():
+    rule = {"freq": "monthly", "mode": "weekday", "ordinal": "first", "weekday": 0, "interval": 1}
+    # today Jan 20; first Monday of Jan (5th) has passed -> first Monday of Feb (2nd).
+    assert _first_custom(rule, date(2026, 1, 20)) == date(2026, 2, 2)
+
+
+def test_custom_helpers_unknown_freq_fall_through():
+    assert _next_custom({"freq": "yearly"}, date(2026, 1, 1)) == date(2026, 1, 2)
+    assert _last_custom({"freq": "yearly"}, date(2026, 1, 7)) == date(2026, 1, 7)
+    assert _first_custom({"freq": "yearly"}, date(2026, 1, 7)) == date(2026, 1, 7)
+
+
+def test_public_api_unknown_recurrence_type_falls_through():
+    # "custom" with no custom_rule, and an unrecognized type, hit the defaults.
+    assert get_next_recurrence_date(rt("custom"), date(2026, 1, 1)) == date(2026, 1, 2)
+    assert get_last_recurrence_date(rt("weekdays"), date(2026, 1, 7)) == date(2026, 1, 7)
+    assert get_first_recurrence_date(rt("custom"), date(2026, 1, 7)) == date(2026, 1, 7)
+
+
+def test_public_api_custom_type_delegates_to_helpers():
+    r = rt("custom", custom_rule={"freq": "daily"})
+    assert get_next_recurrence_date(r, date(2026, 1, 1)) == date(2026, 1, 2)
+    assert get_last_recurrence_date(r, date(2026, 1, 7)) == date(2026, 1, 7)
+    assert get_first_recurrence_date(r, date(2026, 1, 7)) == date(2026, 1, 7)
+
+
+def test_next_custom_monthly_day_this_month():
+    rule = {"freq": "monthly", "mode": "day", "day": 15, "interval": 1}
+    assert _next_custom(rule, date(2026, 1, 10)) == date(2026, 1, 15)
+
+
+def test_last_custom_monthly_day_this_month():
+    rule = {"freq": "monthly", "mode": "day", "day": 15}
+    assert _last_custom(rule, date(2026, 1, 20)) == date(2026, 1, 15)
+
+
+def test_first_custom_daily_returns_today():
+    assert _first_custom({"freq": "daily"}, date(2026, 1, 7)) == date(2026, 1, 7)
+
+
+def test_first_custom_weekly_wraps_to_next_week():
+    # today Wed Jan 7; only Monday is listed, and it's behind -> next week's Monday.
+    assert _first_custom({"freq": "weekly", "weekdays": [0]}, date(2026, 1, 7)) == date(2026, 1, 12)
+
+
+def test_first_custom_monthly_day_this_month():
+    rule = {"freq": "monthly", "mode": "day", "day": 15, "interval": 1}
+    assert _first_custom(rule, date(2026, 1, 10)) == date(2026, 1, 15)
+
+
+def test_process_backfills_reference_from_due_date(
+    db_session, make_recurring_todo, make_todo, frozen_now
+):
+    frozen_now(datetime(2026, 3, 15, 12, tzinfo=UTC))
+    template = make_recurring_todo("Vitamins", recurrence_type="daily", has_due_date=True)
+    # No last_generated_date -> backfill from the most recent instance's due_date.
+    make_todo("Vitamins", completed=True, due_date="2026-03-12", recurring_todo_id=template.id)
+
+    assert process_recurring_todos(db_session) == 1
+    assert template.last_generated_date == "2026-03-13"
+
+
+def test_process_backfills_reference_from_created_at_when_no_due_date(
+    db_session, make_recurring_todo, make_todo, frozen_now
+):
+    frozen_now(datetime(2026, 3, 15, 12, tzinfo=UTC))
+    template = make_recurring_todo("Vitamins", recurrence_type="daily", has_due_date=False)
+    # No due_date on the instance -> backfill from its created_at date.
+    make_todo(
+        "Vitamins",
+        completed=True,
+        due_date=None,
+        recurring_todo_id=template.id,
+        created_at=datetime(2026, 3, 10, 8, 0),
+    )
+
+    assert process_recurring_todos(db_session) == 1
+    assert template.last_generated_date == "2026-03-11"
+
+
 # --- process_recurring_todos (integration) -------------------------------------
 
 FROZEN = datetime(2026, 3, 15, 12, 0, tzinfo=UTC)  # a Sunday


### PR DESCRIPTION
## Summary

**Phase 11** — the final phase of the test-coverage expansion ([milestone](https://github.com/pid1/rally/milestone/1)). Closes the small branch-coverage gaps left across several otherwise well-covered modules. Implements #114.

## Changes

Extends four existing test files:

- **`dashboard.py` → 100%** — `_build_stem_section` activity filtering (non-dict and empty-idea skips); `_render_html` schedule-notes and briefing branches, exercised via a rendered snapshot.
- **`routers/todos.py` → 100%** — the completed-endpoint alternate sorts (`due-soonest`, `due-furthest`, `assignee`, `newest`, `oldest`).
- **`recurrence.py` → 100%** — custom monthly-day/weekday this-month-vs-advance branches, weekdays-only Sunday roll, weekly next-week wrap, the public-API custom-delegation and unknown-type fallthroughs, and `_resolve_reference_date` backfill from both `due_date` and `created_at`.
- **`cli.py` → 98%** — the `seed()` error/rollback path.

## Notes for reviewers

- No new fixtures or mocks — reuses the existing conftest fixtures.
- The only line left in `cli.py` is the `if __name__ == "__main__"` guard, which is conventionally excluded from coverage.
- This is the last phase in the milestone; merging it completes Phases 7–11.

## Testing

- **286 passed** across the full suite; `ruff check` and `ruff format --check` clean.
- Total coverage **94% → 96%**.

Closes #114
