### PR TITLE
Filter meals by meal type on both meal pages (#120)

### DIFF
--- a/src/rally/cli.py
+++ b/src/rally/cli.py
@@ -163,6 +163,86 @@ def seed():
 
         # Create sample meal plans (multiple per date to showcase the feature)
         today_date = today_utc()
+
+        # Past meals across all meal types with a range of ratings (and some
+        # unrated) so the Previous Meals page and its meal-type/rating filters
+        # have realistic data to act on.
+        past_meals = [
+            DinnerPlan(
+                date=(today_date - timedelta(days=2)).strftime("%Y-%m-%d"),
+                meal_type="Breakfast",
+                plan="Veggie omelettes and toast",
+                cook_id=mom.id,
+                rating=5,
+                review="Fluffy and filling — a keeper for weekend mornings.",
+            ),
+            DinnerPlan(
+                date=(today_date - timedelta(days=3)).strftime("%Y-%m-%d"),
+                meal_type="Lunch",
+                plan="Turkey and avocado sandwiches",
+                attendee_ids=[emma.id, jake.id],
+                rating=3,
+            ),
+            DinnerPlan(
+                date=(today_date - timedelta(days=4)).strftime("%Y-%m-%d"),
+                meal_type="Dinner",
+                plan="Meatloaf with mashed potatoes",
+                cook_id=dad.id,
+                rating=4,
+                review="Comfort food done right.",
+            ),
+            DinnerPlan(
+                date=(today_date - timedelta(days=5)).strftime("%Y-%m-%d"),
+                meal_type="Snacks",
+                plan="Fruit and cheese board",
+                rating=2,
+                review="Fine, but the crackers were stale.",
+            ),
+            DinnerPlan(
+                date=(today_date - timedelta(days=6)).strftime("%Y-%m-%d"),
+                meal_type="Dinner",
+                plan="Taco night",
+                cook_id=mom.id,
+                rating=5,
+                review="Everyone's favorite — always a hit.",
+            ),
+            DinnerPlan(
+                date=(today_date - timedelta(days=7)).strftime("%Y-%m-%d"),
+                meal_type="Breakfast",
+                plan="Oatmeal with berries",
+                # Not yet rated
+            ),
+            DinnerPlan(
+                date=(today_date - timedelta(days=9)).strftime("%Y-%m-%d"),
+                meal_type="Lunch",
+                plan="Grilled cheese and tomato soup",
+                rating=4,
+            ),
+            DinnerPlan(
+                date=(today_date - timedelta(days=10)).strftime("%Y-%m-%d"),
+                meal_type="Snacks",
+                plan="Popcorn and smoothies",
+                # Not yet rated
+            ),
+            DinnerPlan(
+                date=(today_date - timedelta(days=12)).strftime("%Y-%m-%d"),
+                meal_type="Dinner",
+                plan="Roast chicken with vegetables",
+                cook_id=dad.id,
+                rating=5,
+                review="Crispy skin, juicy inside. Restaurant quality.",
+            ),
+            DinnerPlan(
+                date=(today_date - timedelta(days=14)).strftime("%Y-%m-%d"),
+                meal_type="Breakfast",
+                plan="French toast",
+                attendee_ids=[emma.id, jake.id],
+                rating=3,
+            ),
+        ]
+        for dp in past_meals:
+            db.add(dp)
+
         dinner_plans = [
             # Today: breakfast and dinner for different groups
             DinnerPlan(
@@ -215,7 +295,8 @@ def seed():
         print(f"   - {len(calendars)} calendars")
         print(f"   - {len(sample_settings)} settings")
         print(f"   - {len(todos)} sample todos")
-        print(f"   - {len(dinner_plans)} meal plans")
+        print(f"   - {len(dinner_plans)} upcoming meal plans")
+        print(f"   - {len(past_meals)} past meal plans")
 
     except Exception as e:
         db.rollback()

--- a/src/rally/routers/dinner_planner.py
+++ b/src/rally/routers/dinner_planner.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 from rally.database import get_db
 from rally.models import DinnerPlan, Setting
 from rally.schemas import (
+    MEAL_TYPES,
     UNSET,
     DinnerPlanCreate,
     DinnerPlanResponse,
@@ -52,6 +53,7 @@ def create_dinner_plan(plan: DinnerPlanCreate, db: Session = Depends(get_db)):
 def list_meal_history(
     sort: str = Query("rating_desc", pattern="^(rating_desc|date_desc|date_asc)$"),
     min_rating: int | None = Query(None, ge=1, le=5),
+    meal_type: list[str] | None = Query(None),
     db: Session = Depends(get_db),
 ):
     """List past meal plans (before today in the user's timezone).
@@ -60,7 +62,18 @@ def list_meal_history(
     - rating_desc: highest rated first, null ratings last
     - date_desc: most recent first
     - date_asc: oldest first
+
+    ``meal_type`` may be repeated to filter to any of the given types (e.g.
+    ``?meal_type=Breakfast&meal_type=Lunch``); each value must be a known meal
+    type.
     """
+    if meal_type:
+        invalid = [m for m in meal_type if m not in MEAL_TYPES]
+        if invalid:
+            raise HTTPException(
+                status_code=422, detail=f"Invalid meal_type value(s): {invalid}"
+            )
+
     settings = {r.key: r.value for r in db.query(Setting).all()}
     tz_name = settings.get("local_timezone", "UTC")
     today = today_local(tz_name).strftime("%Y-%m-%d")
@@ -69,6 +82,9 @@ def list_meal_history(
 
     if min_rating is not None:
         query = query.filter(DinnerPlan.rating >= min_rating)
+
+    if meal_type:
+        query = query.filter(DinnerPlan.meal_type.in_(meal_type))
 
     if sort == "rating_desc":
         query = query.order_by(nullslast(DinnerPlan.rating.desc()), DinnerPlan.date.desc())

--- a/src/rally/routers/dinner_planner.py
+++ b/src/rally/routers/dinner_planner.py
@@ -70,9 +70,7 @@ def list_meal_history(
     if meal_type:
         invalid = [m for m in meal_type if m not in MEAL_TYPES]
         if invalid:
-            raise HTTPException(
-                status_code=422, detail=f"Invalid meal_type value(s): {invalid}"
-            )
+            raise HTTPException(status_code=422, detail=f"Invalid meal_type value(s): {invalid}")
 
     settings = {r.key: r.value for r in db.query(Setting).all()}
     tz_name = settings.get("local_timezone", "UTC")

--- a/static/styles.css
+++ b/static/styles.css
@@ -683,7 +683,7 @@ footer a:hover {
 }
 
 
-.todo-toolbar {
+.filter-toolbar {
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;

--- a/templates/dinner_planner.html
+++ b/templates/dinner_planner.html
@@ -35,6 +35,21 @@
                 <button class="btn-add" id="btn-add-meal">Add Meal</button>
             </div>
         </div>
+
+        <!-- Filter toolbar (filters first; this page has no sort control) -->
+        <div class="filter-toolbar">
+            <div class="toolbar-group">
+                <label>Meal Type</label>
+                <div class="filter-chips" id="meal-type-filters">
+                    <button type="button" class="filter-chip" data-meal="Breakfast">Breakfast</button>
+                    <button type="button" class="filter-chip" data-meal="Lunch">Lunch</button>
+                    <button type="button" class="filter-chip" data-meal="Dinner">Dinner</button>
+                    <button type="button" class="filter-chip" data-meal="Snacks">Snacks</button>
+                </div>
+                <button type="button" class="filter-clear" id="filter-clear">Clear Filters</button>
+            </div>
+        </div>
+
         <div class="list-container" id="plans-list">
             <div class="container-loading-state">Loading meal plans...</div>
         </div>
@@ -91,6 +106,7 @@
         let editingId = null;
         let defaultMealType = 'Dinner';
         let localTimezone = 'UTC';
+        let selectedMealTypes = new Set();
 
         const MEAL_TYPES = ['Breakfast', 'Lunch', 'Dinner', 'Snacks'];
         const MEAL_TYPE_ORDER = { 'Breakfast': 0, 'Lunch': 1, 'Dinner': 2, 'Snacks': 3 };
@@ -229,16 +245,25 @@
             if (!response.ok) throw new Error('Failed to delete plan');
         }
 
+        // Apply the active meal-type filter (empty selection = show all).
+        function getVisiblePlans() {
+            if (selectedMealTypes.size === 0) return plans;
+            return plans.filter(p => selectedMealTypes.has(p.meal_type || 'Dinner'));
+        }
+
         // Render
         function renderPlans() {
             const container = document.getElementById('plans-list');
+            const visible = getVisiblePlans();
 
-            if (plans.length === 0) {
-                container.innerHTML = '<div class="container-empty-state">No meal plans for the next 7 days. Click "Add Meal" to get started.</div>';
+            if (visible.length === 0) {
+                container.innerHTML = selectedMealTypes.size > 0
+                    ? '<div class="container-empty-state">No meals match the current filters.</div>'
+                    : '<div class="container-empty-state">No meal plans for the next 7 days. Click "Add Meal" to get started.</div>';
                 return;
             }
 
-            container.innerHTML = plans.map(plan => {
+            container.innerHTML = visible.map(plan => {
                 // Build meta parts
                 const parts = [];
                 if (plan.attendee_ids && plan.attendee_ids.length > 0) {
@@ -330,6 +355,29 @@
                 alert('Failed to delete meal plan');
             }
         }
+
+        // Meal type filter: multi-select (any of the selected types). Filtering
+        // is client-side over the already-loaded week, so no refetch is needed.
+        document.getElementById('meal-type-filters').addEventListener('click', (e) => {
+            const chip = e.target.closest('.filter-chip');
+            if (!chip) return;
+
+            const meal = chip.dataset.meal;
+            if (selectedMealTypes.has(meal)) {
+                selectedMealTypes.delete(meal);
+                chip.classList.remove('active');
+            } else {
+                selectedMealTypes.add(meal);
+                chip.classList.add('active');
+            }
+            renderPlans();
+        });
+
+        document.getElementById('filter-clear').addEventListener('click', () => {
+            selectedMealTypes.clear();
+            document.querySelectorAll('#meal-type-filters .filter-chip').forEach(c => c.classList.remove('active'));
+            renderPlans();
+        });
 
         // Event handlers
         document.getElementById('btn-add-meal').addEventListener('click', openAddModal);

--- a/templates/meal_history.html
+++ b/templates/meal_history.html
@@ -319,6 +319,8 @@
         document.getElementById('filter-clear').addEventListener('click', function() {
             selectedMealTypes.clear();
             currentMinRating = '';
+            currentSort = 'rating_desc';
+            document.getElementById('sort-select').value = currentSort;
             document.querySelectorAll('.filter-toolbar .filter-chip').forEach(c => c.classList.remove('active'));
             fetchHistory();
         });

--- a/templates/meal_history.html
+++ b/templates/meal_history.html
@@ -33,8 +33,26 @@
             <h2>Meal History</h2>
         </div>
 
-        <!-- Sort/filter toolbar -->
-        <div class="todo-toolbar">
+        <!-- Filter/sort toolbar (filters first, sort last) -->
+        <div class="filter-toolbar">
+            <div class="toolbar-group">
+                <label>Meal Type</label>
+                <div class="filter-chips" id="meal-type-filters">
+                    <button type="button" class="filter-chip" data-meal="Breakfast">Breakfast</button>
+                    <button type="button" class="filter-chip" data-meal="Lunch">Lunch</button>
+                    <button type="button" class="filter-chip" data-meal="Dinner">Dinner</button>
+                    <button type="button" class="filter-chip" data-meal="Snacks">Snacks</button>
+                </div>
+            </div>
+            <div class="toolbar-group">
+                <label>Rating</label>
+                <div class="filter-chips" id="rating-filters">
+                    <button type="button" class="filter-chip" data-min="5">5 Stars</button>
+                    <button type="button" class="filter-chip" data-min="4">4+ Stars</button>
+                    <button type="button" class="filter-chip" data-min="3">3+ Stars</button>
+                </div>
+                <button type="button" class="filter-clear" id="filter-clear">Clear Filters</button>
+            </div>
             <div class="toolbar-group">
                 <label>Sort</label>
                 <select id="sort-select">
@@ -42,15 +60,6 @@
                     <option value="date_desc">Most Recent</option>
                     <option value="date_asc">Oldest First</option>
                 </select>
-            </div>
-            <div class="toolbar-group">
-                <label>Rating</label>
-                <div class="filter-chips" id="rating-filters">
-                    <button class="filter-chip active" data-min="">All</button>
-                    <button class="filter-chip" data-min="5">5 Stars</button>
-                    <button class="filter-chip" data-min="4">4+ Stars</button>
-                    <button class="filter-chip" data-min="3">3+ Stars</button>
-                </div>
             </div>
         </div>
 
@@ -93,6 +102,7 @@
         let familyMembers = [];
         let currentSort = 'rating_desc';
         let currentMinRating = '';
+        let selectedMealTypes = new Set();
 
         // Star rating state
         let selectedRating = 0;
@@ -141,6 +151,7 @@
             if (currentMinRating) {
                 params.set('min_rating', currentMinRating);
             }
+            selectedMealTypes.forEach(t => params.append('meal_type', t));
             const response = await fetch(`/api/dinner-plans/history?${params}`);
             historyPlans = await response.json();
             renderHistory();
@@ -165,7 +176,10 @@
             const container = document.getElementById('history-list');
 
             if (historyPlans.length === 0) {
-                container.innerHTML = '<div class="container-empty-state">No meal history yet. Past meals will appear here once you have some plans behind you.</div>';
+                const filtersActive = selectedMealTypes.size > 0 || currentMinRating;
+                container.innerHTML = filtersActive
+                    ? '<div class="container-empty-state">No meals match the current filters.</div>'
+                    : '<div class="container-empty-state">No meal history yet. Past meals will appear here once you have some plans behind you.</div>';
                 return;
             }
 
@@ -270,13 +284,42 @@
             fetchHistory();
         });
 
+        // Meal type: multi-select (any of the selected types).
+        document.getElementById('meal-type-filters').addEventListener('click', function(e) {
+            const chip = e.target.closest('.filter-chip');
+            if (!chip) return;
+
+            const meal = chip.dataset.meal;
+            if (selectedMealTypes.has(meal)) {
+                selectedMealTypes.delete(meal);
+                chip.classList.remove('active');
+            } else {
+                selectedMealTypes.add(meal);
+                chip.classList.add('active');
+            }
+            fetchHistory();
+        });
+
+        // Rating: single-select; clicking the active chip clears it.
         document.getElementById('rating-filters').addEventListener('click', function(e) {
             const chip = e.target.closest('.filter-chip');
             if (!chip) return;
 
+            const alreadyActive = chip.classList.contains('active');
             document.querySelectorAll('#rating-filters .filter-chip').forEach(c => c.classList.remove('active'));
-            chip.classList.add('active');
-            currentMinRating = chip.dataset.min;
+            if (alreadyActive) {
+                currentMinRating = '';
+            } else {
+                chip.classList.add('active');
+                currentMinRating = chip.dataset.min;
+            }
+            fetchHistory();
+        });
+
+        document.getElementById('filter-clear').addEventListener('click', function() {
+            selectedMealTypes.clear();
+            currentMinRating = '';
+            document.querySelectorAll('.filter-toolbar .filter-chip').forEach(c => c.classList.remove('active'));
             fetchHistory();
         });
 

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -38,7 +38,7 @@
 
         <a class="todo-view-switch" href="/todo/completed">View completed tasks</a>
 
-        <div class="todo-toolbar">
+        <div class="filter-toolbar">
             <div class="toolbar-group">
                 <label>Assignee</label>
                 <div class="filter-chips" id="filter-assignee-chips">

--- a/templates/todo_completed.html
+++ b/templates/todo_completed.html
@@ -35,7 +35,7 @@
 
         <a class="todo-view-switch" href="/todo">Back to current tasks</a>
 
-        <div class="todo-toolbar">
+        <div class="filter-toolbar">
             <div class="toolbar-group">
                 <label>Assignee</label>
                 <div class="filter-chips" id="filter-assignee-chips">

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,13 +8,14 @@ from sqlalchemy.pool import StaticPool
 from rally import cli
 from rally.database import Base
 from rally.models import Calendar, DashboardSnapshot, DinnerPlan, FamilyMember, Setting, Todo
+from rally.utils.timezone import today_utc
 
 EXPECTED_COUNTS = {
     "family": 4,
     "calendars": 3,
     "settings": 5,
     "todos": 6,
-    "dinner": 6,
+    "dinner": 16,  # 6 upcoming + 10 past
     "snapshots": 1,
 }
 
@@ -52,6 +53,23 @@ def _counts(session):
 def test_seed_populates_sample_data(cli_db):
     cli.seed()
     assert _counts(cli_db) == EXPECTED_COUNTS
+
+
+def test_seed_creates_past_meals_for_history_filters(cli_db):
+    """Seeded history must span all meal types and a range of ratings so the
+    Previous Meals meal-type and rating filters have data to act on."""
+    cli.seed()
+    today = today_utc().strftime("%Y-%m-%d")
+
+    past = cli_db.query(DinnerPlan).filter(DinnerPlan.date < today).all()
+
+    assert past, "expected seeded meals in the past for the Previous Meals page"
+    # All four meal types are represented.
+    assert {p.meal_type for p in past} == {"Breakfast", "Lunch", "Dinner", "Snacks"}
+    # A spread of ratings, including at least one unrated meal.
+    ratings = {p.rating for p in past}
+    assert None in ratings
+    assert len([r for r in ratings if r is not None]) >= 3
 
 
 def test_seed_is_idempotent(cli_db):

--- a/tests/test_dinner_planner.py
+++ b/tests/test_dinner_planner.py
@@ -209,6 +209,52 @@ def test_history_sort_date_asc_and_desc(client, make_dinner_plan, frozen_now):
     assert [p["date"] for p in desc] == ["2026-05-05", "2026-05-01"]
 
 
+def test_history_meal_type_filter(client, make_dinner_plan, frozen_now):
+    frozen_now(TODAY)
+    make_dinner_plan("2026-05-01", plan="Eggs", meal_type="Breakfast", rating=4)
+    make_dinner_plan("2026-05-02", plan="Steak", meal_type="Dinner", rating=4)
+
+    hist = client.get("/api/dinner-plans/history", params={"meal_type": "Breakfast"}).json()
+
+    assert [p["plan"] for p in hist] == ["Eggs"]
+
+
+def test_history_meal_type_filter_multiple(client, make_dinner_plan, frozen_now):
+    frozen_now(TODAY)
+    make_dinner_plan("2026-05-01", plan="Eggs", meal_type="Breakfast", rating=4)
+    make_dinner_plan("2026-05-02", plan="Sandwich", meal_type="Lunch", rating=4)
+    make_dinner_plan("2026-05-03", plan="Steak", meal_type="Dinner", rating=4)
+
+    hist = client.get(
+        "/api/dinner-plans/history", params={"meal_type": ["Breakfast", "Lunch"]}
+    ).json()
+
+    assert sorted(p["plan"] for p in hist) == ["Eggs", "Sandwich"]
+
+
+def test_history_meal_type_composes_with_min_rating(client, make_dinner_plan, frozen_now):
+    frozen_now(TODAY)
+    make_dinner_plan("2026-05-01", plan="GoodDinner", meal_type="Dinner", rating=5)
+    make_dinner_plan("2026-05-02", plan="BadDinner", meal_type="Dinner", rating=2)
+    make_dinner_plan("2026-05-03", plan="GoodLunch", meal_type="Lunch", rating=5)
+
+    hist = client.get(
+        "/api/dinner-plans/history",
+        params={"meal_type": "Dinner", "min_rating": 3},
+    ).json()
+
+    assert [p["plan"] for p in hist] == ["GoodDinner"]
+
+
+def test_history_invalid_meal_type_returns_422(client, make_dinner_plan, frozen_now):
+    frozen_now(TODAY)
+    make_dinner_plan("2026-05-01", plan="Eggs", meal_type="Breakfast", rating=4)
+
+    resp = client.get("/api/dinner-plans/history", params={"meal_type": "Brunch"})
+
+    assert resp.status_code == 422
+
+
 def test_history_respects_local_timezone(client, make_dinner_plan, frozen_now, local_timezone):
     # At 02:00Z the local date in Kolkata (+05:30) is already the next day, so a
     # plan dated that local day counts as "today" and is excluded from history.


### PR DESCRIPTION
Closes #120.

Adds a meal-type filter to both meal pages and standardizes their filter/sort toolbars on the Tasks page pattern.

## Changes

**Filtering**
- **Previous Meals** (`/meal-history`): new multi-select `Meal Type` chips. `GET /api/dinner-plans/history` gains a repeatable `meal_type` query param (validated against `MEAL_TYPES`, filtered server-side; invalid → 422). Toolbar reordered to filters-first / sort-last. The rating filter's `All` chip is replaced with a shared `Clear Filters` link, which also resets sort to the default.
- **Current & Upcoming** (`/dinner-planner`): new filter toolbar with multi-select `Meal Type` chips, filtered client-side over the loaded week.

**Standardization**
- Renamed the shared `.todo-toolbar` → `.filter-toolbar` in `styles.css` and all four templates that use it (`todo`, `todo_completed`, `meal_history`, `dinner_planner`).

**Seed data**
- `seed` only created today/future meals, leaving a freshly seeded Previous Meals page empty. Added 10 past meals spanning all four meal types with a range of ratings (2–5 and unrated) plus reviews, so the filters have realistic data to exercise.

## Testing
- `ruff` clean; **291 tests pass**.
- New tests: `meal_type` filtering (single, multiple, composed with `min_rating`, invalid → 422) and seeded-history variety.
- Manually verified both pages in-browser: single/multi-select, no-match empty states, Clear Filters (incl. sort reset), and the seeded history filtering end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)