### PR TITLE
Document format check in AGENTS.md pre-push steps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,12 +245,20 @@ dev
 
 ### Running Tests
 
+Before pushing, run everything CI runs, or the PR check will fail. PR CI runs
+`pytest`, `ruff check`, and `ruff format --check` (see Pull Request Format).
+The `check` command covers both the linter **and** the formatter check — plain
+`lint` only runs `ruff check` and will miss formatting problems.
+
 ```bash
 # Ensure dependencies are installed
 install-deps
 
-# Run linting
-lint
+# Lint + format check together (mirrors CI's `ruff check` + `ruff format --check`)
+check
+
+# Run the full test suite (see the env note under Pull Request Format)
+uv run pytest
 
 # Test summary generation
 test-generate


### PR DESCRIPTION
## Summary

The **Running Tests** checklist in `AGENTS.md` listed only `lint` (which runs `ruff check` alone) and `test-generate`. It omitted the formatter check and the test suite, so an agent following that section would miss `ruff format --check` and get a red PR check — which is exactly what happened on #121.

## Change

- Point the pre-push steps at `check` (runs both `ruff check` **and** `ruff format --check`) plus `uv run pytest`, so the local steps mirror CI.
- Add a short note that plain `lint` skips formatting.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)