### PR TITLE
Add meal editing on Meal History with shared edit modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ envrc
 
 # FastForward runtime artifacts
 .fastforward/
+
+# Claude Code (local agent config, e.g. launch.json)
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,35 @@ sleep 2       # Give it time to start
 dev-logs      # Check for errors
 ```
 
-### 6. Working with Docker
+### 6. Never Destructively Mutate the Local Dev Database
+
+The dev database (`rally.db`) holds the developer's local data. It is **gitignored**,
+and SQLite keeps **no history** — an `UPDATE`/`DELETE` that commits overwrites the
+old value irreversibly. There is no `git checkout` to fall back on. So verification
+that drives the **running app against write endpoints** (create/update/delete, or
+UI actions that call them) will permanently change local data.
+
+❌ **Don't** exercise write paths against `rally.db` for exploratory/manual testing.
+
+✅ **Prefer the automated suite** — each test gets an isolated in-memory database
+(see `tests/conftest.py`), so it never touches `rally.db`:
+
+```bash
+uv run pytest
+```
+
+✅ **If you must drive the running app against write paths**, isolate the data first:
+
+```bash
+resetdb && seed     # start from a known, reproducible sample state
+```
+
+and, before mutating any specific row, read and stash its full contents so you can
+put it back. If you do mutate `rally.db` incidentally, restore it: the sample data
+is defined in `src/rally/cli.py` (the `seed` command), or run `resetdb && seed` to
+rebuild the whole thing. Tell the user what you changed and how you restored it.
+
+### 7. Working with Docker
 
 For Docker operations, use non-blocking variants:
 
@@ -193,7 +221,7 @@ logs-tail
 # Not logs (that follows and blocks)
 ```
 
-### 7. Pull Request Format
+### 8. Pull Request Format
 
 Open PRs with `gh pr create` and follow the template at
 `.github/pull_request_template.md`. **`gh pr create` does not auto-apply the

--- a/src/rally/routers/dinner_planner.py
+++ b/src/rally/routers/dinner_planner.py
@@ -26,6 +26,17 @@ _MEAL_TYPE_ORDER = case(
 )
 
 
+def _today_local_str(db: Session) -> str:
+    """Today's date (YYYY-MM-DD) in the configured local timezone.
+
+    This is the day boundary that splits Meal History (``date < today``) from the
+    Meal Planner (``date >= today``); both use it so the two pages agree.
+    """
+    settings = {r.key: r.value for r in db.query(Setting).all()}
+    tz_name = settings.get("local_timezone", "UTC")
+    return today_local(tz_name).strftime("%Y-%m-%d")
+
+
 @router.get("", response_model=list[DinnerPlanResponse])
 def list_dinner_plans(db: Session = Depends(get_db)):
     """List all meal plans ordered by date then meal type."""
@@ -72,9 +83,7 @@ def list_meal_history(
         if invalid:
             raise HTTPException(status_code=422, detail=f"Invalid meal_type value(s): {invalid}")
 
-    settings = {r.key: r.value for r in db.query(Setting).all()}
-    tz_name = settings.get("local_timezone", "UTC")
-    today = today_local(tz_name).strftime("%Y-%m-%d")
+    today = _today_local_str(db)
 
     query = db.query(DinnerPlan).filter(DinnerPlan.date < today)
 
@@ -131,6 +140,14 @@ def update_dinner_plan(
         db_plan.attendee_ids = plan.attendee_ids
     if plan.cook_id is not UNSET:
         db_plan.cook_id = plan.cook_id
+
+    # A rating/review only makes sense for a past meal. If the date is moved onto
+    # the Meal Planner (today or later, out of Meal History), discard any existing
+    # rating and review. The client warns and confirms before sending such a
+    # change; enforcing it here keeps the invariant regardless of the caller.
+    if plan.date is not None and db_plan.date >= _today_local_str(db):
+        db_plan.rating = None
+        db_plan.review = None
 
     db.commit()
     db.refresh(db_plan)

--- a/static/meal_edit_modal.js
+++ b/static/meal_edit_modal.js
@@ -1,0 +1,204 @@
+// Shared meal add/edit modal used by both meal pages:
+//   - Meal Planner (Current & Upcoming) — add + edit upcoming meals
+//   - Meal History (Previous Meals)      — edit past meals
+//
+// Both templates include _meal_edit_modal.html (same element IDs); each page
+// constructs a MealEditModal with page-specific hooks. Keeping the markup and
+// behavior in one place means the edit experience has a single source of truth.
+//
+// Ratings/reviews live only on past meals (Meal History). When an edit moves a
+// meal's date onto the planner (today or later), any existing rating/review is
+// discarded: this class warns and confirms first, and the server clears them.
+(function (global) {
+    'use strict';
+
+    const MEAL_TYPES = ['Breakfast', 'Lunch', 'Dinner', 'Snacks'];
+
+    function escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    // Today's date (YYYY-MM-DD) in a given IANA timezone. Mirrors the backend's
+    // today_local() so the planner/history day boundary agrees with the server.
+    function todayLocal(tzName) {
+        return new Intl.DateTimeFormat('en-CA', { timeZone: tzName || 'UTC' }).format(new Date());
+    }
+
+    class MealEditModal {
+        // opts:
+        //   getFamilyMembers  () => [{id, name}]   (required)
+        //   getDefaultMealType() => 'Dinner'        (optional)
+        //   getTimezone       () => 'UTC'           (optional; for the discard check)
+        //   onSaved           () => Promise|void    (called after save/delete)
+        constructor(opts) {
+            this.getFamilyMembers = opts.getFamilyMembers;
+            this.getDefaultMealType = opts.getDefaultMealType || (() => 'Dinner');
+            this.getTimezone = opts.getTimezone || (() => 'UTC');
+            this.onSaved = opts.onSaved || (() => {});
+
+            this.editingId = null;
+            this.editingPlan = null; // full plan object when editing (for rating checks)
+
+            this.overlay = document.getElementById('modal-overlay');
+            this.form = document.getElementById('plan-form');
+            this._bindEvents();
+        }
+
+        _bindEvents() {
+            this.form.addEventListener('submit', (e) => {
+                e.preventDefault();
+                this._submit();
+            });
+            document.getElementById('btn-cancel').addEventListener('click', () => this.close());
+            document.getElementById('btn-delete-plan').addEventListener('click', () => this._confirmDelete());
+            this.overlay.addEventListener('click', (e) => {
+                if (e.target === this.overlay) this.close();
+            });
+        }
+
+        // --- Form population --------------------------------------------------
+
+        populateFamilyControls() {
+            const members = this.getFamilyMembers();
+
+            const checkboxGroup = document.getElementById('attendee-checkboxes');
+            checkboxGroup.innerHTML = members.map(m =>
+                `<label class="checkbox-label"><input type="checkbox" class="attendee-cb" value="${m.id}"> ${escapeHtml(m.name)}</label>`
+            ).join('');
+
+            const cookSelect = document.getElementById('plan-cook');
+            cookSelect.innerHTML = '<option value="">— nobody assigned —</option>';
+            members.forEach(m => {
+                cookSelect.innerHTML += `<option value="${m.id}">${escapeHtml(m.name)}</option>`;
+            });
+        }
+
+        populateMealTypeSelector() {
+            const select = document.getElementById('plan-meal-type');
+            const def = this.getDefaultMealType();
+            select.innerHTML = MEAL_TYPES.map(t => {
+                const label = t === def ? `${t} (default)` : t;
+                return `<option value="${t}">${label}</option>`;
+            }).join('');
+        }
+
+        _getSelectedAttendeeIds() {
+            const checked = document.querySelectorAll('.attendee-cb:checked');
+            const ids = Array.from(checked).map(cb => parseInt(cb.value));
+            return ids.length > 0 ? ids : null; // null = everyone
+        }
+
+        _getSelectedCookId() {
+            const val = document.getElementById('plan-cook').value;
+            return val ? parseInt(val) : null;
+        }
+
+        // --- Open / close -----------------------------------------------------
+
+        openAdd(defaults = {}) {
+            this.editingId = null;
+            this.editingPlan = null;
+            document.getElementById('modal-title').textContent = 'Add Meal Plan';
+            this.form.reset();
+            document.getElementById('plan-edit-id').value = '';
+            this.populateFamilyControls();
+            this.populateMealTypeSelector();
+            document.getElementById('plan-date').value = defaults.date || todayLocal(this.getTimezone());
+            document.getElementById('plan-meal-type').value = defaults.meal_type || this.getDefaultMealType();
+            document.querySelectorAll('.attendee-cb').forEach(cb => cb.checked = false);
+            document.getElementById('plan-cook').value = '';
+            document.getElementById('btn-delete-plan').style.display = 'none';
+            this.overlay.style.display = 'flex';
+        }
+
+        openEdit(plan) {
+            if (!plan) return;
+            this.editingId = plan.id;
+            this.editingPlan = plan;
+            document.getElementById('modal-title').textContent = 'Edit Meal Plan';
+            this.populateFamilyControls();
+            this.populateMealTypeSelector();
+            document.getElementById('plan-edit-id').value = plan.id;
+            document.getElementById('plan-date').value = plan.date;
+            document.getElementById('plan-meal-type').value = plan.meal_type || 'Dinner';
+            document.getElementById('plan-text').value = plan.plan;
+            document.querySelectorAll('.attendee-cb').forEach(cb => {
+                cb.checked = plan.attendee_ids && plan.attendee_ids.includes(parseInt(cb.value));
+            });
+            document.getElementById('plan-cook').value = plan.cook_id || '';
+            document.getElementById('btn-delete-plan').style.display = '';
+            this.overlay.style.display = 'flex';
+        }
+
+        close() {
+            this.overlay.style.display = 'none';
+            this.editingId = null;
+            this.editingPlan = null;
+        }
+
+        // --- Save / delete ----------------------------------------------------
+
+        async _submit() {
+            const date = document.getElementById('plan-date').value;
+            const meal_type = document.getElementById('plan-meal-type').value;
+            const plan = document.getElementById('plan-text').value;
+            const attendee_ids = this._getSelectedAttendeeIds();
+            const cook_id = this._getSelectedCookId();
+
+            // Moving a rated meal onto the planner (today or later) discards its
+            // rating and review. Warn and confirm before doing so.
+            if (this.editingPlan &&
+                (this.editingPlan.rating || this.editingPlan.review) &&
+                date >= todayLocal(this.getTimezone())) {
+                const ok = confirm(
+                    'Moving this meal to the planner will discard its rating and review. Continue?'
+                );
+                if (!ok) return; // keep modal open for correction
+            }
+
+            try {
+                if (this.editingId) {
+                    await this._request(`/api/dinner-plans/${this.editingId}`, 'PUT',
+                        { date, meal_type, plan, attendee_ids, cook_id });
+                } else {
+                    await this._request('/api/dinner-plans', 'POST',
+                        { date, meal_type, plan, attendee_ids, cook_id });
+                }
+                this.close();
+                await this.onSaved();
+            } catch (error) {
+                console.error('Error saving meal plan:', error);
+                alert('Failed to save meal plan');
+            }
+        }
+
+        async _confirmDelete() {
+            if (!this.editingId) return;
+            if (!confirm('Are you sure you want to delete this meal plan?')) return;
+            try {
+                const resp = await fetch(`/api/dinner-plans/${this.editingId}`, { method: 'DELETE' });
+                if (!resp.ok) throw new Error('Failed to delete plan');
+                this.close();
+                await this.onSaved();
+            } catch (error) {
+                console.error('Error deleting meal plan:', error);
+                alert('Failed to delete meal plan');
+            }
+        }
+
+        async _request(url, method, body) {
+            const resp = await fetch(url, {
+                method,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            });
+            if (!resp.ok) throw new Error(`Request failed: ${method} ${url}`);
+            return resp.json();
+        }
+    }
+
+    global.MealEditModal = MealEditModal;
+    global.mealTodayLocal = todayLocal;
+})(window);

--- a/templates/_meal_edit_modal.html
+++ b/templates/_meal_edit_modal.html
@@ -1,0 +1,50 @@
+<!--
+  Shared meal add/edit modal.
+
+  Included by both the Meal Planner (Current & Upcoming) and Meal History
+  (Previous Meals) pages so the edit experience has a single source of truth.
+  Behavior lives in /static/meal_edit_modal.js (class MealEditModal); each page
+  constructs one with page-specific hooks.
+-->
+<div class="modal-overlay" id="modal-overlay">
+    <div class="modal-content">
+        <h3 id="modal-title">Add Meal Plan</h3>
+        <form id="plan-form">
+            <input type="hidden" id="plan-edit-id">
+            <div class="form-group">
+                <label>Date</label>
+                <input type="date" id="plan-date" required>
+            </div>
+            <div class="form-group">
+                <label>Meal Type</label>
+                <select id="plan-meal-type" required>
+                    <option value="Breakfast">Breakfast</option>
+                    <option value="Lunch">Lunch</option>
+                    <option value="Dinner">Dinner</option>
+                    <option value="Snacks">Snacks</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label>Meal Plan</label>
+                <textarea id="plan-text" placeholder="What's on the menu?" required rows="3"></textarea>
+            </div>
+            <div class="form-group">
+                <label>Who's Eating? <small>(leave unchecked for everyone)</small></label>
+                <div class="checkbox-group" id="attendee-checkboxes">
+                    <!-- Populated from /api/family -->
+                </div>
+            </div>
+            <div class="form-group">
+                <label>Who's Cooking? <small>(optional)</small></label>
+                <select id="plan-cook">
+                    <option value="">— nobody assigned —</option>
+                </select>
+            </div>
+            <div class="modal-actions">
+                <button type="submit" class="btn-primary">Save</button>
+                <button type="button" class="btn-cancel" id="btn-cancel">Cancel</button>
+                <button type="button" class="btn-delete modal-delete" id="btn-delete-plan" style="display:none">Delete</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/templates/dinner_planner.html
+++ b/templates/dinner_planner.html
@@ -55,60 +55,19 @@
         </div>
     </div>
 
-    <!-- Modal for add/edit -->
-    <div class="modal-overlay" id="modal-overlay">
-        <div class="modal-content">
-            <h3 id="modal-title">Add Meal Plan</h3>
-            <form id="plan-form">
-                <input type="hidden" id="plan-edit-id">
-                <div class="form-group">
-                    <label>Date</label>
-                    <input type="date" id="plan-date" required>
-                </div>
-                <div class="form-group">
-                    <label>Meal Type</label>
-                    <select id="plan-meal-type" required>
-                        <option value="Breakfast">Breakfast</option>
-                        <option value="Lunch">Lunch</option>
-                        <option value="Dinner">Dinner</option>
-                        <option value="Snacks">Snacks</option>
-                    </select>
-                </div>
-                <div class="form-group">
-                    <label>Meal Plan</label>
-                    <textarea id="plan-text" placeholder="What's on the menu?" required rows="3"></textarea>
-                </div>
-                <div class="form-group">
-                    <label>Who's Eating? <small>(leave unchecked for everyone)</small></label>
-                    <div class="checkbox-group" id="attendee-checkboxes">
-                        <!-- Populated from /api/family -->
-                    </div>
-                </div>
-                <div class="form-group">
-                    <label>Who's Cooking? <small>(optional)</small></label>
-                    <select id="plan-cook">
-                        <option value="">— nobody assigned —</option>
-                    </select>
-                </div>
-                <div class="modal-actions">
-                    <button type="submit" class="btn-primary">Save</button>
-                    <button type="button" class="btn-cancel" id="btn-cancel">Cancel</button>
-                    <button type="button" class="btn-delete modal-delete" id="btn-delete-plan" style="display:none" onclick="confirmDeleteFromModal()">Delete</button>
-                </div>
-            </form>
-        </div>
-    </div>
+    <!-- Shared meal add/edit modal (see templates/_meal_edit_modal.html) -->
+    {% include "_meal_edit_modal.html" %}
 
+    <script src="/static/meal_edit_modal.js?v={{ css_version }}"></script>
     <script>
         // State
         let plans = [];
         let familyMembers = [];
-        let editingId = null;
         let defaultMealType = 'Dinner';
         let localTimezone = 'UTC';
         let selectedMealTypes = new Set();
+        let mealModal = null;  // shared MealEditModal instance
 
-        const MEAL_TYPES = ['Breakfast', 'Lunch', 'Dinner', 'Snacks'];
         const MEAL_TYPE_ORDER = { 'Breakfast': 0, 'Lunch': 1, 'Dinner': 2, 'Snacks': 3 };
 
         // Today's date (YYYY-MM-DD) in the configured local timezone.
@@ -145,37 +104,10 @@
         async function fetchFamilyMembers() {
             const response = await fetch('/api/family');
             familyMembers = await response.json();
-            populateFamilyControls();
         }
 
         function getMemberById(id) {
             return familyMembers.find(m => m.id === id);
-        }
-
-        function populateFamilyControls() {
-            // Attendee checkboxes
-            const checkboxGroup = document.getElementById('attendee-checkboxes');
-            checkboxGroup.innerHTML = familyMembers.map(m =>
-                `<label class="checkbox-label"><input type="checkbox" class="attendee-cb" value="${m.id}"> ${escapeHtml(m.name)}</label>`
-            ).join('');
-
-            // Cook dropdown
-            const cookSelect = document.getElementById('plan-cook');
-            cookSelect.innerHTML = '<option value="">— nobody assigned —</option>';
-            familyMembers.forEach(m => {
-                cookSelect.innerHTML += `<option value="${m.id}">${escapeHtml(m.name)}</option>`;
-            });
-        }
-
-        function getSelectedAttendeeIds() {
-            const checked = document.querySelectorAll('.attendee-cb:checked');
-            const ids = Array.from(checked).map(cb => parseInt(cb.value));
-            return ids.length > 0 ? ids : null;  // null = everyone
-        }
-
-        function getSelectedCookId() {
-            const val = document.getElementById('plan-cook').value;
-            return val ? parseInt(val) : null;
         }
 
         // Settings
@@ -189,15 +121,6 @@
             } catch (_) {
                 defaultMealType = 'Dinner';
             }
-            populateMealTypeSelector();
-        }
-
-        function populateMealTypeSelector() {
-            const select = document.getElementById('plan-meal-type');
-            select.innerHTML = MEAL_TYPES.map(t => {
-                const label = t === defaultMealType ? `${t} (default)` : t;
-                return `<option value="${t}">${label}</option>`;
-            }).join('');
         }
 
         // API calls
@@ -216,33 +139,6 @@
                 });
 
             renderPlans();
-        }
-
-        async function savePlan(data) {
-            const response = await fetch('/api/dinner-plans', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data)
-            });
-            if (!response.ok) throw new Error('Failed to save plan');
-            return response.json();
-        }
-
-        async function updatePlan(id, data) {
-            const response = await fetch(`/api/dinner-plans/${id}`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data)
-            });
-            if (!response.ok) throw new Error('Failed to update plan');
-            return response.json();
-        }
-
-        async function deletePlan(id) {
-            const response = await fetch(`/api/dinner-plans/${id}`, {
-                method: 'DELETE'
-            });
-            if (!response.ok) throw new Error('Failed to delete plan');
         }
 
         // Apply the active meal-type filter (empty selection = show all).
@@ -300,60 +196,10 @@
             return div.innerHTML;
         }
 
-        // Modal
-        function openAddModal() {
-            editingId = null;
-            document.getElementById('modal-title').textContent = 'Add Meal Plan';
-            document.getElementById('plan-form').reset();
-            document.getElementById('plan-edit-id').value = '';
-            document.getElementById('plan-date').value = new Date().toISOString().split('T')[0];
-            // Pre-select default meal type
-            document.getElementById('plan-meal-type').value = defaultMealType;
-            document.querySelectorAll('.attendee-cb').forEach(cb => cb.checked = false);
-            document.getElementById('plan-cook').value = '';
-            document.getElementById('btn-delete-plan').style.display = 'none';
-            document.getElementById('modal-overlay').style.display = 'flex';
-        }
-
+        // Modal — the shared MealEditModal (static/meal_edit_modal.js) owns the
+        // add/edit/delete behavior. Called from the per-card Edit button.
         function openEditModal(id) {
-            const plan = plans.find(p => p.id === id);
-            if (!plan) return;
-
-            editingId = id;
-            document.getElementById('modal-title').textContent = 'Edit Meal Plan';
-            document.getElementById('plan-edit-id').value = id;
-            document.getElementById('plan-date').value = plan.date;
-            document.getElementById('plan-meal-type').value = plan.meal_type || 'Dinner';
-            document.getElementById('plan-text').value = plan.plan;
-
-            // Set attendee checkboxes
-            document.querySelectorAll('.attendee-cb').forEach(cb => {
-                cb.checked = plan.attendee_ids && plan.attendee_ids.includes(parseInt(cb.value));
-            });
-
-            // Set cook dropdown
-            document.getElementById('plan-cook').value = plan.cook_id || '';
-
-            document.getElementById('btn-delete-plan').style.display = '';
-            document.getElementById('modal-overlay').style.display = 'flex';
-        }
-
-        function closeModal() {
-            document.getElementById('modal-overlay').style.display = 'none';
-            editingId = null;
-        }
-
-        async function confirmDeleteFromModal() {
-            if (!editingId) return;
-            if (!confirm('Are you sure you want to delete this meal plan?')) return;
-            try {
-                await deletePlan(editingId);
-                closeModal();
-                await fetchPlans();
-            } catch (error) {
-                console.error('Error deleting plan:', error);
-                alert('Failed to delete meal plan');
-            }
+            mealModal.openEdit(plans.find(p => p.id === id));
         }
 
         // Meal type filter: multi-select (any of the selected types). Filtering
@@ -380,37 +226,16 @@
         });
 
         // Event handlers
-        document.getElementById('btn-add-meal').addEventListener('click', openAddModal);
-        document.getElementById('btn-cancel').addEventListener('click', closeModal);
-        document.getElementById('modal-overlay').addEventListener('click', (e) => {
-            if (e.target.id === 'modal-overlay') closeModal();
-        });
-
-        document.getElementById('plan-form').addEventListener('submit', async (e) => {
-            e.preventDefault();
-
-            const date = document.getElementById('plan-date').value;
-            const meal_type = document.getElementById('plan-meal-type').value;
-            const plan = document.getElementById('plan-text').value;
-            const attendee_ids = getSelectedAttendeeIds();
-            const cook_id = getSelectedCookId();
-
-            try {
-                if (editingId) {
-                    await updatePlan(editingId, { date, meal_type, plan, attendee_ids, cook_id });
-                } else {
-                    await savePlan({ date, meal_type, plan, attendee_ids, cook_id });
-                }
-                closeModal();
-                await fetchPlans();
-            } catch (error) {
-                console.error('Error saving plan:', error);
-                alert('Failed to save meal plan');
-            }
-        });
+        document.getElementById('btn-add-meal').addEventListener('click', () => mealModal.openAdd());
 
         // Initialize — settings and family members load before plans render
         Promise.all([fetchDefaultMealType(), fetchFamilyMembers()]).then(() => {
+            mealModal = new MealEditModal({
+                getFamilyMembers: () => familyMembers,
+                getDefaultMealType: () => defaultMealType,
+                getTimezone: () => localTimezone,
+                onSaved: fetchPlans,
+            });
             fetchPlans();
         });
 

--- a/templates/meal_history.html
+++ b/templates/meal_history.html
@@ -96,6 +96,10 @@
         </div>
     </div>
 
+    <!-- Shared meal add/edit modal (see templates/_meal_edit_modal.html) -->
+    {% include "_meal_edit_modal.html" %}
+
+    <script src="/static/meal_edit_modal.js?v={{ css_version }}"></script>
     <script>
         // State
         let historyPlans = [];
@@ -103,6 +107,9 @@
         let currentSort = 'rating_desc';
         let currentMinRating = '';
         let selectedMealTypes = new Set();
+        let defaultMealType = 'Dinner';
+        let localTimezone = 'UTC';
+        let mealModal = null;  // shared MealEditModal instance
 
         // Star rating state
         let selectedRating = 0;
@@ -111,6 +118,20 @@
         async function fetchFamilyMembers() {
             const response = await fetch('/api/family');
             familyMembers = await response.json();
+        }
+
+        // Settings — needed by the shared edit modal (default meal type, and the
+        // timezone that decides whether an edited date lands on the planner).
+        async function fetchSettings() {
+            try {
+                const response = await fetch('/api/settings');
+                const data = await response.json();
+                const s = data.settings || {};
+                defaultMealType = s.meal_default_type || 'Dinner';
+                localTimezone = s.local_timezone || 'UTC';
+            } catch (_) {
+                defaultMealType = 'Dinner';
+            }
         }
 
         function getMemberById(id) {
@@ -192,6 +213,7 @@
                 const ratingRow = `<div class="history-card-rating-row">
                     ${renderStars(plan.rating)}
                     <button class="btn-edit" onclick="openReviewModal(${plan.id})">${plan.rating ? 'Edit Review' : 'Add Review'}</button>
+                    <button class="btn-edit" onclick="openEditModal(${plan.id})">Edit</button>
                 </div>`;
 
                 return `
@@ -205,6 +227,13 @@
                     </div>
                 `;
             }).join('');
+        }
+
+        // Edit modal — the shared MealEditModal (static/meal_edit_modal.js) owns
+        // the edit/delete behavior. Editing a meal's date onto the planner
+        // (today or later) discards its rating/review after a confirm prompt.
+        function openEditModal(planId) {
+            mealModal.openEdit(historyPlans.find(p => p.id === planId));
         }
 
         // Review modal
@@ -355,8 +384,14 @@
             document.getElementById('meal-dropdown').classList.remove('open');
         });
 
-        // Initialize
-        fetchFamilyMembers().then(() => {
+        // Initialize — settings and family members load before the modal and list
+        Promise.all([fetchSettings(), fetchFamilyMembers()]).then(() => {
+            mealModal = new MealEditModal({
+                getFamilyMembers: () => familyMembers,
+                getDefaultMealType: () => defaultMealType,
+                getTimezone: () => localTimezone,
+                onSaved: fetchHistory,
+            });
             fetchHistory();
         });
     </script>

--- a/tests/test_dinner_planner.py
+++ b/tests/test_dinner_planner.py
@@ -268,6 +268,73 @@ def test_history_respects_local_timezone(client, make_dinner_plan, frozen_now, l
     assert dates == ["2026-05-09"]
 
 
+# --- Moving a meal onto the planner discards its rating/review -----------------
+#
+# A rating/review only makes sense for a past meal (Meal History). Editing a
+# meal's date to today or later moves it onto the Meal Planner, which clears any
+# rating and review. The frozen "today" here is TODAY (2026-05-10, UTC).
+
+
+def test_update_date_to_today_discards_rating_and_review(client, make_dinner_plan, frozen_now):
+    frozen_now(TODAY)
+    plan = make_dinner_plan("2026-05-01", plan="Tacos", rating=5, review="Great")
+
+    body = client.put(f"/api/dinner-plans/{plan.id}", json={"date": "2026-05-10"}).json()
+
+    assert body["date"] == "2026-05-10"
+    assert body["rating"] is None
+    assert body["review"] is None
+
+
+def test_update_date_to_future_discards_rating_and_review(client, make_dinner_plan, frozen_now):
+    frozen_now(TODAY)
+    plan = make_dinner_plan("2026-05-01", plan="Tacos", rating=4, review="Yum")
+
+    body = client.put(f"/api/dinner-plans/{plan.id}", json={"date": "2026-06-01"}).json()
+
+    assert body["rating"] is None
+    assert body["review"] is None
+
+
+def test_update_date_still_past_keeps_rating_and_review(client, make_dinner_plan, frozen_now):
+    frozen_now(TODAY)
+    plan = make_dinner_plan("2026-05-01", plan="Tacos", rating=5, review="Great")
+
+    body = client.put(f"/api/dinner-plans/{plan.id}", json={"date": "2026-05-05"}).json()
+
+    assert body["date"] == "2026-05-05"
+    assert body["rating"] == 5
+    assert body["review"] == "Great"
+
+
+def test_update_without_date_change_keeps_rating_and_review(client, make_dinner_plan, frozen_now):
+    frozen_now(TODAY)
+    plan = make_dinner_plan("2026-05-01", plan="Tacos", rating=5, review="Great")
+
+    # No date field in the payload -> rating/review untouched even though the
+    # meal's date remains in the past.
+    body = client.put(f"/api/dinner-plans/{plan.id}", json={"plan": "Tacos al pastor"}).json()
+
+    assert body["plan"] == "Tacos al pastor"
+    assert body["rating"] == 5
+    assert body["review"] == "Great"
+
+
+def test_update_respects_local_timezone_for_planner_boundary(
+    client, make_dinner_plan, frozen_now, local_timezone
+):
+    # At 02:00Z the local date in Kolkata (+05:30) is already 2026-05-10, so
+    # editing a meal to 2026-05-10 moves it onto the planner and clears its rating.
+    frozen_now(datetime(2026, 5, 10, 2, 0, tzinfo=UTC))
+    local_timezone("Asia/Kolkata")
+    plan = make_dinner_plan("2026-05-08", plan="Tacos", rating=5, review="Great")
+
+    body = client.put(f"/api/dinner-plans/{plan.id}", json={"date": "2026-05-10"}).json()
+
+    assert body["rating"] is None
+    assert body["review"] is None
+
+
 # --- DB-level rating constraint ------------------------------------------------
 
 

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -13,6 +13,16 @@ def test_page_renders_html(client, path):
     assert resp.headers["content-type"].startswith("text/html")
 
 
+@pytest.mark.parametrize("path", ["/dinner-planner", "/meal-history"])
+def test_meal_pages_include_shared_edit_modal(client, path):
+    """Both meal pages render the shared edit modal partial and load its JS, so
+    the edit experience has a single source of truth."""
+    html = client.get(path).text
+    assert 'id="modal-overlay"' in html  # markup from _meal_edit_modal.html
+    assert 'id="plan-form"' in html
+    assert "/static/meal_edit_modal.js" in html
+
+
 def test_root_redirects_to_dashboard(client):
     resp = client.get("/", follow_redirects=False)
     assert resp.status_code in (307, 308)


### PR DESCRIPTION
## Summary

Adds full editing of past meals on the **Meal History** (`Previous Meals`) page. Previously only a meal's **review** (rating + text) could be edited there; its date, meal type, plan, attendees, and cook could not be changed once the meal fell into the past. Editing now uses the **same modal as the Meal Planner**, extracted into a shared component so both pages stay in sync. The `Add Review` / `Edit Review` buttons are unchanged and remain how ratings/reviews are handled. Since a rating/review only makes sense for a past meal, moving a meal's date onto the planner (today or later) discards its rating and review after a confirmation.

## Changes

**Frontend**
- Extract the meal add/edit modal into a shared partial `templates/_meal_edit_modal.html` and a `MealEditModal` class in `static/meal_edit_modal.js`; both meal pages include the partial and construct the class, giving the modal one source of truth.
- `templates/dinner_planner.html`: replace the inline modal markup + ~190 lines of modal JS with the shared partial and a `MealEditModal` instance (behavior unchanged).
- `templates/meal_history.html`: add an `Edit` button to each `history-card` that opens the shared modal; load settings for the timezone used by the discard check. `Add Review` / `Edit Review` left as-is.

**Backend**
- `src/rally/routers/dinner_planner.py`: when `update_dinner_plan` sets a date that lands on the planner (`>= today` in the configured timezone), clear `rating` and `review`. Factor a `_today_local_str()` helper shared with the history endpoint so both agree on the day boundary.

**Docs / config**
- `AGENTS.md`: new guidance — never destructively mutate the local dev database; prefer the isolated pytest DB, or `resetdb && seed` and restore from `src/rally/cli.py`.
- `.gitignore`: ignore `.claude/` (local agent config).

**Tests**
- `tests/test_dinner_planner.py`: cover the discard rule — date moved to today/future clears rating+review; date staying in the past keeps them; an update without a date change keeps them; and the timezone boundary is respected.
- `tests/test_pages.py`: assert both meal pages render the shared edit-modal partial and load its JS.

## Notes for reviewers

- The discard rule is enforced **server-side** (the invariant holds regardless of caller); the client only adds the confirmation prompt (`"Moving this meal to the planner will discard its rating and review. Continue?"`). Cancelling keeps the modal open.
- The **review modal stays local to Meal History** — it is not shared, since only that page uses it. Only the edit modal is shared.
- Verified manually end-to-end: editing a rated past meal's date to the future fired the confirmation, and on confirm the API returned `rating: null` / `review: null` with the meal now on the planner; the planner's own add/edit path still works after the refactor.

## Testing

- `uv run pytest` — 298 passed (5 new backend tests + 1 new page test).
- `ruff check` and `ruff format --check` — clean.
- Manual browser run against a seeded DB: confirmation dialog, server-side discard, meal appearing on the planner, and planner Add/Edit modal all verified. (The one sample row mutated during testing was restored.)

Closes #123
