### PR TITLE
Fade modal content at overflow edges

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -265,8 +265,7 @@ footer a:hover {
 
 /* Wrapper positioned over the scroll viewport. Its ::before/::after paint a
    fade in the modal's background colour over the top/bottom edges — a plain
-   overlay rather than a CSS mask, which would break native <select>/date
-   pickers inside the scroller (they close immediately) in Firefox. */
+   overlay rather than a CSS mask.*/
 .modal-scroll {
     position: relative;
     flex: 1;

--- a/static/styles.css
+++ b/static/styles.css
@@ -246,7 +246,11 @@ footer a:hover {
     padding: 32px;
     width: 90%;
     max-width: 500px;
-    max-height: 95vh;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    /* Fallback scroll for modals without a .modal-body wrapper. Modals that
+       use .modal-body never trigger this — their body flexes to fit. */
     overflow: auto;
 }
 
@@ -256,7 +260,57 @@ footer a:hover {
     margin-bottom: 24px;
     text-transform: uppercase;
     letter-spacing: 0.1em;
+    flex-shrink: 0;
 }
+
+/* Wrapper positioned over the scroll viewport. Its ::before/::after paint a
+   fade in the modal's background colour over the top/bottom edges — a plain
+   overlay rather than a CSS mask, which would break native <select>/date
+   pickers inside the scroller (they close immediately) in Firefox. */
+.modal-scroll {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Scrollable inner area — the form and actions scroll together. */
+.modal-body {
+    overflow-y: auto;
+    flex: 1;
+    min-height: 0;
+    /* Padding so content isn't clipped under the scrollbar. */
+    padding: 0 4px 0 0;
+}
+
+.modal-scroll::before,
+.modal-scroll::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 32px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    z-index: 1;
+}
+
+.modal-scroll::before {
+    top: 0;
+    background: linear-gradient(to bottom, var(--white), transparent);
+}
+
+.modal-scroll::after {
+    bottom: 0;
+    background: linear-gradient(to top, var(--white), transparent);
+}
+
+/* Fade an edge only when content is actually hidden in that direction, so the
+   Save/Cancel buttons render crisp once you scroll to the bottom. */
+.modal-scroll[data-overflow-top]::before { opacity: 1; }
+.modal-scroll[data-overflow-bottom]::after { opacity: 1; }
 
 .modal-actions {
     display: flex;

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -80,6 +80,8 @@
     <div class="modal-overlay" id="recurring-modal-overlay">
         <div class="modal-content">
             <h3 id="recurring-modal-title">Add Recurring Task</h3>
+            <div class="modal-scroll">
+            <div class="modal-body">
             <form id="recurring-form">
                 <input type="hidden" id="recurring-id">
                 <div class="form-group">
@@ -181,12 +183,14 @@
                     <label>Include in The Briefing starting <input type="number" id="recurring-remind-days" min="0" step="1" placeholder="e.g. 3" class="remind-days-input"> days before the due date</label>
                     <small>Leave blank to always include in briefings</small>
                 </div>
+            </form>
                 <div class="modal-actions">
-                    <button type="submit" class="btn-primary">Save</button>
+                    <button type="submit" form="recurring-form" class="btn-primary">Save</button>
                     <button type="button" class="btn-cancel" id="btn-cancel-recurring">Cancel</button>
                     <button type="button" class="btn-delete modal-delete" id="btn-delete-recurring" style="display:none" onclick="confirmDeleteRecurringFromModal()">Delete</button>
                 </div>
-            </form>
+            </div>
+            </div>
         </div>
     </div>
 
@@ -194,37 +198,41 @@
     <div class="modal-overlay" id="modal-overlay">
         <div class="modal-content">
             <h3 id="modal-title">Add Task</h3>
-            <form id="todo-form">
-                <input type="hidden" id="todo-id">
-                <div class="form-group">
-                    <label>Task</label>
-                    <input type="text" id="todo-title" placeholder="Task title" required>
-                </div>
-                <div class="form-group">
-                    <label>Notes (optional)</label>
-                    <textarea id="todo-description" placeholder="Additional details" rows="3"></textarea>
-                </div>
-                <div class="form-group">
-                    <label>Assigned To (optional)</label>
-                    <select id="todo-assigned-to">
-                        <option value="">Unassigned</option>
-                    </select>
-                </div>
-                <div class="form-group">
-                    <label>Due Date (optional)</label>
-                    <input type="date" id="todo-due-date">
-                    <small>Leave blank if no specific deadline</small>
-                </div>
-                <div class="form-group" id="todo-remind-group" style="display:none;">
-                    <label>Include in The Briefing starting <input type="number" id="todo-remind-days" min="0" step="1" placeholder="e.g. 3" class="remind-days-input"> days before the due date</label>
-                    <small>Leave blank to always include in briefings</small>
-                </div>
+            <div class="modal-scroll">
+            <div class="modal-body">
+                <form id="todo-form">
+                    <input type="hidden" id="todo-id">
+                    <div class="form-group">
+                        <label>Task</label>
+                        <input type="text" id="todo-title" placeholder="Task title" required>
+                    </div>
+                    <div class="form-group">
+                        <label>Notes (optional)</label>
+                        <textarea id="todo-description" placeholder="Additional details" rows="3"></textarea>
+                    </div>
+                    <div class="form-group">
+                        <label>Assigned To (optional)</label>
+                        <select id="todo-assigned-to">
+                            <option value="">Unassigned</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label>Due Date (optional)</label>
+                        <input type="date" id="todo-due-date">
+                        <small>Leave blank if no specific deadline</small>
+                    </div>
+                    <div class="form-group" id="todo-remind-group" style="display:none;">
+                        <label>Include in The Briefing starting <input type="number" id="todo-remind-days" min="0" step="1" placeholder="e.g. 3" class="remind-days-input"> days before the due date</label>
+                        <small>Leave blank to always include in briefings</small>
+                    </div>
+                </form>
                 <div class="modal-actions">
-                    <button type="submit" class="btn-primary">Save</button>
+                    <button type="submit" form="todo-form" class="btn-primary">Save</button>
                     <button type="button" class="btn-cancel" id="btn-cancel">Cancel</button>
                     <button type="button" class="btn-delete modal-delete" id="btn-delete-todo" style="display:none" onclick="confirmDeleteFromModal()">Delete</button>
                 </div>
-            </form>
+            </div>
+            </div>
         </div>
     </div>
 
@@ -497,7 +505,7 @@
             document.getElementById('todo-remind-days').value = '';
             document.getElementById('btn-delete-todo').style.display = 'none';
             toggleRemindGroup();
-            document.getElementById('modal-overlay').style.display = 'flex';
+            showModalOverlay('modal-overlay');
         }
 
         function openEditModal(id) {
@@ -514,7 +522,7 @@
             document.getElementById('todo-remind-days').value = todo.remind_days_before != null ? todo.remind_days_before : '';
             document.getElementById('btn-delete-todo').style.display = '';
             toggleRemindGroup();
-            document.getElementById('modal-overlay').style.display = 'flex';
+            showModalOverlay('modal-overlay');
         }
 
         function closeModal() {
@@ -813,7 +821,7 @@
             resetCustomFields();
             updateDaySelector();
             toggleRecurringRemindGroup();
-            document.getElementById('recurring-modal-overlay').style.display = 'flex';
+            showModalOverlay('recurring-modal-overlay');
         }
 
         function openEditRecurringModal(id) {
@@ -838,7 +846,7 @@
             document.getElementById('recurring-remind-days').value = rt.remind_days_before != null ? rt.remind_days_before : '';
             document.getElementById('btn-delete-recurring').style.display = '';
             toggleRecurringRemindGroup();
-            document.getElementById('recurring-modal-overlay').style.display = 'flex';
+            showModalOverlay('recurring-modal-overlay');
         }
 
         function closeRecurringModal() {
@@ -926,6 +934,36 @@
                 alert('Failed to save recurring task');
             }
         });
+
+        // Fade the top/bottom edges of a scrollable modal only when content is
+        // hidden in that direction, so the scrolled-to actions stay crisp.
+        function updateModalFade(scroll) {
+            const body = scroll.querySelector('.modal-body');
+            const maxScroll = body.scrollHeight - body.clientHeight;
+            scroll.toggleAttribute('data-overflow-top', body.scrollTop > 1);
+            scroll.toggleAttribute('data-overflow-bottom', body.scrollTop < maxScroll - 1);
+        }
+        document.querySelectorAll('.modal-scroll').forEach(scroll => {
+            const body = scroll.querySelector('.modal-body');
+            const refresh = () => updateModalFade(scroll);
+            body.addEventListener('scroll', refresh);
+            // Recompute when fields toggle the body's height (e.g. switching
+            // to custom recurrence). Field handlers run before this bubbles.
+            body.addEventListener('change', refresh);
+            // Backstop for size changes not driven by a change event.
+            if (window.ResizeObserver) {
+                const ro = new ResizeObserver(refresh);
+                Array.from(body.children).forEach(child => ro.observe(child));
+            }
+        });
+
+        // Show a modal and compute its fade state once it's laid out.
+        function showModalOverlay(overlayId) {
+            const overlay = document.getElementById(overlayId);
+            overlay.style.display = 'flex';
+            const scroll = overlay.querySelector('.modal-scroll');
+            if (scroll) requestAnimationFrame(() => updateModalFade(scroll));
+        }
 
         // Initialize
         fetchFamilyMembers().then(() => {


### PR DESCRIPTION
## Summary

Implements #45 — modal content now **fades out at the top/bottom edges when it overflows**, instead of being clipped abruptly at the container edge.

## Changes

- Each modal is restructured into a **fixed title above a scrollable body** (`.modal-scroll` wrapping `.modal-body`), which holds the form and its actions.
- A gradient overlay in the modal's background colour is painted over the top/bottom edges of the scroll area via `.modal-scroll`'s `::before`/`::after`. It shows **only on an edge that actually has hidden content**, so content stays crisp at the edge you've scrolled to.
- `.modal-content` keeps `overflow: auto` as a fallback so other modals (settings, meal) that don't use `.modal-body` still scroll unchanged.

## Verification

Checked in-browser (Chromium):
- Fade shows only on edges with hidden content; content crisp at the scrolled-to edge.
- No double scrollbar; no console errors.
- Settings/meal modals unaffected.

## Known limitation

Native date/`<select>` pickers close immediately in **Firefox Responsive Design Mode** — a [known Firefox RDM bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1505705) with native popups, independent of this change. Normal Firefox and real mobile browsers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)