### PR TITLE
Advance recurrence reference past late completion dates

### DIFF
--- a/src/rally/recurrence.py
+++ b/src/rally/recurrence.py
@@ -285,7 +285,24 @@ def _resolve_reference_date(rt: RecurringTodo, db: Session) -> date | None:
             .first()
         )
         if latest_completed:
-            return max(ref, date.fromisoformat(latest_completed.due_date))
+            ref = max(ref, date.fromisoformat(latest_completed.due_date))
+        # If the task was completed *after* its scheduled date, advance the
+        # reference past any occurrences that already elapsed, so the next
+        # instance is scheduled in the future instead of on an already-past
+        # date. On-time or early completions leave the reference unchanged
+        # (completed_at falls on or before the scheduled date).
+        latest_completion = (
+            db.query(Todo)
+            .filter(
+                Todo.recurring_todo_id == rt.id,
+                Todo.completed == True,  # noqa: E712
+                Todo.completed_at.isnot(None),
+            )
+            .order_by(Todo.completed_at.desc())
+            .first()
+        )
+        if latest_completion:
+            ref = max(ref, latest_completion.completed_at.date())
         return ref
 
     # Backfill: find the most recent instance by due_date (or created_at)

--- a/tests/test_recurrence.py
+++ b/tests/test_recurrence.py
@@ -417,6 +417,97 @@ def test_process_reference_advances_past_completed_reschedule(
     assert due_dates == {"2026-03-14", "2026-03-15"}
 
 
+def test_process_late_completion_skips_elapsed_occurrence(
+    db_session, make_recurring_todo, make_todo, frozen_now
+):
+    frozen_now(FROZEN)
+    # Weekly-Sunday task last generated for Sun Mar 1. The instance was not
+    # completed until Mon Mar 9 -- after the Mar 8 occurrence already elapsed.
+    # The next instance should be the next *future* Sunday (Mar 15), not Mar 8.
+    template = make_recurring_todo(
+        "Swap sheets",
+        recurrence_type="weekly",
+        recurrence_day=6,  # Sunday
+        has_due_date=True,
+        last_generated_date="2026-03-01",
+    )
+    make_todo(
+        "Swap sheets",
+        completed=True,
+        due_date="2026-03-01",
+        completed_at=datetime(2026, 3, 9, 12, 0, tzinfo=UTC),
+        recurring_todo_id=template.id,
+    )
+
+    created = process_recurring_todos(db_session)
+
+    assert created == 1
+    assert template.last_generated_date == "2026-03-15"
+    due_dates = {t.due_date for t in _instances(db_session, template.id)}
+    # Mar 8 was skipped; no already-past instance was generated.
+    assert "2026-03-08" not in due_dates
+    assert "2026-03-15" in due_dates
+
+
+def test_process_late_completion_skips_multiple_elapsed_periods(
+    db_session, make_recurring_todo, make_todo, frozen_now
+):
+    frozen_now(FROZEN)
+    # Daily task last generated Mar 10, completed 4 days late (Mar 14). Only the
+    # single next future occurrence (Mar 15) is generated -- not a backlog of the
+    # skipped Mar 11-14 instances.
+    template = make_recurring_todo(
+        "Vitamins",
+        recurrence_type="daily",
+        has_due_date=True,
+        last_generated_date="2026-03-10",
+    )
+    make_todo(
+        "Vitamins",
+        completed=True,
+        due_date="2026-03-10",
+        completed_at=datetime(2026, 3, 14, 12, 0, tzinfo=UTC),
+        recurring_todo_id=template.id,
+    )
+
+    created = process_recurring_todos(db_session)
+
+    assert created == 1
+    assert template.last_generated_date == "2026-03-15"
+    new_due_dates = {
+        t.due_date for t in _instances(db_session, template.id) if not t.completed
+    }
+    assert new_due_dates == {"2026-03-15"}
+
+
+def test_process_early_completion_keeps_cadence(
+    db_session, make_recurring_todo, make_todo, frozen_now
+):
+    frozen_now(FROZEN)
+    # Completed on or before its scheduled date -> completion date must NOT push
+    # the reference forward; the next instance follows the normal cadence.
+    template = make_recurring_todo(
+        "Swap sheets",
+        recurrence_type="weekly",
+        recurrence_day=6,  # Sunday
+        has_due_date=True,
+        last_generated_date="2026-03-08",
+    )
+    make_todo(
+        "Swap sheets",
+        completed=True,
+        due_date="2026-03-08",
+        completed_at=datetime(2026, 3, 5, 12, 0, tzinfo=UTC),  # completed early
+        recurring_todo_id=template.id,
+    )
+
+    created = process_recurring_todos(db_session)
+
+    assert created == 1
+    # Next Sunday after Mar 8, unchanged by the early completion.
+    assert template.last_generated_date == "2026-03-15"
+
+
 def test_process_counts_multiple_and_ignores_inactive(db_session, make_recurring_todo, frozen_now):
     frozen_now(FROZEN)
     make_recurring_todo("Active A", recurrence_type="daily", has_due_date=True)

--- a/tests/test_recurrence.py
+++ b/tests/test_recurrence.py
@@ -474,9 +474,7 @@ def test_process_late_completion_skips_multiple_elapsed_periods(
 
     assert created == 1
     assert template.last_generated_date == "2026-03-15"
-    new_due_dates = {
-        t.due_date for t in _instances(db_session, template.id) if not t.completed
-    }
+    new_due_dates = {t.due_date for t in _instances(db_session, template.id) if not t.completed}
     assert new_due_dates == {"2026-03-15"}
 
 


### PR DESCRIPTION
## Summary

Fixes #126.

When a recurring task instance is completed **after** its next scheduled occurrence has already elapsed, the engine generated the next instance on an already-past date (e.g. completing the Sun Jul 19 "Swap sheets" instance on Mon Jul 27 produced a next instance due Jul 26 — already overdue). This PR anchors the next occurrence to the later of the previous scheduled date and the **completion date**, so late completions roll forward to the next *future* occurrence (Aug 2 in that example).

## Change

- `_resolve_reference_date` (`src/rally/recurrence.py`) now folds the most recent instance's `completed_at` date into the reference `max`.
  - **Late completion** → reference advances past elapsed occurrences; next instance is the next future occurrence.
  - **On-time / early completion** → `completed_at` is on or before the scheduled date, so the `max` is unchanged and the existing cadence is preserved.
  - **Multiple missed periods** → still a single next-future instance (unchanged one-open-at-a-time model).
- Applies to all recurrence types (`daily`, `weekly`, `monthly`, `custom`).
- No schema change or data migration — `completed_at` is already stored.

## Tests

Added to `tests/test_recurrence.py`:
- `test_process_late_completion_skips_elapsed_occurrence` — weekly-Sunday late completion lands on the next future Sunday, not the elapsed one.
- `test_process_late_completion_skips_multiple_elapsed_periods` — a daily task completed several days late generates only the single next-future instance.
- `test_process_early_completion_keeps_cadence` — early completion does not push the schedule forward.

All recurrence tests pass and `ruff check` is clean.

> **Note:** 7 pre-existing `tests/test_pages.py` failures appear under an ad-hoc Python 3.14 venv (a Jinja version mismatch); confirmed they also fail on a clean tree and are unrelated to this change. Recommend a final run inside the project's `devenv`/`uv` environment before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
