### PR TITLE
Add due-date vs completion-date anchor for custom daily recurrences

### DIFF
--- a/src/rally/recurrence.py
+++ b/src/rally/recurrence.py
@@ -264,11 +264,59 @@ def get_first_recurrence_date(rt: RecurringTodo, today: date) -> date:
     return today
 
 
-def _resolve_reference_date(rt: RecurringTodo, db: Session) -> date | None:
+def _anchored_custom_daily(rt: RecurringTodo) -> bool:
+    """True when a template uses the configurable next-due-date anchor.
+
+    Only Custom "every N days" templates that set a due date on their generated
+    instances participate; every other template keeps the generic reference
+    logic.
+    """
+    return (
+        rt.recurrence_type == "custom"
+        and bool(rt.custom_rule)
+        and rt.custom_rule.get("freq") == "daily"
+        and rt.has_due_date
+    )
+
+
+def _anchor_reference(
+    rt: RecurringTodo,
+    due_ref: date,
+    latest_completion: Todo | None,
+    today: date,
+) -> date:
+    """Pick the reference date for an anchored custom "every N days" template.
+
+    get_next_recurrence_date() adds the interval (and the weekdays-only weekend
+    adjustment) to whatever reference we return, so selecting the reference is
+    enough to express both anchors:
+
+    - ``"completion_date"``: measure the next due date from when the last task
+      was actually completed.
+    - ``"due_date"`` (default): measure from the last task's due date, but if
+      that would land the next due date in the past (a very late completion),
+      fall back to the completion date so a task is never generated already
+      overdue.
+    """
+    anchor = rt.custom_rule.get("next_due_from", "due_date")
+    completion_ref = latest_completion.completed_at.date() if latest_completion else None
+
+    if anchor == "completion_date" and completion_ref is not None:
+        return completion_ref
+
+    # "due_date" (default), with a past-due fallback to the completion date.
+    if completion_ref is not None and get_next_recurrence_date(rt, due_ref) < today:
+        return completion_ref
+    return due_ref
+
+
+def _resolve_reference_date(rt: RecurringTodo, db: Session, today: date) -> date | None:
     """Determine the reference date for calculating the next instance.
 
-    Returns the recurrence date of the most recently generated instance,
-    or None if no instances have ever been created.
+    Returns the recurrence date of the most recently generated instance, or
+    None if no instances have ever been created. Custom "every N days"
+    templates with a due date honor the ``custom_rule["next_due_from"]`` anchor
+    (see _anchor_reference).
     """
     if rt.last_generated_date:
         ref = date.fromisoformat(rt.last_generated_date)
@@ -286,11 +334,6 @@ def _resolve_reference_date(rt: RecurringTodo, db: Session) -> date | None:
         )
         if latest_completed:
             ref = max(ref, date.fromisoformat(latest_completed.due_date))
-        # If the task was completed *after* its scheduled date, advance the
-        # reference past any occurrences that already elapsed, so the next
-        # instance is scheduled in the future instead of on an already-past
-        # date. On-time or early completions leave the reference unchanged
-        # (completed_at falls on or before the scheduled date).
         latest_completion = (
             db.query(Todo)
             .filter(
@@ -301,6 +344,15 @@ def _resolve_reference_date(rt: RecurringTodo, db: Session) -> date | None:
             .order_by(Todo.completed_at.desc())
             .first()
         )
+        # Custom "every N days" + due date: the user chooses whether the next
+        # due date is measured from the last task's due date or its completion.
+        if _anchored_custom_daily(rt):
+            return _anchor_reference(rt, ref, latest_completion, today)
+        # Generic behavior: if the task was completed *after* its scheduled
+        # date, advance the reference past any occurrences that already elapsed,
+        # so the next instance is scheduled in the future instead of on an
+        # already-past date. On-time or early completions leave the reference
+        # unchanged (completed_at falls on or before the scheduled date).
         if latest_completion:
             ref = max(ref, latest_completion.completed_at.date())
         return ref
@@ -348,7 +400,7 @@ def process_recurring_todos(db: Session) -> int:
             continue
 
         # Determine what recurrence date was last generated
-        ref_date = _resolve_reference_date(rt, db)
+        ref_date = _resolve_reference_date(rt, db, today)
 
         if ref_date:
             # Calculate the next recurrence date after the last generated one

--- a/static/styles.css
+++ b/static/styles.css
@@ -1270,6 +1270,31 @@ footer a:hover {
     accent-color: var(--charcoal);
     margin: 0;
 }
+
+/* A vertical list of plain (borderless) radio options — used for the custom
+   recurrence anchor and the monthly "day vs. weekday" mode selectors. */
+.radio-options {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 6px;
+}
+
+.radio-options label {
+    font-family: var(--body-font);
+    font-size: 0.9rem;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    color: var(--charcoal);
+    user-select: none;
+}
+
+.radio-options input[type="radio"] {
+    accent-color: var(--charcoal);
+    margin: 0;
+}
 /** End Custom Recurrence Styles **/
 
 /** Settings Page Styles **/

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -123,6 +123,19 @@
                             Schedule on weekdays only
                         </label>
                     </div>
+                    <div class="form-group" id="custom-next-due-from-group" style="display:none;">
+                        <label title="&quot;Due date of the last task&quot; keeps the original cadence — the interval after the last task's due date — but if that date has already passed, it falls back to the interval after completion so a task is never created already overdue. &quot;Date the last task was completed&quot; schedules the next task the interval after you finish the last one.">Calculate next due date from:</label>
+                        <div class="radio-options">
+                            <label>
+                                <input type="radio" name="custom-next-due-from" value="due_date" checked>
+                                Due date of the last task
+                            </label>
+                            <label>
+                                <input type="radio" name="custom-next-due-from" value="completion_date">
+                                Date the last task was completed
+                            </label>
+                        </div>
+                    </div>
                     <div class="form-group" id="custom-weekly-group" style="display:none;">
                         <label>On</label>
                         <div class="weekday-checkboxes" id="custom-weekdays">
@@ -137,9 +150,9 @@
                     </div>
                     <div class="form-group" id="custom-monthly-group" style="display:none;">
                         <label>On</label>
-                        <div style="margin-bottom:8px;">
-                            <label class="weekday-label"><input type="radio" name="custom-monthly-mode" value="day" checked> Day of month</label>
-                            <label class="weekday-label"><input type="radio" name="custom-monthly-mode" value="weekday"> Relative weekday</label>
+                        <div class="radio-options" style="margin-bottom:8px;">
+                            <label><input type="radio" name="custom-monthly-mode" value="day" checked> Day of month</label>
+                            <label><input type="radio" name="custom-monthly-mode" value="weekday"> Relative weekday</label>
                         </div>
                         <div id="custom-monthly-day-group">
                             <select id="custom-monthly-day"></select>
@@ -646,7 +659,10 @@
             const every = n === 1 ? 'Every' : `Every ${n}`;
             if (freq === 'daily') {
                 const base = n === 1 ? 'Daily' : `Every ${n} days`;
-                return rule.weekdays_only ? `${base} (weekdays only)` : base;
+                const notes = [];
+                if (rule.weekdays_only) notes.push('weekdays only');
+                if (rule.next_due_from === 'completion_date') notes.push('from completion date');
+                return notes.length ? `${base} (${notes.join(', ')})` : base;
             }
             if (freq === 'weekly') {
                 const days = (rule.weekdays || [0]).map(d => DAY_NAMES[d].slice(0, 3)).join(', ');
@@ -726,7 +742,12 @@
 
         function updateCustomSubGroups() {
             const freq = document.getElementById('custom-freq').value;
+            const hasDue = document.getElementById('recurring-has-due-date').checked;
             document.getElementById('custom-weekdays-only-group').style.display = freq === 'daily' ? '' : 'none';
+            // The due-date/completion-date anchor only applies to "every N days"
+            // templates that set a due date on their generated tasks.
+            document.getElementById('custom-next-due-from-group').style.display =
+                freq === 'daily' && hasDue ? '' : 'none';
             document.getElementById('custom-weekly-group').style.display = freq === 'weekly' ? '' : 'none';
             document.getElementById('custom-monthly-group').style.display = freq === 'monthly' ? '' : 'none';
             if (freq !== 'daily') {
@@ -746,11 +767,13 @@
             r.addEventListener('change', updateCustomMonthlyMode)
         );
         document.getElementById('recurring-has-due-date').addEventListener('change', toggleRecurringRemindGroup);
+        document.getElementById('recurring-has-due-date').addEventListener('change', updateCustomSubGroups);
 
         function resetCustomFields() {
             document.getElementById('custom-interval').value = '1';
             document.getElementById('custom-freq').value = 'daily';
             document.getElementById('custom-weekdays-only').checked = false;
+            document.querySelector('input[name="custom-next-due-from"][value="due_date"]').checked = true;
             document.querySelectorAll('#custom-weekdays input[type="checkbox"]').forEach(cb => cb.checked = false);
             document.querySelector('input[name="custom-monthly-mode"][value="day"]').checked = true;
             document.getElementById('custom-monthly-day').value = '1';
@@ -767,6 +790,8 @@
             updateCustomSubGroups();
             if (rule.freq === 'daily') {
                 document.getElementById('custom-weekdays-only').checked = !!rule.weekdays_only;
+                const anchor = rule.next_due_from === 'completion_date' ? 'completion_date' : 'due_date';
+                document.querySelector(`input[name="custom-next-due-from"][value="${anchor}"]`).checked = true;
             }
             if (rule.freq === 'weekly') {
                 const wds = rule.weekdays || [];
@@ -792,6 +817,13 @@
             const rule = { freq, interval };
             if (freq === 'daily' && document.getElementById('custom-weekdays-only').checked) {
                 rule.weekdays_only = true;
+            }
+            // Only persist a non-default anchor; absence means "due_date".
+            if (freq === 'daily') {
+                const anchor = document.querySelector('input[name="custom-next-due-from"]:checked');
+                if (anchor && anchor.value === 'completion_date') {
+                    rule.next_due_from = 'completion_date';
+                }
             }
             if (freq === 'weekly') {
                 rule.weekdays = [...document.querySelectorAll('#custom-weekdays input[type="checkbox"]:checked')]

--- a/tests/test_recurrence.py
+++ b/tests/test_recurrence.py
@@ -516,3 +516,199 @@ def test_process_counts_multiple_and_ignores_inactive(db_session, make_recurring
 
     assert created == 2
     assert db_session.query(Todo).count() == 2
+
+
+# --- custom "every N days" next-due anchor (custom_rule["next_due_from"]) -------
+#
+# For custom daily templates with a due date, the user picks whether the next
+# due date is measured from the last task's due date (default) or its completion
+# date. All dates below use 2026-03 (Mar 15 is a Sunday; Mar 5 is a Thursday).
+
+
+def _daily_rule(interval, *, next_due_from=None, weekdays_only=False):
+    rule = {"freq": "daily", "interval": interval}
+    if next_due_from is not None:
+        rule["next_due_from"] = next_due_from
+    if weekdays_only:
+        rule["weekdays_only"] = True
+    return rule
+
+
+def test_anchor_completion_date_early_completion(
+    db_session, make_recurring_todo, make_todo, frozen_now
+):
+    # "Water the plant" every 7 days, anchored to completion. Due Mar 7 but
+    # watered early on Mar 5 -> next due is 7 days after completion: Mar 12
+    # (not Mar 14, which the due-date anchor would give).
+    frozen_now(datetime(2026, 3, 5, 12, tzinfo=UTC))
+    template = make_recurring_todo(
+        "Water the plant",
+        recurrence_type="custom",
+        custom_rule=_daily_rule(7, next_due_from="completion_date"),
+        has_due_date=True,
+        last_generated_date="2026-03-07",
+    )
+    make_todo(
+        "Water the plant",
+        completed=True,
+        due_date="2026-03-07",
+        completed_at=datetime(2026, 3, 5, 9, 0, tzinfo=UTC),
+        recurring_todo_id=template.id,
+    )
+
+    assert process_recurring_todos(db_session) == 1
+    assert template.last_generated_date == "2026-03-12"
+    new_due = {t.due_date for t in _instances(db_session, template.id) if not t.completed}
+    assert new_due == {"2026-03-12"}
+
+
+def test_anchor_completion_date_late_completion(
+    db_session, make_recurring_todo, make_todo, frozen_now
+):
+    # "Allergy shot" every 4 days, anchored to completion. Due Mar 1 but not
+    # done until Mar 5 -> next due 4 days after completion: Mar 9.
+    frozen_now(datetime(2026, 3, 5, 12, tzinfo=UTC))
+    template = make_recurring_todo(
+        "Allergy shot",
+        recurrence_type="custom",
+        custom_rule=_daily_rule(4, next_due_from="completion_date"),
+        has_due_date=True,
+        last_generated_date="2026-03-01",
+    )
+    make_todo(
+        "Allergy shot",
+        completed=True,
+        due_date="2026-03-01",
+        completed_at=datetime(2026, 3, 5, 9, 0, tzinfo=UTC),
+        recurring_todo_id=template.id,
+    )
+
+    assert process_recurring_todos(db_session) == 1
+    assert template.last_generated_date == "2026-03-09"
+
+
+def test_anchor_due_date_default_keeps_cadence_on_late_completion(
+    db_session, make_recurring_todo, make_todo, frozen_now
+):
+    # "Water the garden" every 5 days, default (due-date) anchor with no
+    # explicit key. Due Mar 5, watered late on Mar 6 -> next due stays on the
+    # original cadence: Mar 10 (not Mar 11 from the completion date).
+    frozen_now(datetime(2026, 3, 6, 12, tzinfo=UTC))
+    template = make_recurring_todo(
+        "Water the garden",
+        recurrence_type="custom",
+        custom_rule=_daily_rule(5),  # no next_due_from -> defaults to due_date
+        has_due_date=True,
+        last_generated_date="2026-03-05",
+    )
+    make_todo(
+        "Water the garden",
+        completed=True,
+        due_date="2026-03-05",
+        completed_at=datetime(2026, 3, 6, 9, 0, tzinfo=UTC),
+        recurring_todo_id=template.id,
+    )
+
+    assert process_recurring_todos(db_session) == 1
+    assert template.last_generated_date == "2026-03-10"
+
+
+def test_anchor_due_date_ignores_early_completion(
+    db_session, make_recurring_todo, make_todo, frozen_now
+):
+    # Same template shape as the completion-anchor early case, but due-date
+    # anchored: the early completion is ignored and the next due date is 7 days
+    # after the due date (Mar 14), contrasting Mar 12 for completion anchor.
+    frozen_now(datetime(2026, 3, 5, 12, tzinfo=UTC))
+    template = make_recurring_todo(
+        "Water the plant",
+        recurrence_type="custom",
+        custom_rule=_daily_rule(7, next_due_from="due_date"),
+        has_due_date=True,
+        last_generated_date="2026-03-07",
+    )
+    make_todo(
+        "Water the plant",
+        completed=True,
+        due_date="2026-03-07",
+        completed_at=datetime(2026, 3, 5, 9, 0, tzinfo=UTC),
+        recurring_todo_id=template.id,
+    )
+
+    assert process_recurring_todos(db_session) == 1
+    assert template.last_generated_date == "2026-03-14"
+
+
+def test_anchor_due_date_falls_back_to_completion_when_past_due(
+    db_session, make_recurring_todo, make_todo, frozen_now
+):
+    # Due-date anchor, but a very late completion: due Mar 5 + 5 = Mar 10 is
+    # already in the past on Mar 30, so we fall back to the completion date so
+    # the task is never born overdue: Mar 30 + 5 = Apr 4.
+    frozen_now(datetime(2026, 3, 30, 12, tzinfo=UTC))
+    template = make_recurring_todo(
+        "Water the garden",
+        recurrence_type="custom",
+        custom_rule=_daily_rule(5, next_due_from="due_date"),
+        has_due_date=True,
+        last_generated_date="2026-03-05",
+    )
+    make_todo(
+        "Water the garden",
+        completed=True,
+        due_date="2026-03-05",
+        completed_at=datetime(2026, 3, 30, 9, 0, tzinfo=UTC),
+        recurring_todo_id=template.id,
+    )
+
+    assert process_recurring_todos(db_session) == 1
+    assert template.last_generated_date == "2026-04-04"
+
+
+def test_anchor_completion_date_applies_weekend_adjustment(
+    db_session, make_recurring_todo, make_todo, frozen_now
+):
+    # Completion anchor + weekdays-only: completed Thu Mar 5, every 3 days ->
+    # Mar 8 (a Sunday) is bumped to Mon Mar 9.
+    frozen_now(datetime(2026, 3, 5, 12, tzinfo=UTC))
+    template = make_recurring_todo(
+        "Pick up mail",
+        recurrence_type="custom",
+        custom_rule=_daily_rule(3, next_due_from="completion_date", weekdays_only=True),
+        has_due_date=True,
+        last_generated_date="2026-03-01",
+    )
+    make_todo(
+        "Pick up mail",
+        completed=True,
+        due_date="2026-03-01",
+        completed_at=datetime(2026, 3, 5, 9, 0, tzinfo=UTC),
+        recurring_todo_id=template.id,
+    )
+
+    assert process_recurring_todos(db_session) == 1
+    assert template.last_generated_date == "2026-03-09"
+
+
+def test_anchor_ignored_without_due_date(db_session, make_recurring_todo, make_todo, frozen_now):
+    # No due date -> the anchor does not apply even if custom_rule sets it; the
+    # generic reference logic runs (early completion keeps the cadence). Every 7
+    # days from Mar 8 -> Mar 15, not Mar 12 that a completion anchor would give.
+    frozen_now(FROZEN)
+    template = make_recurring_todo(
+        "Stretch",
+        recurrence_type="custom",
+        custom_rule=_daily_rule(7, next_due_from="completion_date"),
+        has_due_date=False,
+        last_generated_date="2026-03-08",
+    )
+    make_todo(
+        "Stretch",
+        completed=True,
+        due_date=None,
+        completed_at=datetime(2026, 3, 5, 9, 0, tzinfo=UTC),
+        recurring_todo_id=template.id,
+    )
+
+    assert process_recurring_todos(db_session) == 1
+    assert template.last_generated_date == "2026-03-15"


### PR DESCRIPTION
## Summary

Adds a per-template cadence option for Custom recurring tasks that repeat **every N days**: the user chooses whether the next task's due date is measured from the **due date of the last task** (default) or the **date the last task was completed**. This lets fixed-cadence tasks (e.g. "water the garden every 5 days") stay anchored to their schedule while completion-sensitive tasks (e.g. "allergy shot every 4 days", "water the plant every 7 days") re-space from when they were actually done. The option applies **only** to Custom `Days` schedules with a due date; Custom `Weeks`/`Months` and the built-in `Daily`/`Weekly`/`Monthly` types are unchanged, and the existing `Schedule on weekdays only` weekend adjustment continues to apply on top of the chosen anchor.

## Changes

**Backend (`src/rally/recurrence.py`)**
- Added `_anchored_custom_daily()` — gates the new behavior to Custom `freq == "daily"` templates that set a due date (`has_due_date`).
- Added `_anchor_reference()` — selects the reference date that `get_next_recurrence_date()` advances by the interval (and weekend-adjusts). `completion_date` measures from the completion date; `due_date` (default) measures from the due date, but falls back to the completion date when the next due date would already be in the past, so a task is never generated already overdue.
- `_resolve_reference_date()` now takes `today` and routes anchored custom-daily templates through the new logic; every other template keeps the existing generic reference behavior (including the late-completion advance).

**Frontend (`templates/todo.html`)**
- New radio group `Calculate next due date from:` below the `Schedule on weekdays only` checkbox, with options `Due date of the last task` (default) and `Date the last task was completed`, plus a `title` tooltip explaining both choices and the past-due fallback.
- Visibility gated on `freq == "daily"` **and** the due-date checkbox; wired into `updateCustomSubGroups`, `resetCustomFields`, `loadCustomRule`, `buildCustomRule` (persists only the non-default `completion_date` so existing blobs are unchanged), the has-due-date listener, and `describeCustomRule` (shows "from completion date").

**Styles (`static/styles.css`)**
- Added a generic borderless `.radio-options` class, applied to both the new anchor radios and the monthly `Day of month` / `Relative weekday` mode radios (the latter previously used the boxed `.weekday-label` chip style). The weekly day-of-week chips still use `.weekday-label`.

**Tests (`tests/test_recurrence.py`)**
- 7 new `process_recurring_todos` cases: completion anchor (early and late completion), due-date default cadence, due-date ignoring an early completion, the past-due fallback to completion date, the weekend adjustment combined with the anchor, and the `has_due_date == false` bypass.

## Notes for reviewers

- **Data model:** `next_due_from` lives inside the existing opaque `custom_rule` JSON, so there is **no migration** — an absent key is interpreted as `due_date`.
- **Behavior change for existing custom-daily templates:** they now default to the `due_date` anchor rather than today's generic "advance past late completions." For example, an every-5-days task due day 5 and completed day 6 now lands on day 10 (was day 11). This is intended; the past-due fallback still prevents a task from being born overdue.

## Testing

- `ruff check .` — clean.
- `ruff format --check .` — 56 files already formatted.
- `uv run pytest` (via `.devenv/state/venv/bin/pytest`) — **308 passed**, including the 7 new anchor tests.
- Manual UI verification in the running dev app: confirmed the radio group renders below the weekdays-only checkbox with the default selected and tooltip present; verified gating (hidden for `Weeks`/`Months` and when no due date is set) and that the radios toggle; confirmed the boxes are removed from both the anchor radios and the monthly-mode radios, the monthly mode toggle still reveals the ordinal/weekday selects, and there were no console errors. Only the modal was opened/closed — no records were created, edited, or deleted.

Closes #128
