### PR TITLE
Add a store-grouped family shopping list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,6 +374,7 @@ Rally uses a simple, file-based migration system. All migrations live in the `mi
 - `014_configurable_nws_weather` - Replace OpenWeather settings with configurable NWS forecast URL
 - `015_add_llm_settings_history` - Add `llm_settings_history` table; seed a coupled provider+model snapshot from the existing `llm_provider` / model settings rows and point the `current_llm_config_history_id` settings key at it (original settings rows are preserved — they remain the source of truth for the generator)
 - `016_add_stem_concept_history` - Add `stem_concept_history` table (records used STEM "concept of the day" topics so the generator avoids repeating a specific topic within 60 days)
+- `017_add_shopping_lists` - Add `shopping_stores`, `shopping_items`, and `shopping_item_history` tables, plus the case-insensitive unique index on store names and the unique index on `shopping_item_history.name_key`
 
 ### Running Migrations
 
@@ -513,7 +514,7 @@ rally/
 │   ├── __init__.py
 │   ├── main.py           # FastAPI application
 │   ├── database.py       # SQLAlchemy database setup
-│   ├── models.py         # Database models (FamilyMember, Calendar, Setting, AISettingsHistory, LLMSettingsHistory, StemConceptHistory, DashboardSnapshot, Todo, RecurringTodo, DinnerPlan)
+│   ├── models.py         # Database models (FamilyMember, Calendar, Setting, AISettingsHistory, LLMSettingsHistory, StemConceptHistory, DashboardSnapshot, Todo, RecurringTodo, ShoppingStore, ShoppingItem, ShoppingItemHistory, DinnerPlan)
 │   ├── schemas.py        # Pydantic schemas
 │   ├── cli.py            # CLI commands (seed, etc.)
 │   ├── recurrence.py     # Recurring todo processing (template → instance generation, next-date calculation)
@@ -523,11 +524,13 @@ rally/
 │   │   └── __main__.py   # CLI entry point
 │   ├── utils/
 │   │   ├── __init__.py
+│   │   ├── settings.py   # Settings-backed helpers (today_start_utc, local_timezone_name) — kept out of timezone.py to avoid a models.py import cycle
 │   │   └── timezone.py   # Timezone helpers (now_utc, today_utc, today_local, ensure_utc)
 │   └── routers/
 │       ├── __init__.py
 │       ├── dashboard.py     # Dashboard routes
 │       ├── todos.py         # Todo CRUD API
+│       ├── shopping.py      # Shopping list, store, and autocomplete-suggestion API
 │       ├── recurring_todos.py # Recurring todo template CRUD API
 │       ├── dinner_planner.py # Dinner plan CRUD API
 │       ├── family.py        # Family member CRUD API
@@ -538,6 +541,7 @@ rally/
 │   ├── dashboard.html       # Generated dashboard template
 │   ├── todo.html            # Todo management page
 │   ├── todo_completed.html  # Read-only previously-completed tasks page
+│   ├── shopping.html        # Shopping list page
 │   ├── dinner_planner.html  # Dinner planner page
 │   └── settings.html        # Settings, family member, and calendar management page
 ├── config.toml.example   # Example configuration file
@@ -557,6 +561,7 @@ rally/
 │   ├── migrate_011_add_meal_reviews.py # Migration 011: add rating and review to dinner_plans
 │   ├── migrate_012_add_ai_settings_history.py # Migration 012: add ai_settings_history table
 │   ├── migrate_015_add_llm_settings_history.py # Migration 015: add llm_settings_history table
+│   ├── migrate_017_add_shopping_lists.py # Migration 017: add shopping list tables
 │   └── run_migrations.py              # Migration runner (executes all migrations in order)
 ├── data/                 # Mounted in container (not in git)
 │   ├── config.toml       # API keys, URLs, coordinates (optional if using Settings UI)
@@ -599,6 +604,8 @@ rally/
   - Configure LLM provider, API keys, timezone
   - DB settings take precedence over config.toml
   - `stem_concept_enabled` ("true"/"false") toggles the STEM Concept of the Day feature (Learning section)
+  - `shopping_list_in_summary_enabled` ("true"/"false", default "false") folds open shopping items into the daily summary (Shopping List section)
+  - `shopping_last_purge_date` (local YYYY-MM-DD) is internal bookkeeping written by the shopping retention purge — never surfaced in the UI
   - Connection verification on save: LLM, Weather, and Calendar settings show a verification modal with spinner, checkmark on success (auto-closes), or error message with Close button on failure
 - ✅ AI settings snapshotting with version history and rollback
   - `agent_voice` and `family_context` each have their own Save button and Version History link on the settings page
@@ -634,6 +641,14 @@ rally/
   - Auto-generates concrete todo instances when due and no open instance exists
   - Recurrence processing runs during dashboard generation
   - Activate/deactivate templates without deleting
+- ✅ Shopping list (`/shopping`) - Store-grouped family shopping list, a peer of Tasks and the Meal Planner
+  - Quick add is a persistent inline row (not a modal): type, Enter, refocus. The store select defaults to the active filter when exactly one store is filtered
+  - Autocomplete is a custom dropdown (not a native `datalist`) reading `GET /api/shopping/suggestions` server-side, with a ~150 ms debounce and a request-sequence guard against out-of-order replies. ↑/↓ move, Enter accepts, Esc dismisses, `×` forgets a suggestion. Accepting fills the store **only when the user hasn't already chosen one** — including a choice inherited from an active single-store filter. `note` is deliberately not restored
+  - Completed items stay on the list until **local midnight**, exactly like tasks, via the shared `today_start_utc()` helper in `utils/settings.py`. There is no countdown and no client-side expiry sweep — the page just refetches periodically
+  - `Show purchased` toggles the `include_hidden` server parameter inline rather than opening a separate archive page: the 30-day purge keeps that set small enough to need no sorting, searching or pagination
+  - **Two separate memories, deliberately.** `shopping_items` is a 30-day rolling record whose completed rows are *deleted*; `shopping_item_history` is permanent and deduplicated with a use counter. The purge is safe precisely because autocomplete reads history, not items — trimming one never damages the other
+  - The purge runs opportunistically from the items listing (the `process_recurring_todos` precedent), gated on the `shopping_last_purge_date` settings row so it executes at most once per local day. The 4 AM container job would be the obvious home but lives in `entrypoint.sh` and only runs under Docker, so a `dev`-served instance would never purge
+  - Open items optionally feed the AI daily summary via `shopping_list_in_summary_enabled` (Settings → Shopping List, default off). Completed items never reach the LLM
 - ✅ STEM Concept of the Day - Optional family learning feature (toggle in Settings → Learning)
   - When `stem_concept_enabled` is "true", the generator adds a `stem_concept` object to the summary JSON (title, field, explanation, and age-appropriate `activities`)
   - The LLM tailors ideas to the ages described in FAMILY CONTEXT and keeps each idea super easy to fold into the day's existing plans
@@ -665,6 +680,7 @@ rally/
 - `/dashboard` - Serves the generated daily summary from cached snapshot (shows error if missing)
 - `/todo` - Todo management page with full CRUD interface
 - `/todo/completed` - Read-only page of todos completed before today (local time); reachable only via the `View completed tasks` link on `/todo`, not from the nav bar
+- `/shopping` - Shopping list page: quick add with history-backed autocomplete, store grouping, store filter chips, a `Show purchased` toggle, and a Manage Stores modal
 - `/dinner-planner` - Dinner planning page with date picker and plan management
 - `/settings` - Settings, family member, and calendar management page
 
@@ -677,6 +693,17 @@ rally/
   - `GET /api/todos/{id}` - Get specific todo
   - `PUT /api/todos/{id}` - Update todo
   - `DELETE /api/todos/{id}` - Delete todo
+- `/api/shopping` - Shopping list endpoints
+  - `GET /api/shopping/stores` - List stores, ordered by name ASC
+  - `POST /api/shopping/stores` - Create a store. `409` on a case-insensitive name conflict
+  - `PUT /api/shopping/stores/{id}` - Rename. `409` on conflict with a *different* store
+  - `DELETE /api/shopping/stores/{id}` - Delete. **Reassigns the store's items to `store_id = NULL` first** — SQLite FKs aren't enforced, so an orphaned `store_id` would make those items vanish from every rendered group
+  - `GET /api/shopping/items?include_hidden=false` - List items, ordered `completed ASC, created_at DESC`. Hides items completed before local midnight today unless `include_hidden=true`. Runs the once-per-local-day retention purge (see below)
+  - `POST /api/shopping/items` - Create. `201`, or `200` with the existing row when an **open** item with the same trimmed, case-insensitive name already exists in the same store (a merely *completed* match creates a new item). Accepts `store` as a store **name** in place of `store_id` for scripted/voice clients; sending both is `422`, and an unrecognized name falls back to the catch-all rather than erroring or auto-creating a store. A `201` upserts `shopping_item_history`; a `200` does not
+  - `PUT /api/shopping/items/{id}` - Partial update of `name`, `note`, `store_id`, `completed` (`note`/`store_id` use the `UNSET` sentinel). Completion stamping matches `PUT /api/todos/{id}` exactly. Does **not** touch history
+  - `DELETE /api/shopping/items/{id}` - Delete an item; history is untouched
+  - `GET /api/shopping/suggestions?q=&limit=8` - Autocomplete over `shopping_item_history`. Substring (wildcard) match with `%`/`_` escaped, ranked prefix-matches-first then by `times_added` DESC, `last_added_at` DESC, `name` ASC. Empty `q` returns the top entries by use count. `limit` defaults to 8 and is clamped to 25
+  - `DELETE /api/shopping/suggestions/{id}` - Forget a suggestion (history is permanent, so a typo'd add would otherwise haunt autocomplete forever). Leaves `shopping_items` alone
 - `/api/recurring-todos` - Recurring todo template CRUD endpoints
   - `GET /api/recurring-todos` - List all recurring todo templates
   - `POST /api/recurring-todos` - Create new recurring todo template
@@ -722,7 +749,7 @@ rally/
   - `POST /api/calendars/{id}/test` - Test calendar feed connectivity. For ICS feeds, fetches the URL and validates calendar data. For CalDAV, connects and counts available calendars. Returns `{success, message}` or `{success, error}`.
 
 ### Navigation
-All pages include a navigation bar allowing users to switch between Dashboard, Todos, Dinner Planner, and Settings.
+All pages include a navigation bar allowing users to switch between Dashboard, Todos, Shopping, Dinner Planner, and Settings. The nav markup is duplicated across all six page templates, so a nav change must be applied to each.
 
 ## Configuration
 
@@ -782,6 +809,9 @@ The database is automatically created when the app starts. Migrations run automa
 - `DashboardSnapshot` - Stores generated dashboard data with date, timestamp, JSON data, and active flag
 - `Todo` - Task management with title, description, optional due_date (YYYY-MM-DD), assigned_to (family member), optional recurring_todo_id (link to recurring template), optional remind_days_before (reminder window), completion status, and timestamps
 - `RecurringTodo` - Recurring todo templates with title, description, recurrence_type (daily/weekly/monthly), recurrence_day, assigned_to, has_due_date, remind_days_before, last_generated_date (tracks most recently generated instance's recurrence date), active flag, and timestamps
+- `ShoppingStore` - User-defined store items are grouped under (Costco, Trader Joe's, …). Names are unique case-insensitively; there is no seeded "Anywhere" row — the catch-all is `store_id IS NULL`
+- `ShoppingItem` - Shopping list item with name, optional note, optional store_id, completion status, completed_at, and timestamps. Uses the same `completed`/`completed_at` columns and semantics as `Todo`, so a completed item stays visible until local midnight; completed rows are deleted 30 days after completion
+- `ShoppingItemHistory` - Permanent, deduplicated record of every name ever added (name_key = trimmed + casefolded), with the display casing, the most recently used store_id, a `times_added` counter and `last_added_at`. Powers autocomplete and deliberately survives the purchased-item purge
 - `DinnerPlan` - Meal planning with date, plan text, attendee_ids (JSON array of family member IDs), cook_id (family member ID), and timestamps. Multiple plans per date are allowed.
 
 ### Dependency Issues

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Rally helps families come together around a shared daily plan. It synthesizes ca
   - Optional due dates and reminder windows per template
   - Assign to family members
   - Activate/deactivate templates without deleting
+- 🛒 **Shopping List** - A shared family list built for burst entry
+  - Add an item in one interaction: type, Enter, keep typing
+  - Autocomplete from a permanent history of what the family has bought before, ranked by how often you buy it and remembering which store
+  - Group items under your own stores (Costco, Trader Joe's, Hardware Store, …), with an "Anywhere" catch-all, and filter the view to any of them
+  - Purchased items stay visible until local midnight, exactly like tasks, then move behind "Show purchased" — and are deleted after 30 days so the list never grows without bound
+  - Add items from Apple Shortcuts or Siri by store *name*, no ids required (see [Adding Items by Voice](#adding-items-by-voice))
+  - Optionally folds your open list into the AI daily summary (toggle in Settings)
 - 🔬 **STEM Concept of the Day** - Optional family learning boost (toggle in Settings)
   - Adds one simple, everyday STEM concept to the daily summary
   - Age-appropriate ideas tailored to the kids in your family context
@@ -192,6 +199,7 @@ Rally uses a **file-based migration system** that runs automatically on containe
 || `006_add_reminder_window` | Add `remind_days_before` to todos and recurring_todos |
 || `007_add_last_generated_date` | Add `last_generated_date` to recurring_todos |
 || `008_add_caldav_support` | Add `cal_type`, `username`, `password` to calendars for CalDAV |
+|| `017_add_shopping_lists` | Add `shopping_stores`, `shopping_items`, and `shopping_item_history` tables |
 
 ### Running Migrations Manually
 
@@ -224,7 +232,7 @@ rally/
 ├── src/rally/              # Application source code
 │   ├── main.py             # FastAPI application entry point
 │   ├── database.py         # SQLAlchemy database configuration
-│   ├── models.py           # Database models (FamilyMember, Calendar, Setting, StemConceptHistory, DashboardSnapshot, Todo, RecurringTodo, DinnerPlan)
+│   ├── models.py           # Database models (FamilyMember, Calendar, Setting, StemConceptHistory, DashboardSnapshot, Todo, RecurringTodo, DinnerPlan, ShoppingStore, ShoppingItem, ShoppingItemHistory)
 │   ├── schemas.py          # Pydantic request/response schemas
 │   ├── cli.py              # CLI commands (seed, etc.)
 │   ├── recurrence.py       # Recurring todo processing (template → instance generation)
@@ -232,10 +240,12 @@ rally/
 │   │   ├── generate.py     # Core generation logic with calendar, todos, dinner plans
 │   │   └── __main__.py     # CLI entry point
 │   ├── utils/              # Shared utilities
+│   │   ├── settings.py     # Settings-backed helpers (today_start_utc, local_timezone_name)
 │   │   └── timezone.py     # Timezone helpers (now_utc, today_utc, ensure_utc)
 │   └── routers/            # API route handlers
 │       ├── dashboard.py    # Dashboard routes
 │       ├── todos.py        # Todo CRUD API
+│       ├── shopping.py     # Shopping list, store, and suggestion API
 │       ├── recurring_todos.py # Recurring todo template CRUD API
 │       ├── dinner_planner.py # Dinner plan CRUD API
 │       ├── family.py       # Family member CRUD API
@@ -245,6 +255,7 @@ rally/
 ├── templates/              # HTML templates
 │   ├── dashboard.html      # Daily dashboard template
 │   ├── todo.html           # Todo management page
+│   ├── shopping.html       # Shopping list page
 │   ├── dinner_planner.html # Dinner planner page
 │   └── settings.html       # Settings and family/calendar management page
 ├── data/                   # Configuration and data (not in git)
@@ -261,6 +272,7 @@ rally/
 │   ├── migrate_add_reminder_window.py # Migration 006: add remind_days_before to todos and recurring_todos
 │   ├── migrate_add_last_generated_date.py # Migration 007: add last_generated_date to recurring_todos
 │   ├── migrate_add_caldav_support.py  # Migration 008: add CalDAV columns to calendars
+│   ├── migrate_017_add_shopping_lists.py # Migration 017: add shopping list tables
 │   └── run_migrations.py              # Migration runner (executes all migrations)
 ├── config.toml.example     # Example configuration file
 ├── context.txt.example     # Example family context
@@ -339,6 +351,38 @@ Rally supports three calendar types, all configured through the Settings UI:
 4. Generate a new password with a label like "Rally"
 5. Copy the generated password
 6. In Rally Settings, add a calendar with type "Apple iCloud CalDAV", enter your Apple ID email and the app-specific password
+
+## Adding Items by Voice
+
+The shopping list API is designed so an Apple Shortcut (and therefore Siri) can add
+items without knowing any database ids.
+
+Create a Shortcut with a single **Get Contents of URL** action:
+
+| Field | Value |
+|-------|-------|
+| URL | `http://<your-rally-host>:8000/api/shopping/items` |
+| Method | `POST` |
+| Request Body | `JSON` |
+| `name` (Text) | Ask Each Time — or a Dictated Text variable |
+| `store` (Text) | e.g. `Costco` — optional |
+
+Name the shortcut something like "Add to shopping list" and say *"Hey Siri, add to
+shopping list."*
+
+Two details make this robust:
+
+- **Stores are referenced by name, not id.** A shortcut hardcoding `store_id: 3`
+  breaks silently the first time that store is deleted and recreated.
+- **An unrecognized store name is not an error.** The item lands in the "Anywhere"
+  catch-all instead, because a hard failure mid-dictation is worse than a slightly
+  misfiled item. Unknown names never auto-create a store.
+
+Adding an item that is already on the open list for that store returns the existing
+item rather than creating a duplicate, so a repeated "add milk" is harmless.
+
+> **Note:** a HomePod can't join a Tailscale tailnet, so a kitchen-speaker shortcut
+> needs Rally's LAN address while phone shortcuts can use MagicDNS.
 
 ## Environment Variables
 

--- a/migrations/migrate_017_add_shopping_lists.py
+++ b/migrations/migrate_017_add_shopping_lists.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Migration: Add the shopping list tables.
+
+Creates three new tables:
+
+- shopping_stores        User-defined stores items are grouped under.
+- shopping_items         The live list. Completed rows are purged at 30 days.
+- shopping_item_history  Permanent, deduplicated autocomplete vocabulary with a
+                         use counter. Deliberately outlives the purge.
+
+All three are new tables rather than ALTERs, so idempotency comes free from
+CREATE TABLE IF NOT EXISTS.
+
+Safe to run multiple times (idempotent).
+"""
+
+import os
+import sqlite3
+from pathlib import Path
+
+
+def migrate():
+    """Run the migration. Return True on success, False on failure."""
+    db_path = os.environ.get("RALLY_DB_PATH")
+
+    if not db_path:
+        prod_path = Path("/data/rally.db")
+        dev_path = Path(__file__).parent.parent / "rally.db"
+        db_path = str(prod_path) if prod_path.exists() else str(dev_path)
+
+    db_path = Path(db_path)
+
+    if not db_path.exists():
+        print(f"✓ Database not found at {db_path}")
+        print("  No migration needed - database will be created with correct schema.")
+        return True
+
+    print(f"Checking database at {db_path}...")
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name IN "
+            "('shopping_stores', 'shopping_items', 'shopping_item_history')"
+        )
+        existing = {row[0] for row in cursor.fetchall()}
+        if len(existing) == 3:
+            print("✓ Migration: shopping list tables already exist (idempotent)")
+            return True
+
+        print("  Applying migration...")
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS shopping_stores (
+                id INTEGER PRIMARY KEY,
+                name VARCHAR(100) NOT NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL
+            )
+        """)
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS shopping_items (
+                id INTEGER PRIMARY KEY,
+                name VARCHAR(200) NOT NULL,
+                note TEXT,
+                store_id INTEGER,
+                completed BOOLEAN NOT NULL DEFAULT 0,
+                completed_at DATETIME,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL
+            )
+        """)
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS shopping_item_history (
+                id INTEGER PRIMARY KEY,
+                name_key VARCHAR(200) NOT NULL,
+                name VARCHAR(200) NOT NULL,
+                store_id INTEGER,
+                times_added INTEGER NOT NULL DEFAULT 1,
+                last_added_at DATETIME NOT NULL,
+                created_at DATETIME NOT NULL
+            )
+        """)
+
+        # Store names are unique case-insensitively.
+        cursor.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS ix_shopping_stores_name_nocase
+            ON shopping_stores (name COLLATE NOCASE)
+        """)
+
+        # name_key already stores a casefolded value, so a plain unique index is
+        # correct here — COLLATE NOCASE would be redundant and misleading.
+        cursor.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS ix_shopping_item_history_name_key
+            ON shopping_item_history (name_key)
+        """)
+
+        conn.commit()
+        print("✓ Migration complete: shopping list tables added")
+        return True
+
+    except sqlite3.Error as e:
+        print(f"✗ Migration failed: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    import sys
+
+    success = migrate()
+    sys.exit(0 if success else 1)

--- a/migrations/run_migrations.py
+++ b/migrations/run_migrations.py
@@ -25,6 +25,9 @@ def run_migrations():
         from migrate_016_add_stem_concept_history import (
             migrate as migrate_016_add_stem_concept_history,
         )
+        from migrate_017_add_shopping_lists import (
+            migrate as migrate_017_add_shopping_lists,
+        )
         from migrate_add_caldav_support import migrate as migrate_008_add_caldav_support
         from migrate_add_completed_at import migrate as migrate_013_add_completed_at
         from migrate_add_custom_recurrence import migrate as migrate_009_add_custom_recurrence
@@ -62,6 +65,7 @@ def run_migrations():
         ("014_configurable_nws_weather", migrate_014_configurable_nws_weather),
         ("015_add_llm_settings_history", migrate_015_add_llm_settings_history),
         ("016_add_stem_concept_history", migrate_016_add_stem_concept_history),
+        ("017_add_shopping_lists", migrate_017_add_shopping_lists),
     ]
 
     print("=" * 60)

--- a/src/rally/cli.py
+++ b/src/rally/cli.py
@@ -3,8 +3,18 @@
 from datetime import timedelta
 
 from rally.database import SessionLocal, init_db
-from rally.models import Calendar, DashboardSnapshot, DinnerPlan, FamilyMember, Setting, Todo
-from rally.utils.timezone import today_utc
+from rally.models import (
+    Calendar,
+    DashboardSnapshot,
+    DinnerPlan,
+    FamilyMember,
+    Setting,
+    ShoppingItem,
+    ShoppingItemHistory,
+    ShoppingStore,
+    Todo,
+)
+from rally.utils.timezone import now_utc, today_utc
 
 
 def seed():
@@ -19,6 +29,9 @@ def seed():
         db.query(Setting).delete()
         db.query(DashboardSnapshot).delete()
         db.query(Todo).delete()
+        db.query(ShoppingItem).delete()
+        db.query(ShoppingItemHistory).delete()
+        db.query(ShoppingStore).delete()
         db.query(FamilyMember).delete()
         db.commit()
 
@@ -161,6 +174,46 @@ def seed():
         for todo in todos:
             db.add(todo)
 
+        # Create a sample shopping list: two named stores plus catch-all items,
+        # one already purchased today so the dimmed-until-midnight styling shows.
+        costco = ShoppingStore(name="Costco")
+        trader_joes = ShoppingStore(name="Trader Joe's")
+        db.add_all([costco, trader_joes])
+        db.flush()
+
+        shopping_items = [
+            ShoppingItem(name="Paper towels", store_id=costco.id),
+            ShoppingItem(name="Rotisserie chicken", note="2 if they have them", store_id=costco.id),
+            ShoppingItem(
+                name="Coffee beans", store_id=costco.id, completed=True, completed_at=now_utc()
+            ),
+            ShoppingItem(name="Almond milk", store_id=trader_joes.id),
+            ShoppingItem(name="Frozen dumplings", store_id=trader_joes.id),
+            ShoppingItem(name="Stamps"),
+            ShoppingItem(name="Batteries", note="AA"),
+        ]
+        for item in shopping_items:
+            db.add(item)
+
+        # Seed the autocomplete vocabulary so suggestions have something to rank.
+        history = [
+            ("Milk", trader_joes.id, 24),
+            ("Paper towels", costco.id, 12),
+            ("Almond milk", trader_joes.id, 9),
+            ("Coffee beans", costco.id, 7),
+            ("Eggs", trader_joes.id, 6),
+            ("Stamps", None, 2),
+        ]
+        for name, store_id, times_added in history:
+            db.add(
+                ShoppingItemHistory(
+                    name_key=name.strip().casefold(),
+                    name=name,
+                    store_id=store_id,
+                    times_added=times_added,
+                )
+            )
+
         # Create sample meal plans (multiple per date to showcase the feature)
         today_date = today_utc()
 
@@ -295,6 +348,8 @@ def seed():
         print(f"   - {len(calendars)} calendars")
         print(f"   - {len(sample_settings)} settings")
         print(f"   - {len(todos)} sample todos")
+        print(f"   - {len(shopping_items)} shopping items across 2 stores")
+        print(f"   - {len(history)} shopping history entries")
         print(f"   - {len(dinner_plans)} upcoming meal plans")
         print(f"   - {len(past_meals)} past meal plans")
 

--- a/src/rally/generator/generate.py
+++ b/src/rally/generator/generate.py
@@ -103,6 +103,11 @@ class SummaryGenerator:
         # Optional: STEM "concept of the day" for the family (toggle in Settings)
         self.stem_concept_enabled = db_settings.get("stem_concept_enabled", "false") == "true"
 
+        # Optional: fold the open shopping list into the briefing (toggle in Settings)
+        self.shopping_list_in_summary_enabled = (
+            db_settings.get("shopping_list_in_summary_enabled", "false") == "true"
+        )
+
         # Optional: owner emails for accurate declined-event detection (config.toml fallback only)
         self.calendar_owners = self.config.get("calendar_owners", {})
 
@@ -576,6 +581,52 @@ class SummaryGenerator:
         finally:
             db.close()
 
+    def load_shopping_items(self) -> str:
+        """Load open shopping items from database for LLM context.
+
+        Open items only — a completed item is a purchase the family already
+        made, and it must never reach the LLM as something still outstanding.
+        Grouped under store names, with the catch-all rendered as "Anywhere"
+        and ordered last, matching the /shopping page.
+        """
+        db = SessionLocal()
+        try:
+            from rally.models import ShoppingItem, ShoppingStore
+
+            items = (
+                db.query(ShoppingItem)
+                .filter(ShoppingItem.completed == False)  # noqa: E712
+                .order_by(ShoppingItem.created_at.desc())
+                .all()
+            )
+
+            if not items:
+                return "No shopping items currently active."
+
+            store_names = {s.id: s.name for s in db.query(ShoppingStore).all()}
+
+            groups: dict[str, list[str]] = {}
+            for item in items:
+                # An item whose store was deleted falls back to the catch-all.
+                label = store_names.get(item.store_id) if item.store_id else None
+                entry = item.name
+                if item.note:
+                    entry += f" - {item.note}"
+                groups.setdefault(label or "Anywhere", []).append(entry)
+
+            ordered = sorted(name for name in groups if name != "Anywhere")
+            if "Anywhere" in groups:
+                ordered.append("Anywhere")
+
+            lines = []
+            for label in ordered:
+                lines.append(f"{label}:")
+                lines.extend(f"  - {entry}" for entry in groups[label])
+
+            return "\n".join(lines)
+        finally:
+            db.close()
+
     def load_recent_stem_concepts(self) -> list[str]:
         """Load titles of STEM concepts used within the last 60 days (newest first).
 
@@ -801,6 +852,9 @@ class SummaryGenerator:
         dinner_plans = self.load_dinner_plans()
         context = self.load_context()
         voice = self.load_voice()
+        # Only queried when the feature is on — an empty section would burn
+        # tokens and invite the model to reference a list that isn't there.
+        shopping_items = self.load_shopping_items() if self.shopping_list_in_summary_enabled else ""
 
         # Format calendars for prompt
         cal_text = ""
@@ -864,6 +918,7 @@ class SummaryGenerator:
             "weather": weather_text,
             "todos": todos,
             "dinner_plans": dinner_plans,
+            "shopping_items": shopping_items,
             "family_members": ", ".join(family_members.values())
             if family_members
             else "No family members configured.",
@@ -884,9 +939,13 @@ class SummaryGenerator:
         if tz_detail:
             tz_label = f"{self.local_tz_name} (currently {tz_detail})"
 
+        # Optional sections. Each appends its guideline body (no leading number)
+        # to optional_guidelines; they are numbered sequentially from 11 below,
+        # so no combination of toggles can collide or leave a gap.
+        optional_guidelines: list[str] = []
+
         # Optional STEM "concept of the day" — schema block + guideline, only when enabled
         stem_schema = ""
-        stem_guideline = ""
         if self.stem_concept_enabled:
             stem_schema = """,
   "stem_concept": {
@@ -900,12 +959,24 @@ class SummaryGenerator:
       }
     ]
   }"""
-            stem_guideline = """
-11. STEM CONCEPT OF THE DAY: Include a "stem_concept" object with one simple, everyday STEM concept the family can notice or play with today.
+            optional_guidelines.append("""STEM CONCEPT OF THE DAY: Include a "stem_concept" object with one simple, everyday STEM concept the family can notice or play with today.
     - Tailor the activities to the ages of the children described in FAMILY CONTEXT. If ages aren't clear, give one idea for younger kids and one for older kids.
     - Every idea MUST be SUPER EASY to fold into what the family is already doing today (a meal, an errand, the weather, a scheduled activity, play or bath time). No special supplies, no extra trips — just a few minutes and a question or observation.
     - Keep it playful, curious, and encouraging — a fun bonus, not homework. Pick a concept that connects naturally to today's schedule, weather, or dinner when possible.
-    - DO NOT reuse any of the specific concepts listed under STEM CONCEPTS USED RECENTLY. Exploring a DIFFERENT sub-topic within the same broader area (e.g. a new idea in "weather" or "fractions") is fine — only the specific topics on that list are off-limits."""
+    - DO NOT reuse any of the specific concepts listed under STEM CONCEPTS USED RECENTLY. Exploring a DIFFERENT sub-topic within the same broader area (e.g. a new idea in "weather" or "fractions") is fine — only the specific topics on that list are off-limits.""")
+
+        # Optional shopping list — guideline only when the section is present
+        if self.shopping_list_in_summary_enabled:
+            optional_guidelines.append(
+                "SHOPPING LIST FILTERING: The SHOPPING LIST section below is pre-filtered to open "
+                "items. Only mention shopping items that explicitly appear in that section. Do not "
+                'infer, recall, or invent items. If it says "No shopping items currently active," '
+                "do not suggest any specific items."
+            )
+
+        optional_guideline_text = "".join(
+            f"\n{number}. {body}" for number, body in enumerate(optional_guidelines, start=11)
+        )
 
         # Static content → system prompt (cached by Anthropic, system role for local models)
         system_prompt = f"""You are creating content for a daily family summary.
@@ -949,7 +1020,7 @@ Guidelines:
 8. The briefing should surface important things that need attention TODAY or VERY SOON (within 1-2 days)
 9. If the weather is actively dangerous (snow, thunderstorms, or tornado risk) within the next 7 days, mention it.
 10. TASK FILTERING: The TODOS section below is pre-filtered. Only mention, reference, or suggest tasks that explicitly appear in the TODOS section. Do not infer, recall, or invent tasks that are not listed. If the TODOS section says "No todos currently active," do not suggest any specific tasks.
-5. LOCAL TIMES: Times in FAMILY CONTEXT are already in the family's local timezone (see TIMEZONE above). Copy them through unchanged — a "7PM" reminder is scheduled at 7:00 PM, not a converted time. Never apply a UTC/local offset to a bare time.{stem_guideline}
+5. LOCAL TIMES: Times in FAMILY CONTEXT are already in the family's local timezone (see TIMEZONE above). Copy them through unchanged — a "7PM" reminder is scheduled at 7:00 PM, not a converted time. Never apply a UTC/local offset to a bare time.{optional_guideline_text}
 
 Do NOT include any HTML in your response. Plain text only for all values."""
 
@@ -965,6 +1036,10 @@ Do NOT include any HTML in your response. Plain text only for all values."""
                     "the same broader area is fine):\n"
                     f"{joined}"
                 )
+
+        shopping_section = ""
+        if self.shopping_list_in_summary_enabled:
+            shopping_section = f"\n\nSHOPPING LIST (open items):\n{shopping_items}"
 
         # Dynamic content → user prompt (changes every generation)
         user_prompt = f"""Create a daily family summary for {today}.
@@ -982,7 +1057,7 @@ TODOS:
 {todos}
 
 DINNER PLANS (next 7 days):
-{dinner_plans}{stem_avoid_block}"""
+{dinner_plans}{shopping_section}{stem_avoid_block}"""
 
         try:
             response_text = self._call_llm(user_prompt, system_prompt=system_prompt)
@@ -1132,6 +1207,13 @@ Respond with ONLY a JSON object (no markdown fences):
             + stem_eval_note
         )
 
+        # The shopping list is ground truth too, so groundedness can be judged
+        # against it. Omitted entirely when the feature is off, matching the
+        # generation prompt.
+        shopping_ground_truth = ""
+        if ctx.get("shopping_items"):
+            shopping_ground_truth = f"\n\nSHOPPING LIST:\n{ctx['shopping_items']}"
+
         # Dynamic data → user prompt
         eval_user = f"""== GENERATED SUMMARY (to evaluate) ==
 {summary_json}
@@ -1147,7 +1229,7 @@ TODOS:
 {ctx["todos"]}
 
 DINNER PLANS:
-{ctx["dinner_plans"]}
+{ctx["dinner_plans"]}{shopping_ground_truth}
 
 FAMILY MEMBERS:
 {ctx["family_members"]}"""

--- a/src/rally/main.py
+++ b/src/rally/main.py
@@ -8,7 +8,15 @@ from fastapi.templating import Jinja2Templates
 from starlette.responses import Response
 
 from rally.database import init_db
-from rally.routers import dashboard, dinner_planner, family, recurring_todos, settings, todos
+from rally.routers import (
+    dashboard,
+    dinner_planner,
+    family,
+    recurring_todos,
+    settings,
+    shopping,
+    todos,
+)
 from rally.utils.static_version import STATIC_VERSION
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
@@ -56,6 +64,7 @@ app.include_router(dinner_planner.router)
 app.include_router(family.router)
 app.include_router(recurring_todos.router)
 app.include_router(settings.router)
+app.include_router(shopping.router)
 
 
 @app.get("/", response_class=RedirectResponse)
@@ -74,6 +83,12 @@ def todo_page(request: Request):
 def todo_completed_page(request: Request):
     """Serve the read-only page of previously completed tasks."""
     return templates.TemplateResponse("todo_completed.html", {"request": request})
+
+
+@app.get("/shopping", response_class=HTMLResponse)
+def shopping_page(request: Request):
+    """Serve the shopping list page."""
+    return templates.TemplateResponse("shopping.html", {"request": request})
 
 
 @app.get("/dinner-planner", response_class=HTMLResponse)

--- a/src/rally/models.py
+++ b/src/rally/models.py
@@ -2,7 +2,17 @@
 
 from datetime import datetime
 
-from sqlalchemy import JSON, Boolean, CheckConstraint, DateTime, Integer, String, Text
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    Index,
+    Integer,
+    String,
+    Text,
+    text,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from rally.database import Base
@@ -192,6 +202,78 @@ class RecurringTodo(Base):
     active: Mapped[bool] = mapped_column(default=True)
     created_at: Mapped[datetime] = mapped_column(default=now_utc)
     updated_at: Mapped[datetime] = mapped_column(default=now_utc, onupdate=now_utc)
+
+
+class ShoppingStore(Base):
+    """A user-defined store items can be grouped under (Costco, Hardware Store, …).
+
+    There is deliberately no seeded "Anywhere" row: an item with no particular
+    store has ``store_id IS NULL``, mirroring ``Todo.assigned_to IS NULL``
+    meaning "Everyone".
+    """
+
+    __tablename__ = "shopping_stores"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100))  # Unique case-insensitively (see index below)
+    created_at: Mapped[datetime] = mapped_column(default=now_utc)
+    updated_at: Mapped[datetime] = mapped_column(default=now_utc, onupdate=now_utc)
+
+    __table_args__ = (
+        Index(
+            "ix_shopping_stores_name_nocase",
+            text("name COLLATE NOCASE"),
+            unique=True,
+        ),
+    )
+
+
+class ShoppingItem(Base):
+    """An item on the family shopping list.
+
+    Completion uses the same column names and semantics as ``Todo`` so the two
+    routers read alike: a completed item stays visible until local midnight.
+    Rows completed more than PURCHASED_RETENTION_DAYS ago are purged from the
+    database — safe because every add is separately recorded in
+    ``ShoppingItemHistory``, which autocomplete reads instead.
+    """
+
+    __tablename__ = "shopping_items"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(200))
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    store_id: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )  # FK to shopping_stores.id; NULL is the "Anywhere" catch-all
+    completed: Mapped[bool] = mapped_column(default=False)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(default=now_utc)
+    updated_at: Mapped[datetime] = mapped_column(default=now_utc, onupdate=now_utc)
+
+
+class ShoppingItemHistory(Base):
+    """Permanent, deduplicated record of every item name ever added.
+
+    Powers autocomplete. Deliberately outlives the purchased-item purge: the
+    30-day retention on ``shopping_items`` trims the purchased list without
+    touching the family's vocabulary. ``store_id`` is the *most recently used*
+    store rather than the most common one — a true mode would need a row per
+    (name, store) pair, which un-deduplicates the table this counter exists to
+    keep small.
+    """
+
+    __tablename__ = "shopping_item_history"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name_key: Mapped[str] = mapped_column(
+        String(200), unique=True, index=True
+    )  # Trimmed + casefolded name; the dedupe key
+    name: Mapped[str] = mapped_column(String(200))  # Display casing from the most recent add
+    store_id: Mapped[int | None] = mapped_column(Integer, nullable=True)  # Most recently used store
+    times_added: Mapped[int] = mapped_column(Integer, default=1)
+    last_added_at: Mapped[datetime] = mapped_column(default=now_utc)
+    created_at: Mapped[datetime] = mapped_column(default=now_utc)
 
 
 class DinnerPlan(Base):

--- a/src/rally/routers/shopping.py
+++ b/src/rally/routers/shopping.py
@@ -1,0 +1,377 @@
+"""Shopping list router for Rally.
+
+Three tables back this feature, and the split between them is deliberate:
+
+* ``shopping_items`` is the live list. Completed items stay visible until local
+  midnight (identical to Tasks) and are deleted outright once they are more than
+  ``PURCHASED_RETENTION_DAYS`` old, so "Show purchased" never grows unbounded.
+* ``shopping_item_history`` is a permanent, deduplicated vocabulary with a use
+  counter. It powers autocomplete and deliberately outlives the purge — which is
+  precisely what makes deleting purchased rows safe.
+* ``shopping_stores`` groups items; the catch-all is ``store_id IS NULL``.
+"""
+
+from datetime import timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from sqlalchemy import case, func
+from sqlalchemy.orm import Session
+
+from rally.database import get_db
+from rally.models import Setting, ShoppingItem, ShoppingItemHistory, ShoppingStore
+from rally.schemas import (
+    UNSET,
+    ShoppingItemCreate,
+    ShoppingItemResponse,
+    ShoppingItemUpdate,
+    ShoppingStoreCreate,
+    ShoppingStoreResponse,
+    ShoppingStoreUpdate,
+    ShoppingSuggestion,
+)
+from rally.utils.settings import local_timezone_name, today_start_utc
+from rally.utils.timezone import now_utc, today_local
+
+router = APIRouter(prefix="/api/shopping", tags=["shopping"])
+
+# Completed items are deleted from the database once they are older than this.
+# Open items are never purged at any age — an item nobody has bought in two
+# years is still something the family wants.
+PURCHASED_RETENTION_DAYS = 30
+
+# Settings row (local YYYY-MM-DD) gating the purge to once per local day.
+PURGE_DATE_SETTING = "shopping_last_purge_date"
+
+# LIKE escape character for user-supplied autocomplete terms.
+_LIKE_ESCAPE = "\\"
+
+MAX_SUGGESTIONS = 25
+
+
+# --- Helpers -------------------------------------------------------------------
+
+
+def _clean_name(raw: str, label: str) -> str:
+    """Trim a user-supplied name, rejecting empty/whitespace-only values."""
+    name = (raw or "").strip()
+    if not name:
+        raise HTTPException(status_code=422, detail=f"{label} cannot be empty")
+    return name
+
+
+def _history_key(name: str) -> str:
+    """The dedupe key for item history: trimmed and casefolded."""
+    return name.strip().casefold()
+
+
+def _find_store_by_name(db: Session, name: str) -> ShoppingStore | None:
+    return (
+        db.query(ShoppingStore)
+        .filter(func.lower(ShoppingStore.name) == name.strip().lower())
+        .first()
+    )
+
+
+def _require_store(db: Session, store_id: int | None) -> None:
+    """Validate a bare integer store reference (no DB-level foreign keys here)."""
+    if store_id is None:
+        return
+    if not db.query(ShoppingStore).filter(ShoppingStore.id == store_id).first():
+        raise HTTPException(status_code=422, detail="Unknown store_id")
+
+
+def _escape_like(term: str) -> str:
+    """Escape LIKE wildcards so a typed ``%`` or ``_`` matches literally.
+
+    Without this, typing ``%`` matches the entire history table and ``_``
+    matches any character — a small bug that presents as "autocomplete is broken
+    and random".
+    """
+    return (
+        term.replace(_LIKE_ESCAPE, _LIKE_ESCAPE * 2)
+        .replace("%", f"{_LIKE_ESCAPE}%")
+        .replace("_", f"{_LIKE_ESCAPE}_")
+    )
+
+
+def purge_old_purchased_items(db: Session) -> None:
+    """Delete items completed more than ``PURCHASED_RETENTION_DAYS`` ago.
+
+    Runs opportunistically from the items listing (the ``process_recurring_todos``
+    precedent in ``list_todos``) rather than from the 4 AM container job, which
+    lives in ``entrypoint.sh`` and would skip a ``dev``-served instance entirely.
+
+    Gated on a settings row so it executes at most once per local day: SQLite
+    takes a write lock, and a read path shouldn't pay for that on every request.
+    """
+    today = today_local(local_timezone_name(db)).strftime("%Y-%m-%d")
+    marker = db.query(Setting).filter(Setting.key == PURGE_DATE_SETTING).first()
+    if marker and marker.value == today:
+        return
+
+    cutoff = now_utc() - timedelta(days=PURCHASED_RETENTION_DAYS)
+    db.query(ShoppingItem).filter(
+        ShoppingItem.completed == True,  # noqa: E712
+        ShoppingItem.completed_at.isnot(None),
+        ShoppingItem.completed_at < cutoff,
+    ).delete(synchronize_session=False)
+
+    if marker:
+        marker.value = today
+    else:
+        db.add(Setting(key=PURGE_DATE_SETTING, value=today))
+    db.commit()
+
+
+def record_item_history(db: Session, name: str, store_id: int | None) -> None:
+    """Upsert the permanent history row backing autocomplete.
+
+    Called only on a real create. A dedupe hit doesn't increment (nothing was
+    added), and renaming an item via PUT doesn't touch history either — history
+    records adds, and a typo correction shouldn't rewrite a counter.
+    """
+    key = _history_key(name)
+    row = db.query(ShoppingItemHistory).filter(ShoppingItemHistory.name_key == key).first()
+    if row:
+        row.times_added += 1
+        row.name = name  # Follow the newest display casing
+        row.store_id = store_id  # Last store used, not the most common one
+        row.last_added_at = now_utc()
+    else:
+        db.add(
+            ShoppingItemHistory(
+                name_key=key,
+                name=name,
+                store_id=store_id,
+                times_added=1,
+                last_added_at=now_utc(),
+            )
+        )
+    db.commit()
+
+
+# --- Stores --------------------------------------------------------------------
+
+
+@router.get("/stores", response_model=list[ShoppingStoreResponse])
+def list_stores(db: Session = Depends(get_db)):
+    """List all stores, alphabetically."""
+    return db.query(ShoppingStore).order_by(ShoppingStore.name.asc()).all()
+
+
+@router.post("/stores", response_model=ShoppingStoreResponse, status_code=201)
+def create_store(store: ShoppingStoreCreate, db: Session = Depends(get_db)):
+    """Create a store. Names are unique case-insensitively."""
+    name = _clean_name(store.name, "Store name")
+    if _find_store_by_name(db, name):
+        raise HTTPException(status_code=409, detail="A store with that name already exists")
+
+    db_store = ShoppingStore(name=name)
+    db.add(db_store)
+    db.commit()
+    db.refresh(db_store)
+    return db_store
+
+
+@router.put("/stores/{store_id}", response_model=ShoppingStoreResponse)
+def update_store(store_id: int, store: ShoppingStoreUpdate, db: Session = Depends(get_db)):
+    """Rename a store."""
+    db_store = db.query(ShoppingStore).filter(ShoppingStore.id == store_id).first()
+    if not db_store:
+        raise HTTPException(status_code=404, detail="Store not found")
+
+    name = _clean_name(store.name, "Store name")
+    conflict = _find_store_by_name(db, name)
+    if conflict and conflict.id != store_id:
+        raise HTTPException(status_code=409, detail="A store with that name already exists")
+
+    db_store.name = name
+    db.commit()
+    db.refresh(db_store)
+    return db_store
+
+
+@router.delete("/stores/{store_id}", status_code=204)
+def delete_store(store_id: int, db: Session = Depends(get_db)):
+    """Delete a store, moving its items to the "Anywhere" catch-all first.
+
+    That reassignment is load-bearing: SQLite foreign keys aren't enforced here,
+    so an orphaned ``store_id`` would make those items silently vanish from every
+    rendered group. History rows keep their ``store_id`` — a suggestion whose
+    store was deleted simply falls back to the catch-all when accepted.
+    """
+    db_store = db.query(ShoppingStore).filter(ShoppingStore.id == store_id).first()
+    if not db_store:
+        raise HTTPException(status_code=404, detail="Store not found")
+
+    db.query(ShoppingItem).filter(ShoppingItem.store_id == store_id).update(
+        {"store_id": None}, synchronize_session=False
+    )
+    db.delete(db_store)
+    db.commit()
+    return None
+
+
+# --- Items ---------------------------------------------------------------------
+
+
+@router.get("/items", response_model=list[ShoppingItemResponse])
+def list_items(
+    include_hidden: bool = Query(
+        False, description="Include items completed before today (local time)"
+    ),
+    db: Session = Depends(get_db),
+):
+    """List shopping items, hiding items completed before today by default.
+
+    ``include_hidden=true`` is the "Show purchased" view, bounded by the
+    retention purge that runs (at most once per local day) from here.
+    """
+    purge_old_purchased_items(db)
+
+    query = db.query(ShoppingItem)
+    if not include_hidden:
+        cutoff = today_start_utc(db)
+        query = query.filter(
+            (ShoppingItem.completed == False) | (ShoppingItem.completed_at >= cutoff)  # noqa: E712
+        )
+
+    return query.order_by(ShoppingItem.completed.asc(), ShoppingItem.created_at.desc()).all()
+
+
+@router.post("/items", response_model=ShoppingItemResponse, status_code=201)
+def create_item(item: ShoppingItemCreate, response: Response, db: Session = Depends(get_db)):
+    """Add an item, deduplicating against the open list and recording history.
+
+    A store may be named instead of referenced by id, for scripted and voice
+    clients (Apple Shortcuts / Siri) that know names but not ids. An
+    *unrecognized* name is not an error — the item lands in the catch-all rather
+    than failing mid-dictation — and unknown names never auto-create a store.
+    """
+    name = _clean_name(item.name, "Item name")
+
+    store_id = item.store_id
+    if store_id is not None:
+        _require_store(db, store_id)
+    elif item.store is not None:
+        match = _find_store_by_name(db, item.store)
+        store_id = match.id if match else None
+
+    # Add-dedupe: an open item with the same name in the same store is returned
+    # as-is with 200. A merely *completed* match creates a new item — you bought
+    # the milk, now you need more milk.
+    store_clause = (
+        ShoppingItem.store_id.is_(None) if store_id is None else ShoppingItem.store_id == store_id
+    )
+    existing = (
+        db.query(ShoppingItem)
+        .filter(
+            ShoppingItem.completed == False,  # noqa: E712
+            func.lower(ShoppingItem.name) == name.lower(),
+            store_clause,
+        )
+        .first()
+    )
+    if existing:
+        response.status_code = 200
+        return existing
+
+    db_item = ShoppingItem(name=name, note=item.note, store_id=store_id, completed=False)
+    db.add(db_item)
+    db.commit()
+    db.refresh(db_item)
+
+    record_item_history(db, name, store_id)
+    return db_item
+
+
+@router.put("/items/{item_id}", response_model=ShoppingItemResponse)
+def update_item(item_id: int, item: ShoppingItemUpdate, db: Session = Depends(get_db)):
+    """Partially update an item. Completion follows the todo pattern exactly."""
+    db_item = db.query(ShoppingItem).filter(ShoppingItem.id == item_id).first()
+    if not db_item:
+        raise HTTPException(status_code=404, detail="Item not found")
+
+    if item.name is not None:
+        db_item.name = _clean_name(item.name, "Item name")
+    if item.note is not UNSET:
+        db_item.note = item.note
+    if item.store_id is not UNSET:
+        _require_store(db, item.store_id)
+        db_item.store_id = item.store_id
+    if item.completed is not None:
+        if item.completed and not db_item.completed:
+            db_item.completed_at = now_utc()
+        elif not item.completed:
+            db_item.completed_at = None
+        db_item.completed = item.completed
+
+    db.commit()
+    db.refresh(db_item)
+    return db_item
+
+
+@router.delete("/items/{item_id}", status_code=204)
+def delete_item(item_id: int, db: Session = Depends(get_db)):
+    """Delete an item. History is untouched."""
+    db_item = db.query(ShoppingItem).filter(ShoppingItem.id == item_id).first()
+    if not db_item:
+        raise HTTPException(status_code=404, detail="Item not found")
+
+    db.delete(db_item)
+    db.commit()
+    return None
+
+
+# --- Suggestions ---------------------------------------------------------------
+
+
+@router.get("/suggestions", response_model=list[ShoppingSuggestion])
+def list_suggestions(
+    q: str | None = Query(None, description="Substring to match anywhere in the item name"),
+    limit: int = Query(8, ge=1),
+    db: Session = Depends(get_db),
+):
+    """Autocomplete matches from the permanent item history.
+
+    Matching is substring, not prefix, so ``milk`` finds "Almond milk". Ranking
+    puts prefix matches first, then substring matches, each tier ordered by use
+    count so the weekly staple beats the one-off. An empty ``q`` returns the
+    usual suspects — the top entries by use count.
+    """
+    limit = min(limit, MAX_SUGGESTIONS)
+    query = db.query(ShoppingItemHistory)
+
+    term = (q or "").strip()
+    ranking = (
+        ShoppingItemHistory.times_added.desc(),
+        ShoppingItemHistory.last_added_at.desc(),
+        ShoppingItemHistory.name.asc(),
+    )
+
+    if term:
+        escaped = _escape_like(term.lower())
+        lowered = func.lower(ShoppingItemHistory.name)
+        query = query.filter(lowered.like(f"%{escaped}%", escape=_LIKE_ESCAPE))
+        prefix_first = case((lowered.like(f"{escaped}%", escape=_LIKE_ESCAPE), 0), else_=1)
+        query = query.order_by(prefix_first, *ranking)
+    else:
+        query = query.order_by(*ranking)
+
+    return query.limit(limit).all()
+
+
+@router.delete("/suggestions/{history_id}", status_code=204)
+def delete_suggestion(history_id: int, db: Session = Depends(get_db)):
+    """Forget a suggestion.
+
+    History is permanent, so a typo'd add ("mikl") would otherwise haunt
+    autocomplete forever. Shopping items are left alone.
+    """
+    row = db.query(ShoppingItemHistory).filter(ShoppingItemHistory.id == history_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Suggestion not found")
+
+    db.delete(row)
+    db.commit()
+    return None

--- a/src/rally/routers/todos.py
+++ b/src/rally/routers/todos.py
@@ -1,17 +1,15 @@
 """Todos router for Rally."""
 
-from datetime import UTC, datetime, time
-from zoneinfo import ZoneInfo
-
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import false, nullslast, or_
 from sqlalchemy.orm import Session
 
 from rally.database import get_db
-from rally.models import FamilyMember, Setting, Todo
+from rally.models import FamilyMember, Todo
 from rally.recurrence import process_recurring_todos
 from rally.schemas import UNSET, CompletedTodoPage, TodoCreate, TodoResponse, TodoUpdate
-from rally.utils.timezone import now_utc, today_local
+from rally.utils.settings import today_start_utc
+from rally.utils.timezone import now_utc
 
 router = APIRouter(prefix="/api/todos", tags=["todos"])
 
@@ -24,19 +22,6 @@ COMPLETED_SORTS = (
     "newest",
     "oldest",
 )
-
-
-def today_start_utc(db: Session) -> datetime:
-    """UTC instant of local midnight today, in the user's configured timezone.
-
-    This is the boundary between "current" todos (shown on /todo) and
-    "previously completed" todos (shown on /todo/completed). Both views must
-    use this same helper or todos would appear on both pages or neither.
-    """
-    setting = db.query(Setting).filter(Setting.key == "local_timezone").first()
-    tz_name = setting.value if setting and setting.value else "UTC"
-    local_midnight = datetime.combine(today_local(tz_name), time.min, tzinfo=ZoneInfo(tz_name))
-    return local_midnight.astimezone(UTC)
 
 
 @router.get("", response_model=list[TodoResponse])

--- a/src/rally/schemas.py
+++ b/src/rally/schemas.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 # Sentinel value to distinguish "field not provided" from "field set to None"
 UNSET = object()
@@ -265,6 +265,71 @@ class RecurringTodoResponse(RecurringTodoBase):
     last_completed_display: str | None = None
     created_at: datetime
     updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# Shopping List
+
+
+class ShoppingStoreCreate(BaseModel):
+    name: str
+
+
+class ShoppingStoreUpdate(BaseModel):
+    name: str
+
+
+class ShoppingStoreResponse(BaseModel):
+    id: int
+    name: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ShoppingItemCreate(BaseModel):
+    name: str
+    note: str | None = None
+    store_id: int | None = None  # NULL / omitted means the "Anywhere" catch-all
+    store: str | None = None  # Store *name*, for clients that know names but not ids
+
+    @model_validator(mode="after")
+    def check_single_store_reference(self):
+        """``store_id`` and ``store`` are two spellings of one field, not both."""
+        if self.store_id is not None and self.store is not None:
+            raise ValueError("Provide either store_id or store, not both")
+        return self
+
+
+class ShoppingItemUpdate(BaseModel):
+    name: str | None = None
+    note: str | None = UNSET  # None means "clear"; UNSET means "not provided"
+    store_id: int | None = UNSET  # None means "Anywhere"; UNSET means "not provided"
+    completed: bool | None = None
+
+
+class ShoppingItemResponse(BaseModel):
+    id: int
+    name: str
+    note: str | None = None
+    store_id: int | None = None
+    completed: bool
+    completed_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ShoppingSuggestion(BaseModel):
+    """One autocomplete match from the permanent item history."""
+
+    id: int
+    name: str
+    store_id: int | None = None
+    times_added: int
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/src/rally/utils/settings.py
+++ b/src/rally/utils/settings.py
@@ -1,0 +1,34 @@
+"""Settings-derived helpers that need database access.
+
+These deliberately do NOT live in ``utils/timezone.py``: that module is imported
+by ``models.py`` (for ``now_utc``), so a helper there that needs ``Setting``
+from ``models.py`` would close an import cycle. Keeping them in their own module
+breaks it.
+"""
+
+from datetime import UTC, datetime, time
+from zoneinfo import ZoneInfo
+
+from sqlalchemy.orm import Session
+
+from rally.models import Setting
+from rally.utils.timezone import today_local
+
+
+def local_timezone_name(db: Session) -> str:
+    """The user's configured IANA timezone name, defaulting to UTC."""
+    setting = db.query(Setting).filter(Setting.key == "local_timezone").first()
+    return setting.value if setting and setting.value else "UTC"
+
+
+def today_start_utc(db: Session) -> datetime:
+    """UTC instant of local midnight today, in the user's configured timezone.
+
+    This is the boundary between "current" rows (todos shown on /todo, shopping
+    items shown on /shopping) and previously-completed ones. Every view that
+    partitions on "completed today" must use this same helper, or rows would
+    appear on both sides of the boundary or neither.
+    """
+    tz_name = local_timezone_name(db)
+    local_midnight = datetime.combine(today_local(tz_name), time.min, tzinfo=ZoneInfo(tz_name))
+    return local_midnight.astimezone(UTC)

--- a/static/styles.css
+++ b/static/styles.css
@@ -941,6 +941,214 @@ footer a:hover {
 }
 /**End Todo Page Styles**/
 
+/** Shopping List Styles **/
+/* Quick add: a persistent inline row, not a modal — a modal per item is too
+   much friction for the burst-entry flow a grocery list is built in. */
+.shopping-quick-add {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+    gap: 12px;
+    margin-bottom: 24px;
+}
+
+.shopping-quick-add .autocomplete-wrap {
+    position: relative;
+    flex: 1 1 240px;
+    min-width: 0;
+}
+
+.shopping-quick-add input[type="text"] {
+    appearance: none;
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 2.75rem;
+    padding: 10px;
+    border: 1px solid var(--charcoal);
+    background: var(--white);
+    color: var(--charcoal);
+    font-family: var(--body-font);
+    font-size: 1rem;
+}
+
+.shopping-quick-add select {
+    appearance: none;
+    box-sizing: border-box;
+    min-height: 2.75rem;
+    flex: 0 1 180px;
+    padding: 10px 32px 10px 10px;
+    border: 1px solid var(--charcoal);
+    background: var(--white);
+    color: var(--charcoal);
+    font-family: var(--body-font);
+    font-size: 1rem;
+    cursor: pointer;
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23333' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+}
+
+/* Autocomplete dropdown. A native <datalist> is nearly free but cannot render
+   the two-part name/store row or the per-row dismiss affordance, and store
+   affinity is the main thing that makes this worth building. */
+.autocomplete-menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 20;
+    margin-top: -1px;
+    max-height: 280px;
+    overflow-y: auto;
+    border: 1px solid var(--charcoal);
+    background: var(--white);
+    display: none;
+}
+
+.autocomplete-menu.open {
+    display: block;
+}
+
+.autocomplete-option {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 8px 10px;
+    cursor: pointer;
+    border-bottom: 1px solid var(--silver);
+}
+
+.autocomplete-option:last-child {
+    border-bottom: none;
+}
+
+.autocomplete-option.active,
+.autocomplete-option:hover {
+    background: var(--off-white);
+}
+
+.autocomplete-name {
+    flex: 1;
+    min-width: 0;
+    font-size: 1rem;
+    word-wrap: break-word;
+}
+
+.autocomplete-store {
+    font-style: italic;
+    font-size: 0.85rem;
+    color: var(--medium-gray);
+    white-space: nowrap;
+}
+
+.autocomplete-dismiss {
+    flex-shrink: 0;
+    border: none;
+    background: none;
+    color: var(--light-gray);
+    font-family: var(--body-font);
+    font-size: 1rem;
+    line-height: 1;
+    padding: 2px 4px;
+    cursor: pointer;
+}
+
+.autocomplete-dismiss:hover {
+    color: var(--charcoal);
+}
+
+/* Store group heading: the identity carrier, since stores have no colour —
+   Rally is grayscale/e-ink first. */
+.shopping-group-header {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin: 32px 0 12px;
+}
+
+.shopping-group-header:first-child {
+    margin-top: 0;
+}
+
+.shopping-group-name {
+    font-family: var(--header-font);
+    font-size: 1rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    white-space: nowrap;
+}
+
+.shopping-group-rule {
+    flex: 1;
+    border-bottom: 1px solid var(--pale-gray);
+}
+
+.shopping-group-count {
+    font-size: 0.8rem;
+    letter-spacing: 0.05em;
+    color: var(--light-gray);
+    white-space: nowrap;
+}
+
+.shopping-item-store {
+    font-family: var(--body-font);
+    font-style: italic;
+    font-size: 0.9rem;
+    color: var(--medium-gray);
+    margin-left: 6px;
+}
+
+.shopping-completed-at {
+    font-size: 0.85rem;
+    color: var(--light-gray);
+    letter-spacing: 0.02em;
+    font-style: italic;
+    margin-top: 4px;
+}
+
+/* Inline "Show purchased" toggle. Unlike Tasks there is no separate archive
+   page: the 30-day purge keeps the set small enough to need no sorting,
+   searching or pagination, which is exactly what /todo/completed exists for. */
+.shopping-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.9rem;
+    color: var(--medium-gray);
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.shopping-toggle input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+}
+
+.store-manage-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--silver);
+}
+
+.store-manage-row input[type="text"] {
+    appearance: none;
+    box-sizing: border-box;
+    flex: 1;
+    min-width: 0;
+    min-height: 2.5rem;
+    padding: 8px 10px;
+    border: 1px solid var(--pale-gray);
+    background: var(--white);
+    color: var(--charcoal);
+    font-family: var(--body-font);
+    font-size: 1rem;
+}
+/** End Shopping List Styles **/
+
 /** Dinner Planner Styles **/
 .plan-card {
     padding: 20px;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -19,6 +19,7 @@
     <nav>
         <a href="/dashboard" class="active">Dashboard</a>
         <a href="/todo">Tasks</a>
+        <a href="/shopping">Shopping</a>
         <div class="nav-dropdown" id="meal-dropdown">
             <button class="nav-dropdown-btn" onclick="toggleMealDropdown(event)">Meal Planner</button>
             <div class="nav-dropdown-content">

--- a/templates/dinner_planner.html
+++ b/templates/dinner_planner.html
@@ -19,6 +19,7 @@
     <nav>
         <a href="/dashboard">Dashboard</a>
         <a href="/todo">Tasks</a>
+        <a href="/shopping">Shopping</a>
         <div class="nav-dropdown" id="meal-dropdown">
             <button class="nav-dropdown-btn active" onclick="toggleMealDropdown(event)">Meal Planner</button>
             <div class="nav-dropdown-content">

--- a/templates/meal_history.html
+++ b/templates/meal_history.html
@@ -19,6 +19,7 @@
     <nav>
         <a href="/dashboard">Dashboard</a>
         <a href="/todo">Tasks</a>
+        <a href="/shopping">Shopping</a>
         <div class="nav-dropdown" id="meal-dropdown">
             <button class="nav-dropdown-btn active" onclick="toggleMealDropdown(event)">Meal Planner</button>
             <div class="nav-dropdown-content">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -19,6 +19,7 @@
     <nav>
         <a href="/dashboard">Dashboard</a>
         <a href="/todo">Tasks</a>
+        <a href="/shopping">Shopping</a>
         <div class="nav-dropdown" id="meal-dropdown">
             <button class="nav-dropdown-btn" onclick="toggleMealDropdown(event)">Meal Planner</button>
             <div class="nav-dropdown-content">
@@ -167,6 +168,23 @@
                     <span>STEM Concept of the Day</span>
                 </label>
                 <small>Add a family-friendly STEM concept to the daily summary, with super-easy, age-appropriate ways to explore it during your day.</small>
+            </div>
+            <button type="submit" class="btn-save">Save</button>
+        </form>
+    </div>
+
+    <!-- Shopping List Section -->
+    <div class="border-container">
+        <div class="header-container">
+            <h2>Shopping List</h2>
+        </div>
+        <form id="shopping-form">
+            <div class="form-group">
+                <label class="checkbox-label">
+                    <input type="checkbox" id="shopping-list-in-summary">
+                    <span>Include the shopping list in the daily summary</span>
+                </label>
+                <small>Adds your open shopping items, grouped by store, to The Briefing. Purchased items are never included.</small>
             </div>
             <button type="submit" class="btn-save">Save</button>
         </form>
@@ -582,6 +600,9 @@
 
             // Learning
             document.getElementById('stem-concept-enabled').checked = s.stem_concept_enabled === 'true';
+
+            // Shopping List
+            document.getElementById('shopping-list-in-summary').checked = s.shopping_list_in_summary_enabled === 'true';
 
             // General
             document.getElementById('general-timezone').value = s.local_timezone || '';
@@ -1006,6 +1027,20 @@
             } catch (error) {
                 console.error('Error saving learning settings:', error);
                 alert('Failed to save learning settings');
+            }
+        });
+
+        // Shopping List form
+        document.getElementById('shopping-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            try {
+                await saveSettings({
+                    shopping_list_in_summary_enabled: document.getElementById('shopping-list-in-summary').checked ? 'true' : 'false'
+                });
+                alert('Shopping List settings saved.');
+            } catch (error) {
+                console.error('Error saving shopping list settings:', error);
+                alert('Failed to save shopping list settings');
             }
         });
 

--- a/templates/shopping.html
+++ b/templates/shopping.html
@@ -1,0 +1,739 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Rally - Shopping List</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📰</text></svg>">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="/static/styles.css?v={{ css_version }}" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <h1>Rally</h1>
+        <div class="subtitle">Shopping List</div>
+    </header>
+
+    <nav>
+        <a href="/dashboard">Dashboard</a>
+        <a href="/todo">Tasks</a>
+        <a href="/shopping" class="active">Shopping</a>
+        <div class="nav-dropdown" id="meal-dropdown">
+            <button class="nav-dropdown-btn" onclick="toggleMealDropdown(event)">Meal Planner</button>
+            <div class="nav-dropdown-content">
+                <a href="/dinner-planner">Current &amp; Upcoming</a>
+                <a href="/meal-history">Previous Meals</a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="section-container">
+        <div class="header-container">
+            <h2>Shopping List</h2>
+            <div class="header-actions">
+                <button class="btn-add" id="btn-manage-stores">Manage Stores</button>
+            </div>
+        </div>
+
+        <!-- Quick add: type, Enter, keep typing. Grocery lists are built in bursts. -->
+        <form class="shopping-quick-add" id="quick-add-form" autocomplete="off">
+            <div class="autocomplete-wrap">
+                <input type="text" id="quick-add-name" placeholder="Add an item…" aria-label="Item name"
+                       role="combobox" aria-expanded="false" aria-autocomplete="list" aria-controls="suggestion-menu" required>
+                <div class="autocomplete-menu" id="suggestion-menu" role="listbox"></div>
+            </div>
+            <select id="quick-add-store" aria-label="Store">
+                <option value="">Anywhere</option>
+            </select>
+            <button type="submit" class="btn-add">Add</button>
+        </form>
+
+        <div class="filter-toolbar">
+            <div class="toolbar-group">
+                <label>Store</label>
+                <div class="filter-chips" id="filter-store-chips"></div>
+                <button type="button" class="filter-clear" id="filter-clear">Clear Filters</button>
+            </div>
+            <div class="toolbar-group">
+                <label class="shopping-toggle">
+                    <input type="checkbox" id="show-purchased">
+                    <span>Show purchased</span>
+                </label>
+            </div>
+        </div>
+
+        <div id="groups-container">
+            <div class="container-loading-state">Loading shopping list…</div>
+        </div>
+    </div>
+
+    <!-- Modal for editing an item -->
+    <div class="modal-overlay" id="item-modal-overlay">
+        <div class="modal-content">
+            <h3>Edit Item</h3>
+            <div class="modal-scroll">
+            <div class="modal-body">
+                <form id="item-form">
+                    <div class="form-group">
+                        <label>Item</label>
+                        <input type="text" id="item-name" placeholder="Item name" required>
+                    </div>
+                    <div class="form-group">
+                        <label>Note (optional)</label>
+                        <textarea id="item-note" placeholder="Quantity, brand, anything else" rows="3"></textarea>
+                    </div>
+                    <div class="form-group">
+                        <label>Store</label>
+                        <select id="item-store">
+                            <option value="">Anywhere</option>
+                        </select>
+                    </div>
+                </form>
+                <div class="modal-actions">
+                    <button type="submit" form="item-form" class="btn-primary">Save</button>
+                    <button type="button" class="btn-cancel" id="btn-cancel-item">Cancel</button>
+                    <button type="button" class="btn-delete modal-delete" id="btn-delete-item">Delete</button>
+                </div>
+            </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal for managing stores -->
+    <div class="modal-overlay" id="store-modal-overlay">
+        <div class="modal-content">
+            <h3>Manage Stores</h3>
+            <div class="modal-scroll">
+            <div class="modal-body">
+                <form id="store-add-form" class="form-group">
+                    <label>Add a store</label>
+                    <div class="store-manage-row">
+                        <input type="text" id="store-add-name" placeholder="Store name" required>
+                        <button type="submit" class="btn-edit">Add</button>
+                    </div>
+                </form>
+                <div id="store-manage-list"></div>
+                <div class="modal-actions">
+                    <button type="button" class="btn-cancel" id="btn-close-stores">Done</button>
+                </div>
+            </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // ── State ──
+        let items = [];
+        let stores = [];
+        let selectedStores = new Set();   // chip values: store ids as strings, or 'anywhere'
+        let editingItemId = null;
+
+        const ANYWHERE = 'anywhere';
+        const REFRESH_MS = 60000;   // multi-device sync + the local-midnight rollover
+
+        const nameInput = document.getElementById('quick-add-name');
+        const storeSelect = document.getElementById('quick-add-store');
+        const suggestionMenu = document.getElementById('suggestion-menu');
+
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        // textContent → innerHTML leaves quotes alone, which is fine in a text
+        // node but would break out of a quoted attribute. Store and item names
+        // are user-supplied, so attribute positions need the stricter escape.
+        function escapeAttr(text) {
+            return escapeHtml(text).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+        }
+
+        function storeName(storeId) {
+            const store = stores.find(s => s.id === storeId);
+            return store ? store.name : null;
+        }
+
+        // ── API ──
+        async function fetchStores() {
+            const response = await fetch('/api/shopping/stores');
+            stores = await response.json();
+            renderStoreOptions();
+            renderStoreChips();
+        }
+
+        async function fetchItems() {
+            const includeHidden = document.getElementById('show-purchased').checked;
+            const response = await fetch(`/api/shopping/items?include_hidden=${includeHidden}`);
+            items = await response.json();
+            renderItems();
+        }
+
+        async function createItem(data) {
+            const response = await fetch('/api/shopping/items', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
+            if (!response.ok) throw new Error('Failed to add item');
+            return response.json();
+        }
+
+        async function updateItem(id, data) {
+            const response = await fetch(`/api/shopping/items/${id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
+            if (!response.ok) throw new Error('Failed to update item');
+            return response.json();
+        }
+
+        async function deleteItem(id) {
+            const response = await fetch(`/api/shopping/items/${id}`, { method: 'DELETE' });
+            if (!response.ok) throw new Error('Failed to delete item');
+        }
+
+        // ── Store select + filter chips ──
+        function renderStoreOptions() {
+            [storeSelect, document.getElementById('item-store')].forEach(select => {
+                const previous = select.value;
+                select.innerHTML = '<option value="">Anywhere</option>' + stores.map(s =>
+                    `<option value="${s.id}">${escapeHtml(s.name)}</option>`
+                ).join('');
+                // Keep a selection alive across a store list refresh.
+                if (previous && select.querySelector(`option[value="${previous}"]`)) {
+                    select.value = previous;
+                }
+            });
+        }
+
+        function renderStoreChips() {
+            const chips = document.getElementById('filter-store-chips');
+            const parts = [`<button type="button" class="filter-chip" data-value="all">All</button>`];
+            stores.forEach(s => {
+                parts.push(`<button type="button" class="filter-chip" data-value="${s.id}">${escapeHtml(s.name)}</button>`);
+            });
+            parts.push(`<button type="button" class="filter-chip" data-value="${ANYWHERE}">Anywhere</button>`);
+            chips.innerHTML = parts.join('');
+            syncChipState();
+        }
+
+        function syncChipState() {
+            document.querySelectorAll('#filter-store-chips .filter-chip').forEach(chip => {
+                const isAll = chip.dataset.value === 'all';
+                const active = isAll ? selectedStores.size === 0 : selectedStores.has(chip.dataset.value);
+                chip.classList.toggle('active', active);
+            });
+        }
+
+        // The quick-add store defaults to the filtered store when exactly one is
+        // filtered — but never overrides a choice the user made themselves.
+        function syncQuickAddStoreDefault() {
+            if (storeSelect.dataset.touched === 'true') return;
+            const only = selectedStores.size === 1 ? [...selectedStores][0] : null;
+            if (only && only !== ANYWHERE && storeSelect.querySelector(`option[value="${only}"]`)) {
+                storeSelect.value = only;
+            } else {
+                storeSelect.value = '';
+            }
+        }
+
+        function clearFilters() {
+            selectedStores.clear();
+            syncChipState();
+            syncQuickAddStoreDefault();
+            renderItems();
+        }
+
+        // ── Rendering ──
+        function chipValueForItem(item) {
+            return item.store_id ? String(item.store_id) : ANYWHERE;
+        }
+
+        function visibleItems() {
+            if (selectedStores.size === 0) return items;
+            return items.filter(item => selectedStores.has(chipValueForItem(item)));
+        }
+
+        function groupLabel(value) {
+            if (value === ANYWHERE) return 'Anywhere';
+            return storeName(parseInt(value, 10)) || 'Anywhere';
+        }
+
+        function renderItems() {
+            const container = document.getElementById('groups-container');
+            const visible = visibleItems();
+
+            const groups = new Map();
+            visible.forEach(item => {
+                const key = chipValueForItem(item);
+                if (!groups.has(key)) groups.set(key, []);
+                groups.get(key).push(item);
+            });
+
+            // An explicitly filtered store renders even when empty, so filtering
+            // to it reads as "nothing here" rather than as a vanished group.
+            selectedStores.forEach(value => {
+                if (!groups.has(value)) groups.set(value, []);
+            });
+
+            // Named stores alphabetically, the catch-all last.
+            const keys = [...groups.keys()].sort((a, b) => {
+                if (a === ANYWHERE) return 1;
+                if (b === ANYWHERE) return -1;
+                return groupLabel(a).localeCompare(groupLabel(b));
+            });
+
+            // Only reachable with no items and no filters: a selected filter
+            // always contributes its own (possibly empty) group above.
+            if (keys.length === 0) {
+                container.innerHTML =
+                    '<div class="container-empty-state">Nothing on the list yet. Type an item above to get started.</div>';
+                return;
+            }
+
+            container.innerHTML = keys.map(key => {
+                const groupItems = [...groups.get(key)].sort((a, b) => {
+                    if (a.completed !== b.completed) return a.completed ? 1 : -1;
+                    return new Date(b.created_at) - new Date(a.created_at);
+                });
+                const openCount = groupItems.filter(i => !i.completed).length;
+                const countLabel = `${openCount} item${openCount === 1 ? '' : 's'}`;
+                const rows = groupItems.length === 0
+                    ? '<div class="container-empty-state">Nothing here right now.</div>'
+                    : `<div class="list-container">${groupItems.map(renderItemRow).join('')}</div>`;
+                return `
+                    <div class="shopping-group-header">
+                        <span class="shopping-group-name">${escapeHtml(groupLabel(key))}</span>
+                        <span class="shopping-group-rule"></span>
+                        <span class="shopping-group-count">${countLabel}</span>
+                    </div>
+                    ${rows}
+                `;
+            }).join('');
+        }
+
+        function renderItemRow(item) {
+            const store = item.store_id ? storeName(item.store_id) : null;
+            const storeHtml = store ? `<span class="shopping-item-store">${escapeHtml(store)}</span>` : '';
+            const completedHtml = item.completed
+                ? `<div class="shopping-completed-at">${escapeHtml(formatCompletedAgo(item.completed_at))}</div>`
+                : '';
+            return `
+                <div class="editable-item ${item.completed ? 'completed' : ''}" data-id="${item.id}">
+                    <div class="todo-checkbox">
+                        <input type="checkbox" ${item.completed ? 'checked' : ''}
+                               aria-label="Mark ${escapeAttr(item.name)} as purchased"
+                               onchange="toggleComplete(${item.id}, this.checked)">
+                    </div>
+                    <div class="editable-item-content">
+                        <div class="editable-item-title">${escapeHtml(item.name)} ${storeHtml}</div>
+                        ${item.note ? `<div class="editable-item-description">${escapeHtml(item.note)}</div>` : ''}
+                        ${completedHtml}
+                    </div>
+                    <div class="editable-item-actions">
+                        <button class="btn-edit" onclick="openEditModal(${item.id})">Edit</button>
+                    </div>
+                </div>
+            `;
+        }
+
+        // completed_at serializes without a "Z" for values SQLite hands back
+        // naive, and new Date("2026-08-07T18:00:00") is parsed as *local* time by
+        // JS — so append the zone when it's missing.
+        function formatCompletedAgo(value) {
+            if (!value) return '';
+            const date = new Date(value.endsWith('Z') || value.includes('+') ? value : value + 'Z');
+            if (isNaN(date)) return '';
+            const minutes = Math.floor((Date.now() - date.getTime()) / 60000);
+            if (minutes < 1) return 'Completed just now';
+            if (minutes < 60) return `Completed ${minutes}m ago`;
+            const hours = Math.floor(minutes / 60);
+            if (hours < 24) return `Completed ${hours}h ago`;
+            return `Completed ${Math.floor(hours / 24)}d ago`;
+        }
+
+        // ── Autocomplete ──
+        //
+        // Queried server-side (the history corpus is permanent and grows with the
+        // family's vocabulary), so this needs the two classic per-keystroke
+        // guards: a debounce, and a sequence number that drops replies which
+        // arrive after a newer one has already been applied.
+        let suggestions = [];
+        let activeSuggestion = -1;
+        let suggestionSeq = 0;
+        let suggestionTimer = null;
+
+        function closeSuggestions() {
+            suggestions = [];
+            activeSuggestion = -1;
+            suggestionMenu.classList.remove('open');
+            suggestionMenu.innerHTML = '';
+            nameInput.setAttribute('aria-expanded', 'false');
+        }
+
+        function scheduleSuggestions() {
+            clearTimeout(suggestionTimer);
+            suggestionTimer = setTimeout(fetchSuggestions, 150);
+        }
+
+        async function fetchSuggestions() {
+            const query = nameInput.value.trim();
+            if (!query) {
+                closeSuggestions();
+                return;
+            }
+            const seq = ++suggestionSeq;
+            try {
+                const response = await fetch(`/api/shopping/suggestions?q=${encodeURIComponent(query)}`);
+                if (!response.ok) return;
+                const data = await response.json();
+                if (seq !== suggestionSeq) return;   // a newer keystroke already answered
+                suggestions = data;
+                activeSuggestion = -1;
+                renderSuggestions();
+            } catch (error) {
+                console.error('Error fetching suggestions:', error);
+            }
+        }
+
+        function renderSuggestions() {
+            if (suggestions.length === 0) {
+                closeSuggestions();
+                return;
+            }
+            suggestionMenu.innerHTML = suggestions.map((s, index) => {
+                const store = s.store_id ? storeName(s.store_id) : null;
+                return `
+                    <div class="autocomplete-option ${index === activeSuggestion ? 'active' : ''}"
+                         role="option" aria-selected="${index === activeSuggestion}" data-index="${index}">
+                        <span class="autocomplete-name">${escapeHtml(s.name)}</span>
+                        ${store ? `<span class="autocomplete-store">${escapeHtml(store)}</span>` : ''}
+                        <button type="button" class="autocomplete-dismiss" data-dismiss="${s.id}"
+                                aria-label="Forget ${escapeAttr(s.name)}">×</button>
+                    </div>
+                `;
+            }).join('');
+            suggestionMenu.classList.add('open');
+            nameInput.setAttribute('aria-expanded', 'true');
+        }
+
+        function highlightSuggestion(index) {
+            activeSuggestion = index;
+            suggestionMenu.querySelectorAll('.autocomplete-option').forEach((el, i) => {
+                el.classList.toggle('active', i === index);
+                el.setAttribute('aria-selected', String(i === index));
+            });
+            const active = suggestionMenu.querySelector('.autocomplete-option.active');
+            if (active) active.scrollIntoView({ block: 'nearest' });
+        }
+
+        function acceptSuggestion(index) {
+            const suggestion = suggestions[index];
+            if (!suggestion) return;
+            nameInput.value = suggestion.name;
+            // Store affinity only fills a blank: an explicit choice — including one
+            // inherited from an active single-store filter — always wins, so
+            // autocomplete can never silently move an item to another store.
+            if (storeSelect.value === '' && suggestion.store_id != null
+                && storeSelect.querySelector(`option[value="${suggestion.store_id}"]`)) {
+                storeSelect.value = String(suggestion.store_id);
+            }
+            // The note is deliberately not restored: notes are trip-specific, and
+            // a silently attached stale one is worse than retyping.
+            closeSuggestions();
+            nameInput.focus();
+        }
+
+        async function forgetSuggestion(historyId) {
+            try {
+                await fetch(`/api/shopping/suggestions/${historyId}`, { method: 'DELETE' });
+                suggestions = suggestions.filter(s => s.id !== historyId);
+                activeSuggestion = -1;
+                renderSuggestions();
+            } catch (error) {
+                console.error('Error removing suggestion:', error);
+            }
+        }
+
+        nameInput.addEventListener('input', scheduleSuggestions);
+
+        nameInput.addEventListener('keydown', (e) => {
+            const open = suggestionMenu.classList.contains('open');
+            if (e.key === 'ArrowDown' && open) {
+                e.preventDefault();
+                highlightSuggestion((activeSuggestion + 1) % suggestions.length);
+            } else if (e.key === 'ArrowUp' && open) {
+                e.preventDefault();
+                highlightSuggestion((activeSuggestion - 1 + suggestions.length) % suggestions.length);
+            } else if (e.key === 'Enter') {
+                // Enter with nothing highlighted submits what was typed, verbatim —
+                // autocomplete must never block adding a genuinely new item.
+                if (open && activeSuggestion >= 0) {
+                    e.preventDefault();
+                    acceptSuggestion(activeSuggestion);
+                }
+            } else if (e.key === 'Escape') {
+                closeSuggestions();
+            }
+        });
+
+        nameInput.addEventListener('blur', () => {
+            // Delayed so a click on an option lands before the menu closes.
+            setTimeout(closeSuggestions, 150);
+        });
+
+        suggestionMenu.addEventListener('mousedown', (e) => e.preventDefault());
+
+        suggestionMenu.addEventListener('click', (e) => {
+            const dismiss = e.target.closest('.autocomplete-dismiss');
+            if (dismiss) {
+                e.preventDefault();
+                e.stopPropagation();
+                forgetSuggestion(parseInt(dismiss.dataset.dismiss, 10));
+                return;
+            }
+            const option = e.target.closest('.autocomplete-option');
+            if (option) acceptSuggestion(parseInt(option.dataset.index, 10));
+        });
+
+        // ── Quick add ──
+        storeSelect.addEventListener('change', () => {
+            storeSelect.dataset.touched = 'true';
+        });
+
+        document.getElementById('quick-add-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const name = nameInput.value.trim();
+            if (!name) return;
+
+            const storeValue = storeSelect.value;
+            closeSuggestions();
+            try {
+                await createItem({
+                    name,
+                    store_id: storeValue ? parseInt(storeValue, 10) : null
+                });
+                nameInput.value = '';
+                storeSelect.dataset.touched = 'false';
+                syncQuickAddStoreDefault();
+                nameInput.focus();   // straight back into the burst
+                await fetchItems();
+            } catch (error) {
+                console.error('Error adding item:', error);
+                alert('Failed to add item');
+            }
+        });
+
+        // ── Item actions ──
+        async function toggleComplete(id, completed) {
+            try {
+                await updateItem(id, { completed });
+                await fetchItems();
+            } catch (error) {
+                console.error('Error updating item:', error);
+                alert('Failed to update item');
+                await fetchItems();   // refresh to revert the checkbox
+            }
+        }
+
+        function openEditModal(id) {
+            const item = items.find(i => i.id === id);
+            if (!item) return;
+            editingItemId = id;
+            document.getElementById('item-name').value = item.name;
+            document.getElementById('item-note').value = item.note || '';
+            document.getElementById('item-store').value = item.store_id ? String(item.store_id) : '';
+            showModalOverlay('item-modal-overlay');
+        }
+
+        function closeItemModal() {
+            document.getElementById('item-modal-overlay').style.display = 'none';
+            editingItemId = null;
+        }
+
+        document.getElementById('item-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            if (!editingItemId) return;
+            const storeValue = document.getElementById('item-store').value;
+            try {
+                await updateItem(editingItemId, {
+                    name: document.getElementById('item-name').value,
+                    note: document.getElementById('item-note').value || null,
+                    store_id: storeValue ? parseInt(storeValue, 10) : null
+                });
+                closeItemModal();
+                await fetchItems();
+            } catch (error) {
+                console.error('Error saving item:', error);
+                alert('Failed to save item');
+            }
+        });
+
+        document.getElementById('btn-delete-item').addEventListener('click', async () => {
+            if (!editingItemId) return;
+            if (!confirm('Delete this item?')) return;
+            try {
+                await deleteItem(editingItemId);
+                closeItemModal();
+                await fetchItems();
+            } catch (error) {
+                console.error('Error deleting item:', error);
+                alert('Failed to delete item');
+            }
+        });
+
+        document.getElementById('btn-cancel-item').addEventListener('click', closeItemModal);
+        document.getElementById('item-modal-overlay').addEventListener('click', (e) => {
+            if (e.target.id === 'item-modal-overlay') closeItemModal();
+        });
+
+        // ── Manage stores ──
+        function renderStoreManageList() {
+            const list = document.getElementById('store-manage-list');
+            if (stores.length === 0) {
+                list.innerHTML = '<div class="container-empty-state">No stores yet. Items you add land under "Anywhere".</div>';
+                return;
+            }
+            list.innerHTML = stores.map(s => `
+                <div class="store-manage-row" data-id="${s.id}">
+                    <input type="text" value="${escapeAttr(s.name)}" aria-label="Store name">
+                    <button type="button" class="btn-edit" data-action="rename">Rename</button>
+                    <button type="button" class="btn-delete" data-action="delete">Delete</button>
+                </div>
+            `).join('');
+        }
+
+        document.getElementById('store-manage-list').addEventListener('click', async (e) => {
+            const button = e.target.closest('button[data-action]');
+            if (!button) return;
+            const row = button.closest('.store-manage-row');
+            const storeId = parseInt(row.dataset.id, 10);
+
+            if (button.dataset.action === 'rename') {
+                const name = row.querySelector('input').value.trim();
+                if (!name) return;
+                const response = await fetch(`/api/shopping/stores/${storeId}`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ name })
+                });
+                if (!response.ok) {
+                    alert(response.status === 409 ? 'A store with that name already exists.' : 'Failed to rename store.');
+                    return;
+                }
+            } else {
+                const store = stores.find(s => s.id === storeId);
+                const label = store ? store.name : 'this store';
+                if (!confirm(`Delete ${label}? Its items move to "Anywhere" — nothing is lost.`)) return;
+                const response = await fetch(`/api/shopping/stores/${storeId}`, { method: 'DELETE' });
+                if (!response.ok) {
+                    alert('Failed to delete store.');
+                    return;
+                }
+                selectedStores.delete(String(storeId));
+            }
+
+            await fetchStores();
+            renderStoreManageList();
+            await fetchItems();
+        });
+
+        document.getElementById('store-add-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const input = document.getElementById('store-add-name');
+            const name = input.value.trim();
+            if (!name) return;
+            const response = await fetch('/api/shopping/stores', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name })
+            });
+            if (!response.ok) {
+                alert(response.status === 409 ? 'A store with that name already exists.' : 'Failed to add store.');
+                return;
+            }
+            input.value = '';
+            await fetchStores();
+            renderStoreManageList();
+        });
+
+        document.getElementById('btn-manage-stores').addEventListener('click', () => {
+            renderStoreManageList();
+            showModalOverlay('store-modal-overlay');
+        });
+
+        function closeStoreModal() {
+            document.getElementById('store-modal-overlay').style.display = 'none';
+        }
+
+        document.getElementById('btn-close-stores').addEventListener('click', closeStoreModal);
+        document.getElementById('store-modal-overlay').addEventListener('click', (e) => {
+            if (e.target.id === 'store-modal-overlay') closeStoreModal();
+        });
+
+        // ── Toolbar ──
+        document.getElementById('filter-store-chips').addEventListener('click', (e) => {
+            const chip = e.target.closest('.filter-chip');
+            if (!chip) return;
+            const value = chip.dataset.value;
+            if (value === 'all') {
+                selectedStores.clear();
+            } else if (selectedStores.has(value)) {
+                selectedStores.delete(value);
+            } else {
+                selectedStores.add(value);
+            }
+            syncChipState();
+            syncQuickAddStoreDefault();
+            renderItems();
+        });
+
+        document.getElementById('filter-clear').addEventListener('click', clearFilters);
+        document.getElementById('show-purchased').addEventListener('change', fetchItems);
+
+        // Show a modal and compute its fade state once it's laid out.
+        function showModalOverlay(overlayId) {
+            const overlay = document.getElementById(overlayId);
+            overlay.style.display = 'flex';
+            const scroll = overlay.querySelector('.modal-scroll');
+            if (scroll) requestAnimationFrame(() => updateModalFade(scroll));
+        }
+
+        function updateModalFade(scroll) {
+            const body = scroll.querySelector('.modal-body');
+            const maxScroll = body.scrollHeight - body.clientHeight;
+            scroll.toggleAttribute('data-overflow-top', body.scrollTop > 1);
+            scroll.toggleAttribute('data-overflow-bottom', body.scrollTop < maxScroll - 1);
+        }
+        document.querySelectorAll('.modal-scroll').forEach(scroll => {
+            const body = scroll.querySelector('.modal-body');
+            body.addEventListener('scroll', () => updateModalFade(scroll));
+        });
+
+        // ── Initialize ──
+        fetchStores().then(fetchItems);
+
+        // A plain refetch, not an expiry sweep: the visibility boundary is local
+        // midnight and is decided server-side, so the client only has to ask again.
+        setInterval(() => {
+            fetchStores().then(fetchItems);
+        }, REFRESH_MS);
+
+        // Nav dropdown toggle (for touch devices)
+        function toggleMealDropdown(e) {
+            e.stopPropagation();
+            document.getElementById('meal-dropdown').classList.toggle('open');
+        }
+        document.addEventListener('click', function() {
+            document.getElementById('meal-dropdown').classList.remove('open');
+        });
+    </script>
+
+    <footer>
+        <a href="/settings">Settings</a>
+    </footer>
+</body>
+</html>

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -19,6 +19,7 @@
     <nav>
         <a href="/dashboard">Dashboard</a>
         <a href="/todo" class="active">Tasks</a>
+        <a href="/shopping">Shopping</a>
         <div class="nav-dropdown" id="meal-dropdown">
             <button class="nav-dropdown-btn" onclick="toggleMealDropdown(event)">Meal Planner</button>
             <div class="nav-dropdown-content">

--- a/templates/todo_completed.html
+++ b/templates/todo_completed.html
@@ -19,6 +19,7 @@
     <nav>
         <a href="/dashboard">Dashboard</a>
         <a href="/todo" class="active">Tasks</a>
+        <a href="/shopping">Shopping</a>
         <div class="nav-dropdown" id="meal-dropdown">
             <button class="nav-dropdown-btn" onclick="toggleMealDropdown(event)">Meal Planner</button>
             <div class="nav-dropdown-content">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,16 @@ from sqlalchemy.pool import StaticPool
 
 from rally.database import Base, get_db
 from rally.main import app
-from rally.models import DinnerPlan, FamilyMember, RecurringTodo, Setting, Todo
+from rally.models import (
+    DinnerPlan,
+    FamilyMember,
+    RecurringTodo,
+    Setting,
+    ShoppingItem,
+    ShoppingItemHistory,
+    ShoppingStore,
+    Todo,
+)
 
 # --- Database + client ---------------------------------------------------------
 
@@ -164,6 +173,75 @@ def make_dinner_plan(db_session: Session):
 
 
 @pytest.fixture
+def make_store(db_session: Session):
+    def _make(name: str = "Costco", **kwargs) -> ShoppingStore:
+        store = ShoppingStore(name=name, **kwargs)
+        db_session.add(store)
+        db_session.commit()
+        db_session.refresh(store)
+        return store
+
+    return _make
+
+
+@pytest.fixture
+def make_shopping_item(db_session: Session):
+    def _make(
+        name: str = "Milk",
+        *,
+        note: str | None = None,
+        store_id: int | None = None,
+        completed: bool = False,
+        completed_at: datetime | None = None,
+        created_at: datetime | None = None,
+        **kwargs,
+    ) -> ShoppingItem:
+        item = ShoppingItem(
+            name=name,
+            note=note,
+            store_id=store_id,
+            completed=completed,
+            completed_at=completed_at,
+            **kwargs,
+        )
+        if created_at is not None:
+            item.created_at = created_at
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+        return item
+
+    return _make
+
+
+@pytest.fixture
+def make_item_history(db_session: Session):
+    def _make(
+        name: str = "Milk",
+        *,
+        store_id: int | None = None,
+        times_added: int = 1,
+        last_added_at: datetime | None = None,
+        **kwargs,
+    ) -> ShoppingItemHistory:
+        row = ShoppingItemHistory(
+            name_key=name.strip().casefold(),
+            name=name,
+            store_id=store_id,
+            times_added=times_added,
+            **kwargs,
+        )
+        if last_added_at is not None:
+            row.last_added_at = last_added_at
+        db_session.add(row)
+        db_session.commit()
+        db_session.refresh(row)
+        return row
+
+    return _make
+
+
+@pytest.fixture
 def make_setting(db_session: Session):
     def _make(key: str, value: str) -> Setting:
         row = db_session.get(Setting, key)
@@ -189,6 +267,7 @@ def make_setting(db_session: Session):
 _NOW_UTC_IMPORTERS = (
     "rally.routers.recurring_todos",
     "rally.routers.todos",
+    "rally.routers.shopping",
     "rally.routers.dashboard",
     "rally.routers.settings",
     "rally.generator.generate",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,17 @@ from sqlalchemy.pool import StaticPool
 
 from rally import cli
 from rally.database import Base
-from rally.models import Calendar, DashboardSnapshot, DinnerPlan, FamilyMember, Setting, Todo
+from rally.models import (
+    Calendar,
+    DashboardSnapshot,
+    DinnerPlan,
+    FamilyMember,
+    Setting,
+    ShoppingItem,
+    ShoppingItemHistory,
+    ShoppingStore,
+    Todo,
+)
 from rally.utils.timezone import today_utc
 
 EXPECTED_COUNTS = {
@@ -17,6 +27,9 @@ EXPECTED_COUNTS = {
     "todos": 6,
     "dinner": 16,  # 6 upcoming + 10 past
     "snapshots": 1,
+    "stores": 2,
+    "shopping_items": 7,
+    "item_history": 6,
 }
 
 
@@ -47,6 +60,9 @@ def _counts(session):
         "todos": session.query(Todo).count(),
         "dinner": session.query(DinnerPlan).count(),
         "snapshots": session.query(DashboardSnapshot).count(),
+        "stores": session.query(ShoppingStore).count(),
+        "shopping_items": session.query(ShoppingItem).count(),
+        "item_history": session.query(ShoppingItemHistory).count(),
     }
 
 

--- a/tests/test_generate_helpers.py
+++ b/tests/test_generate_helpers.py
@@ -18,7 +18,16 @@ from sqlalchemy.pool import StaticPool
 
 from rally.database import Base
 from rally.generator.generate import SummaryGenerator
-from rally.models import AISettingsHistory, Calendar, DinnerPlan, FamilyMember, Setting, Todo
+from rally.models import (
+    AISettingsHistory,
+    Calendar,
+    DinnerPlan,
+    FamilyMember,
+    Setting,
+    ShoppingItem,
+    ShoppingStore,
+    Todo,
+)
 
 
 def make_generator(tz: str = "UTC") -> SummaryGenerator:
@@ -80,6 +89,7 @@ def test_init_anthropic_provider_from_db(gen_db, mock_llm):
             "llm_anthropic_api_key": "sk-test",
             "local_timezone": "America/Chicago",
             "stem_concept_enabled": "true",
+            "shopping_list_in_summary_enabled": "true",
         },
     )
 
@@ -89,6 +99,7 @@ def test_init_anthropic_provider_from_db(gen_db, mock_llm):
     assert gen.model == "claude-x"
     assert gen.local_tz_name == "America/Chicago"
     assert gen.stem_concept_enabled is True
+    assert gen.shopping_list_in_summary_enabled is True
 
 
 def test_init_local_provider_from_db(gen_db, mock_llm):
@@ -107,6 +118,7 @@ def test_init_local_provider_from_db(gen_db, mock_llm):
     assert gen.provider == "local"
     assert gen.model == "llama"
     assert gen.stem_concept_enabled is False  # default when unset
+    assert gen.shopping_list_in_summary_enabled is False  # default when unset
 
 
 # --- load_dinner_plans ---------------------------------------------------------
@@ -215,6 +227,60 @@ def test_load_todos_includes_todo_with_unparseable_due_date(gen_db, frozen_now):
 
     assert "Weird" in out
     assert "[Due not-a-date]" in out
+
+
+# --- load_shopping_items -------------------------------------------------------
+
+
+def test_load_shopping_items_groups_by_store_with_anywhere_last(gen_db):
+    costco = ShoppingStore(name="Costco")
+    aldi = ShoppingStore(name="Aldi")
+    gen_db.add_all([costco, aldi])
+    gen_db.flush()
+    gen_db.add_all(
+        [
+            ShoppingItem(name="Paper towels", store_id=costco.id),
+            ShoppingItem(name="Rotisserie chicken", note="2", store_id=costco.id),
+            ShoppingItem(name="Bread", store_id=aldi.id),
+            ShoppingItem(name="Stamps"),
+        ]
+    )
+    gen_db.commit()
+
+    out = make_generator().load_shopping_items()
+
+    assert out.index("Aldi:") < out.index("Costco:") < out.index("Anywhere:")
+    assert "  - Rotisserie chicken - 2" in out
+    assert "  - Stamps" in out
+
+
+def test_load_shopping_items_excludes_completed_items(gen_db):
+    gen_db.add_all(
+        [
+            ShoppingItem(name="Milk", completed=True, completed_at=datetime(2026, 3, 1, 12)),
+            ShoppingItem(name="Eggs"),
+        ]
+    )
+    gen_db.commit()
+
+    out = make_generator().load_shopping_items()
+
+    assert "Eggs" in out
+    assert "Milk" not in out
+
+
+def test_load_shopping_items_empty(gen_db):
+    assert make_generator().load_shopping_items() == "No shopping items currently active."
+
+
+def test_load_shopping_items_falls_back_when_store_was_deleted(gen_db):
+    """An item pointing at a since-deleted store must still be listed."""
+    gen_db.add(ShoppingItem(name="Orphan", store_id=999))
+    gen_db.commit()
+
+    out = make_generator().load_shopping_items()
+
+    assert out == "Anywhere:\n  - Orphan"
 
 
 # --- load_context / load_voice / load_template ---------------------------------

--- a/tests/test_generate_llm.py
+++ b/tests/test_generate_llm.py
@@ -21,6 +21,7 @@ def make_generator(tz: str = "UTC") -> SummaryGenerator:
     gen.config = {}
     gen.calendar_owners = {}
     gen.stem_concept_enabled = False
+    gen.shopping_list_in_summary_enabled = False
     return gen
 
 
@@ -255,6 +256,84 @@ def test_generate_summary_with_stem_enabled(frozen_now):
     assert "Gravity" in gen.client.last_kwargs["messages"][0]["content"]
 
 
+def _shopping_prompts(gen):
+    """(system_prompt, user_prompt) from the last recorded LLM call."""
+    return gen.client.last_kwargs["system"][0]["text"], gen.client.last_kwargs["messages"][0][
+        "content"
+    ]
+
+
+def test_generate_summary_omits_shopping_section_when_disabled(frozen_now):
+    frozen_now(FROZEN)
+    gen = _summary_gen('{"greeting":"Hi","weather_summary":"","schedule":[],"briefing":""}')
+    gen.load_shopping_items = lambda: "Costco:\n  - Paper towels"
+
+    gen.generate_summary()
+
+    system_prompt, user_prompt = _shopping_prompts(gen)
+    assert "SHOPPING LIST" not in user_prompt
+    assert "Paper towels" not in user_prompt
+    assert "SHOPPING LIST FILTERING" not in system_prompt
+
+
+def test_generate_summary_includes_shopping_section_when_enabled(frozen_now):
+    frozen_now(FROZEN)
+    gen = _summary_gen('{"greeting":"Hi","weather_summary":"","schedule":[],"briefing":""}')
+    gen.shopping_list_in_summary_enabled = True
+    gen.load_shopping_items = lambda: "Costco:\n  - Paper towels\nAnywhere:\n  - Stamps"
+
+    gen.generate_summary()
+
+    system_prompt, user_prompt = _shopping_prompts(gen)
+    assert "SHOPPING LIST (open items):" in user_prompt
+    assert "Costco" in user_prompt
+    assert "Paper towels" in user_prompt
+    assert "11. SHOPPING LIST FILTERING" in system_prompt
+
+
+def test_generate_summary_shopping_empty_list_phrasing(frozen_now):
+    frozen_now(FROZEN)
+    gen = _summary_gen('{"greeting":"Hi","weather_summary":"","schedule":[],"briefing":""}')
+    gen.shopping_list_in_summary_enabled = True
+    gen.load_shopping_items = lambda: "No shopping items currently active."
+
+    gen.generate_summary()
+
+    _, user_prompt = _shopping_prompts(gen)
+    assert "No shopping items currently active." in user_prompt
+
+
+def test_optional_guidelines_are_numbered_sequentially(frozen_now):
+    """With both toggles on the appended guidelines must run 11 then 12 — no
+    collision, no gap, whichever combination of features is enabled."""
+    frozen_now(FROZEN)
+    gen = _summary_gen('{"greeting":"Hi","weather_summary":"","schedule":[],"briefing":""}')
+    gen.stem_concept_enabled = True
+    gen.shopping_list_in_summary_enabled = True
+    gen.load_recent_stem_concepts = lambda: []
+    gen.load_shopping_items = lambda: "Anywhere:\n  - Stamps"
+
+    gen.generate_summary()
+
+    system_prompt, _ = _shopping_prompts(gen)
+    assert "11. STEM CONCEPT OF THE DAY" in system_prompt
+    assert "12. SHOPPING LIST FILTERING" in system_prompt
+    assert "13." not in system_prompt
+
+
+def test_shopping_guideline_is_11_when_stem_is_off(frozen_now):
+    frozen_now(FROZEN)
+    gen = _summary_gen('{"greeting":"Hi","weather_summary":"","schedule":[],"briefing":""}')
+    gen.shopping_list_in_summary_enabled = True
+    gen.load_shopping_items = lambda: "Anywhere:\n  - Stamps"
+
+    gen.generate_summary()
+
+    system_prompt, _ = _shopping_prompts(gen)
+    assert "11. SHOPPING LIST FILTERING" in system_prompt
+    assert "12." not in system_prompt
+
+
 # --- evaluate_summary ----------------------------------------------------------
 
 
@@ -284,6 +363,22 @@ def test_evaluate_summary_parses_json():
     out = gen.evaluate_summary({"greeting": "Hi"})
     assert out["overall_score"] == 4.5
     assert out["pass"] is True
+
+
+def test_evaluate_summary_omits_shopping_ground_truth_when_absent():
+    gen = _eval_gen('{"overall_score":4.0,"pass":true}')
+    gen.evaluate_summary({"greeting": "Hi"})
+    assert "SHOPPING LIST" not in gen.client.last_kwargs["messages"][0]["content"]
+
+
+def test_evaluate_summary_includes_shopping_ground_truth():
+    gen = _eval_gen('{"overall_score":4.0,"pass":true}')
+    gen._generation_context["shopping_items"] = "Costco:\n  - Paper towels"
+    gen.evaluate_summary({"greeting": "Hi"})
+
+    eval_user = gen.client.last_kwargs["messages"][0]["content"]
+    assert "SHOPPING LIST:" in eval_user
+    assert "Paper towels" in eval_user
 
 
 def test_evaluate_summary_extracts_fenced_json():

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -5,12 +5,29 @@ import pytest
 
 @pytest.mark.parametrize(
     "path",
-    ["/todo", "/todo/completed", "/dinner-planner", "/meal-history", "/settings"],
+    ["/todo", "/todo/completed", "/shopping", "/dinner-planner", "/meal-history", "/settings"],
 )
 def test_page_renders_html(client, path):
     resp = client.get(path)
     assert resp.status_code == 200
     assert resp.headers["content-type"].startswith("text/html")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/dashboard",
+        "/todo",
+        "/todo/completed",
+        "/shopping",
+        "/dinner-planner",
+        "/meal-history",
+        "/settings",
+    ],
+)
+def test_nav_links_to_shopping(client, path):
+    """The nav is duplicated across templates, so every page must carry the link."""
+    assert 'href="/shopping"' in client.get(path).text
 
 
 @pytest.mark.parametrize("path", ["/dinner-planner", "/meal-history"])

--- a/tests/test_shopping.py
+++ b/tests/test_shopping.py
@@ -1,0 +1,452 @@
+"""Tests for the shopping list router.
+
+Covers the local-midnight visibility boundary (mirroring test_completed_todos.py),
+the 30-day retention purge and its once-per-local-day gate, store CRUD and the
+reassign-on-delete behaviour, item create/dedupe/update semantics, store-by-name
+resolution for scripted clients, and the history-backed suggestions endpoints.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from rally.models import ShoppingItem, ShoppingItemHistory, ShoppingStore
+
+# Noon UTC on 2026-03-15. In America/Chicago (CDT, UTC-5) local midnight that
+# day is 05:00 UTC, so the 04:00/06:00 fixtures below straddle the boundary.
+NOON = datetime(2026, 3, 15, 12, 0, tzinfo=UTC)
+BEFORE_LOCAL_MIDNIGHT = datetime(2026, 3, 15, 4, 0, tzinfo=UTC)  # Mar 14, 23:00 local
+AFTER_LOCAL_MIDNIGHT = datetime(2026, 3, 15, 6, 0, tzinfo=UTC)  # Mar 15, 01:00 local
+
+
+def item_names(payload) -> list[str]:
+    return [item["name"] for item in payload]
+
+
+# --- Visibility boundary -------------------------------------------------------
+
+
+def test_item_completed_today_stays_on_the_list(
+    client, make_shopping_item, frozen_now, local_timezone
+):
+    local_timezone("America/Chicago")
+    frozen_now(NOON)
+    make_shopping_item("Coffee beans", completed=True, completed_at=AFTER_LOCAL_MIDNIGHT)
+
+    assert item_names(client.get("/api/shopping/items").json()) == ["Coffee beans"]
+
+
+def test_item_completed_yesterday_is_hidden(client, make_shopping_item, frozen_now, local_timezone):
+    local_timezone("America/Chicago")
+    frozen_now(NOON)
+    make_shopping_item("Coffee beans", completed=True, completed_at=BEFORE_LOCAL_MIDNIGHT)
+
+    assert client.get("/api/shopping/items").json() == []
+
+
+def test_include_hidden_returns_previously_purchased_items(
+    client, make_shopping_item, frozen_now, local_timezone
+):
+    local_timezone("America/Chicago")
+    frozen_now(NOON)
+    make_shopping_item("Coffee beans", completed=True, completed_at=BEFORE_LOCAL_MIDNIGHT)
+
+    resp = client.get("/api/shopping/items", params={"include_hidden": "true"})
+    assert item_names(resp.json()) == ["Coffee beans"]
+
+
+def test_boundary_uses_configured_timezone_not_utc(
+    client, make_shopping_item, frozen_now, local_timezone
+):
+    """04:00 UTC is still *yesterday* in Chicago but already today in UTC."""
+    frozen_now(NOON)
+    make_shopping_item("Coffee beans", completed=True, completed_at=BEFORE_LOCAL_MIDNIGHT)
+
+    # Default (no local_timezone setting) is UTC: the item is "completed today".
+    assert item_names(client.get("/api/shopping/items").json()) == ["Coffee beans"]
+
+    local_timezone("America/Chicago")
+    assert client.get("/api/shopping/items").json() == []
+
+
+def test_open_items_sort_before_completed_ones(
+    client, make_shopping_item, frozen_now, local_timezone
+):
+    local_timezone("America/Chicago")
+    frozen_now(NOON)
+    make_shopping_item("Bought", completed=True, completed_at=AFTER_LOCAL_MIDNIGHT)
+    make_shopping_item("Still needed")
+
+    assert item_names(client.get("/api/shopping/items").json()) == ["Still needed", "Bought"]
+
+
+def test_completing_stamps_and_uncompleting_clears(client, make_shopping_item, frozen_now):
+    frozen_now(NOON)
+    item = make_shopping_item("Milk")
+
+    completed = client.put(f"/api/shopping/items/{item.id}", json={"completed": True}).json()
+    assert completed["completed"] is True
+    assert completed["completed_at"] is not None
+
+    reopened = client.put(f"/api/shopping/items/{item.id}", json={"completed": False}).json()
+    assert reopened["completed"] is False
+    assert reopened["completed_at"] is None
+
+
+def test_recompleting_does_not_restamp(client, make_shopping_item, frozen_now):
+    frozen_now(NOON)
+    item = make_shopping_item("Milk")
+
+    first = client.put(f"/api/shopping/items/{item.id}", json={"completed": True}).json()
+    frozen_now(NOON + timedelta(hours=3))
+    again = client.put(f"/api/shopping/items/{item.id}", json={"completed": True}).json()
+
+    assert again["completed_at"] == first["completed_at"]
+
+
+# --- Retention purge -----------------------------------------------------------
+
+
+def test_purge_deletes_items_completed_over_30_days_ago(
+    client, db_session, make_shopping_item, frozen_now, local_timezone
+):
+    local_timezone()
+    frozen_now(NOON)
+    make_shopping_item("Old milk", completed=True, completed_at=NOON - timedelta(days=31))
+
+    client.get("/api/shopping/items", params={"include_hidden": "true"})
+
+    # Deleted from the database, not merely hidden.
+    assert db_session.query(ShoppingItem).count() == 0
+
+
+def test_purge_keeps_items_completed_within_30_days(
+    client, db_session, make_shopping_item, frozen_now, local_timezone
+):
+    local_timezone()
+    frozen_now(NOON)
+    make_shopping_item("Recent milk", completed=True, completed_at=NOON - timedelta(days=29))
+
+    client.get("/api/shopping/items", params={"include_hidden": "true"})
+
+    assert db_session.query(ShoppingItem).count() == 1
+
+
+def test_purge_never_touches_open_items(
+    client, db_session, make_shopping_item, frozen_now, local_timezone
+):
+    """An item nobody has bought in two years is still something the family wants."""
+    local_timezone()
+    frozen_now(NOON)
+    make_shopping_item("Stamps", created_at=NOON - timedelta(days=100))
+
+    client.get("/api/shopping/items")
+
+    assert db_session.query(ShoppingItem).count() == 1
+
+
+def test_purge_leaves_item_history_intact(
+    client, db_session, make_shopping_item, make_item_history, frozen_now, local_timezone
+):
+    """The single most important purge test: splitting the tables is the whole
+    reason purchased rows can be deleted at all."""
+    local_timezone()
+    frozen_now(NOON)
+    make_item_history("Old milk", times_added=7)
+    make_shopping_item("Old milk", completed=True, completed_at=NOON - timedelta(days=31))
+
+    client.get("/api/shopping/items", params={"include_hidden": "true"})
+
+    assert db_session.query(ShoppingItem).count() == 0
+    assert db_session.query(ShoppingItemHistory).one().times_added == 7
+
+
+def test_purge_runs_at_most_once_per_local_day(
+    client, db_session, make_shopping_item, frozen_now, local_timezone
+):
+    local_timezone()
+    frozen_now(NOON)
+    make_shopping_item("First", completed=True, completed_at=NOON - timedelta(days=31))
+    client.get("/api/shopping/items")
+
+    # A second stale row added after today's purge already ran survives until
+    # the local date rolls over — the read path must not take a write lock again.
+    make_shopping_item("Second", completed=True, completed_at=NOON - timedelta(days=31))
+    client.get("/api/shopping/items")
+
+    assert item_names(
+        client.get("/api/shopping/items", params={"include_hidden": "true"}).json()
+    ) == ["Second"]
+
+
+# --- Stores --------------------------------------------------------------------
+
+
+def test_store_crud(client):
+    created = client.post("/api/shopping/stores", json={"name": "Costco"})
+    assert created.status_code == 201
+    store_id = created.json()["id"]
+
+    client.post("/api/shopping/stores", json={"name": "Aldi"})
+    assert item_names(client.get("/api/shopping/stores").json()) == ["Aldi", "Costco"]
+
+    renamed = client.put(f"/api/shopping/stores/{store_id}", json={"name": "Costco Business"})
+    assert renamed.status_code == 200
+    assert renamed.json()["name"] == "Costco Business"
+
+    assert client.delete(f"/api/shopping/stores/{store_id}").status_code == 204
+    assert item_names(client.get("/api/shopping/stores").json()) == ["Aldi"]
+
+
+def test_store_name_conflicts_are_case_insensitive(client, make_store):
+    make_store("Costco")
+    assert client.post("/api/shopping/stores", json={"name": "costco"}).status_code == 409
+
+    other = client.post("/api/shopping/stores", json={"name": "Aldi"}).json()
+    assert (
+        client.put(f"/api/shopping/stores/{other['id']}", json={"name": "COSTCO"}).status_code
+        == 409
+    )
+
+
+def test_renaming_a_store_to_its_own_name_is_allowed(client, make_store):
+    store = make_store("Costco")
+    resp = client.put(f"/api/shopping/stores/{store.id}", json={"name": "costco"})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "costco"
+
+
+def test_empty_store_name_is_rejected(client):
+    assert client.post("/api/shopping/stores", json={"name": "   "}).status_code == 422
+
+
+def test_deleting_a_store_moves_its_items_to_anywhere(
+    client, db_session, make_store, make_shopping_item
+):
+    store = make_store("Costco")
+    item = make_shopping_item("Paper towels", store_id=store.id)
+
+    assert client.delete(f"/api/shopping/stores/{store.id}").status_code == 204
+
+    listed = client.get("/api/shopping/items").json()
+    assert item_names(listed) == ["Paper towels"]
+    assert listed[0]["store_id"] is None
+    db_session.expire_all()
+    assert db_session.get(ShoppingItem, item.id).store_id is None
+
+
+def test_deleting_a_missing_store_is_404(client):
+    assert client.delete("/api/shopping/stores/999").status_code == 404
+
+
+def test_unknown_store_id_on_create_is_rejected(client):
+    resp = client.post("/api/shopping/items", json={"name": "Milk", "store_id": 999})
+    assert resp.status_code == 422
+
+
+def test_unknown_store_id_on_update_is_rejected(client, make_shopping_item):
+    item = make_shopping_item("Milk")
+    assert client.put(f"/api/shopping/items/{item.id}", json={"store_id": 999}).status_code == 422
+
+
+# --- Items ---------------------------------------------------------------------
+
+
+def test_create_item_defaults(client):
+    resp = client.post("/api/shopping/items", json={"name": "  Milk  "})
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["name"] == "Milk"  # trimmed
+    assert body["note"] is None
+    assert body["store_id"] is None
+    assert body["completed"] is False
+    assert body["completed_at"] is None
+
+
+def test_whitespace_only_item_name_is_rejected(client):
+    assert client.post("/api/shopping/items", json={"name": "   "}).status_code == 422
+
+
+def test_renaming_an_item_to_whitespace_is_rejected(client, make_shopping_item):
+    item = make_shopping_item("Milk")
+    assert client.put(f"/api/shopping/items/{item.id}", json={"name": " "}).status_code == 422
+
+
+def test_adding_an_open_duplicate_returns_the_existing_item(client, make_store):
+    store = make_store("Costco")
+    first = client.post("/api/shopping/items", json={"name": "Milk", "store_id": store.id}).json()
+
+    resp = client.post("/api/shopping/items", json={"name": "  milk ", "store_id": store.id})
+    assert resp.status_code == 200
+    assert resp.json()["id"] == first["id"]
+
+
+def test_same_name_in_a_different_store_is_a_new_item(client, make_store):
+    costco = make_store("Costco")
+    aldi = make_store("Aldi")
+    client.post("/api/shopping/items", json={"name": "Milk", "store_id": costco.id})
+
+    resp = client.post("/api/shopping/items", json={"name": "Milk", "store_id": aldi.id})
+    assert resp.status_code == 201
+
+
+def test_a_completed_match_does_not_dedupe(client, make_shopping_item, frozen_now):
+    """You bought the milk; now you need more milk."""
+    frozen_now(NOON)
+    make_shopping_item("Milk", completed=True, completed_at=NOON)
+
+    resp = client.post("/api/shopping/items", json={"name": "Milk"})
+    assert resp.status_code == 201
+
+
+def test_note_null_clears_and_omission_leaves_alone(client, make_shopping_item):
+    item = make_shopping_item("Milk", note="Whole")
+
+    unchanged = client.put(f"/api/shopping/items/{item.id}", json={"name": "Milk"}).json()
+    assert unchanged["note"] == "Whole"
+
+    cleared = client.put(f"/api/shopping/items/{item.id}", json={"note": None}).json()
+    assert cleared["note"] is None
+
+
+def test_delete_item(client, make_shopping_item):
+    item = make_shopping_item("Milk")
+    assert client.delete(f"/api/shopping/items/{item.id}").status_code == 204
+    assert client.get("/api/shopping/items").json() == []
+
+
+# --- Store by name (scripted / voice clients) ----------------------------------
+
+
+def test_store_name_resolves_case_insensitively(client, make_store):
+    store = make_store("Trader Joe's")
+    resp = client.post("/api/shopping/items", json={"name": "Milk", "store": "trader joe's"})
+    assert resp.status_code == 201
+    assert resp.json()["store_id"] == store.id
+
+
+def test_unknown_store_name_falls_back_to_anywhere(client, db_session):
+    """A hard failure mid-dictation is worse than a slightly-misfiled item."""
+    resp = client.post("/api/shopping/items", json={"name": "Milk", "store": "Nowhere"})
+    assert resp.status_code == 201
+    assert resp.json()["store_id"] is None
+    assert db_session.query(ShoppingStore).count() == 0
+
+
+def test_sending_both_store_and_store_id_is_rejected(client, make_store):
+    store = make_store("Costco")
+    resp = client.post(
+        "/api/shopping/items", json={"name": "Milk", "store_id": store.id, "store": "Costco"}
+    )
+    assert resp.status_code == 422
+
+
+# --- History and suggestions ---------------------------------------------------
+
+
+def test_create_records_history(client, db_session, make_store):
+    store = make_store("Costco")
+    client.post("/api/shopping/items", json={"name": "Milk", "store_id": store.id})
+
+    row = db_session.query(ShoppingItemHistory).one()
+    assert row.name == "Milk"
+    assert row.name_key == "milk"
+    assert row.times_added == 1
+    assert row.store_id == store.id
+
+
+def test_second_create_increments_rather_than_inserting(client, db_session, make_shopping_item):
+    client.post("/api/shopping/items", json={"name": "Milk"})
+    # Complete the first one so the second add isn't deduped away.
+    item = db_session.query(ShoppingItem).one()
+    client.put(f"/api/shopping/items/{item.id}", json={"completed": True})
+    client.post("/api/shopping/items", json={"name": "MILK"})
+
+    row = db_session.query(ShoppingItemHistory).one()
+    assert row.times_added == 2
+    assert row.name == "MILK"  # display casing follows the latest add
+
+
+def test_history_store_id_follows_the_most_recent_add(client, db_session, make_store):
+    costco = make_store("Costco")
+    target = make_store("Target")
+    client.post("/api/shopping/items", json={"name": "Milk", "store_id": costco.id})
+    client.post("/api/shopping/items", json={"name": "Milk", "store_id": target.id})
+
+    assert db_session.query(ShoppingItemHistory).one().store_id == target.id
+
+
+def test_dedupe_hit_does_not_increment_history(client, db_session):
+    client.post("/api/shopping/items", json={"name": "Milk"})
+    client.post("/api/shopping/items", json={"name": "Milk"})
+
+    assert db_session.query(ShoppingItemHistory).one().times_added == 1
+
+
+def test_renaming_an_item_leaves_history_untouched(client, db_session):
+    created = client.post("/api/shopping/items", json={"name": "Mikl"}).json()
+    client.put(f"/api/shopping/items/{created['id']}", json={"name": "Milk"})
+
+    row = db_session.query(ShoppingItemHistory).one()
+    assert row.name == "Mikl"
+    assert row.times_added == 1
+
+
+def test_suggestions_match_anywhere_in_the_name(client, make_item_history):
+    make_item_history("Almond milk")
+    resp = client.get("/api/shopping/suggestions", params={"q": "milk"})
+    assert item_names(resp.json()) == ["Almond milk"]
+
+
+def test_prefix_matches_outrank_substring_matches(client, make_item_history):
+    make_item_history("Almond milk", times_added=50)
+    make_item_history("Milk", times_added=1)
+
+    resp = client.get("/api/shopping/suggestions", params={"q": "mil"})
+    assert item_names(resp.json()) == ["Milk", "Almond milk"]
+
+
+def test_use_count_ranks_within_a_tier(client, make_item_history):
+    make_item_history("Milk", times_added=2)
+    make_item_history("Milk chocolate", times_added=9)
+
+    resp = client.get("/api/shopping/suggestions", params={"q": "mil"})
+    assert item_names(resp.json()) == ["Milk chocolate", "Milk"]
+
+
+def test_like_wildcards_in_the_query_are_literal(client, make_item_history):
+    make_item_history("Milk")
+    make_item_history("100% juice")
+
+    assert item_names(client.get("/api/shopping/suggestions", params={"q": "%"}).json()) == [
+        "100% juice"
+    ]
+    assert client.get("/api/shopping/suggestions", params={"q": "_"}).json() == []
+
+
+def test_empty_query_returns_the_usual_suspects(client, make_item_history):
+    make_item_history("Bread", times_added=3)
+    make_item_history("Milk", times_added=12)
+
+    assert item_names(client.get("/api/shopping/suggestions").json()) == ["Milk", "Bread"]
+
+
+def test_limit_is_honored_and_capped(client, make_item_history):
+    for i in range(30):
+        make_item_history(f"Item {i:02d}", times_added=30 - i)
+
+    assert len(client.get("/api/shopping/suggestions", params={"limit": 3}).json()) == 3
+    assert len(client.get("/api/shopping/suggestions", params={"limit": 100}).json()) == 25
+
+
+def test_deleting_a_suggestion_leaves_shopping_items_alone(
+    client, db_session, make_item_history, make_shopping_item
+):
+    history = make_item_history("Mikl")
+    make_shopping_item("Mikl")
+
+    assert client.delete(f"/api/shopping/suggestions/{history.id}").status_code == 204
+    assert db_session.query(ShoppingItemHistory).count() == 0
+    assert db_session.query(ShoppingItem).count() == 1
+
+
+def test_deleting_a_missing_suggestion_is_404(client):
+    assert client.delete("/api/shopping/suggestions/999").status_code == 404

--- a/tests/test_todos.py
+++ b/tests/test_todos.py
@@ -9,7 +9,7 @@ and DELETE.
 from datetime import UTC, datetime
 
 from rally.models import Todo
-from rally.routers.todos import today_start_utc
+from rally.utils.settings import today_start_utc
 
 NOON = datetime(2026, 3, 15, 12, 0, tzinfo=UTC)
 


### PR DESCRIPTION
## Summary

Adds a shared family shopping list as a peer of Tasks and the Meal Planner: its own page at `/shopping`, its own API router, and the same list/modal/filter-chip vocabulary the rest of the app already uses. Items are added fast (type, Enter, keep typing) with autocomplete from what the family has bought before, grouped under user-defined stores, and completed while shopping. A completed item stays visible until local midnight, exactly as tasks behave today. Nothing about existing tasks, meals, or the dashboard changes behaviourally — the one shared-code change is moving `today_start_utc()` out of `routers/todos.py` so both routers can use it.

The two memories are deliberately separate: `shopping_items` is a 30-day rolling record whose completed rows are **deleted** as they age out, while `shopping_item_history` is permanent, deduplicated, and carries the use counter that powers autocomplete. Neither grows without bound, and trimming one never damages the other.

## Changes

**Shared helper**
- New `src/rally/utils/settings.py` with `today_start_utc()` and `local_timezone_name()`, moved out of `routers/todos.py`. It cannot live in `utils/timezone.py` — that module is imported by `models.py` for `now_utc`, so needing `Setting` there would be a circular import.

**Backend**
- New models `ShoppingStore`, `ShoppingItem`, `ShoppingItemHistory`. `ShoppingItem` uses the same `completed` / `completed_at` columns and semantics as `Todo`; the catch-all is `store_id IS NULL`, not a seeded row.
- New router `src/rally/routers/shopping.py` (`/api/shopping`):
  - Stores CRUD, unique case-insensitively (`409`). `DELETE` reassigns the store's items to `store_id = NULL` **first** — SQLite FKs aren't enforced, so an orphaned `store_id` would make those items vanish from every rendered group.
  - `GET /items` hides items completed before local midnight unless `include_hidden=true`, ordered `completed ASC, created_at DESC`.
  - `POST /items` trims the name (`422` when empty), dedupes against **open** items in the same store (`200` with the existing row; a merely completed match creates a new item), and upserts history only on a real create.
  - `store` may be sent as a store **name** in place of `store_id` for scripted/voice clients; both is `422`, an unrecognized name falls back to the catch-all and never auto-creates a store.
  - `GET /suggestions` does substring matching with `%`, `_` and `\` escaped via `ESCAPE`, ranked prefix-matches-first then by `times_added`; `DELETE /suggestions/{id}` forgets one.
  - Retention purge deletes items completed more than `PURCHASED_RETENTION_DAYS` (30) ago, gated on a `shopping_last_purge_date` settings row so it runs at most once per local day.
- `migrations/migrate_017_add_shopping_lists.py`, registered in `run_migrations.py`.

**Frontend**
- New `templates/shopping.html` and the `GET /shopping` route. Quick add is a persistent inline row; autocomplete is a custom dropdown (a native `datalist` can't render the name/store row or the per-row dismiss) with a ~150 ms debounce and a request-sequence guard against out-of-order replies.
- `Shopping` nav link added to all six page templates, since the nav markup is duplicated.
- Shopping styles in `static/styles.css`.
- Settings gains a small Shopping List section with the summary toggle.

**AI summary**
- `load_shopping_items()` mirrors `load_todos()`: open items only, grouped by store with "Anywhere" last. Gated on `shopping_list_in_summary_enabled` (default off); when off the section is omitted entirely rather than sent empty.
- Optional guidelines are now collected into a list and numbered sequentially from 11 at build time, so STEM and shopping can't collide or leave a gap. The eval prompt gets the list as ground truth too.

**Tests**
- New `tests/test_shopping.py`; `make_store` / `make_shopping_item` / `make_item_history` conftest factories; `rally.routers.shopping` added to `_NOW_UTC_IMPORTERS` so `frozen_now` actually freezes the boundary and purge tests.
- Generator coverage for `load_shopping_items()`, the prompt sections, and guideline numbering; `/shopping` added to `test_pages.py` plus a nav-link check across all pages.

**Docs**
- README feature bullet, migration table row, directory structure, and an "Adding Items by Voice" Apple Shortcuts recipe. AGENTS.md routes, models, settings keys, migrations, and implementation status.

## Notes for reviewers

- **`shopping_item_history.store_id` is the most recently used store, not the most common one.** A true mode needs per-`(name, store)` counts — a row per pair, which un-deduplicates the table the counter exists to keep small. Visible cost: buy milk at Costco twenty times and once at Target, and the suggestion follows Target until the next Costco run. Per-pair counts are the upgrade path.
- **The purge lives in the items listing, not the 4 AM container job.** That job lives in `entrypoint.sh` and only runs under Docker, so a `dev`-served instance would never purge. The once-per-local-day gate keeps a read path from taking a SQLite write lock on every request.
- **A dedupe hit (`200`) does not increment history** — nothing was added. Renaming an item via `PUT` doesn't touch history either; history records adds, and a typo correction shouldn't rewrite a counter.
- Accepting a suggestion fills the store select **only when it is still blank**, so an explicit choice — including one inherited from an active single-store filter — always wins. Autocomplete can never silently move an item to a different store than the one you were looking at.

## Testing

- `uv run pytest` — 371 passed (57 new). `uv run ruff check .` and `uv run ruff format --check .` both clean.
- Migration 017 run twice against a **copy** of a real `rally.db` to confirm idempotency. Verified `create_all` and the migration produce matching schemas, and that the `COLLATE NOCASE` unique index really rejects `costco` after `Costco`.
- API smoke-tested against a seeded scratch database on a throwaway port: store-by-name resolution, unknown-name fallback, dedupe `200`, both-fields `422`, empty-name `422`, rename conflict `409`, store deletion reassigning items to "Anywhere" while history keeps its `store_id`, and the purge marker being written once. The dev `rally.db` was never written to.
- **Not verified:** the page was only checked for rendered markup and `node --check` on its inline script — no browser automation was available in this environment, so the autocomplete keyboard handling, debounce, and out-of-order guard have not been exercised against a real DOM. Worth a manual pass on `/shopping` before relying on it.

Closes #130
