### PR TITLE
Drop the redundant per-item store label from the shopping list

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1091,14 +1091,6 @@ footer a:hover {
     white-space: nowrap;
 }
 
-.shopping-item-store {
-    font-family: var(--body-font);
-    font-style: italic;
-    font-size: 0.9rem;
-    color: var(--medium-gray);
-    margin-left: 6px;
-}
-
 .shopping-completed-at {
     font-size: 0.85rem;
     color: var(--light-gray);

--- a/templates/shopping.html
+++ b/templates/shopping.html
@@ -315,9 +315,10 @@
             }).join('');
         }
 
+        // Every item renders inside its store's group, so the store is already
+        // named by the heading directly above — repeating it on the row is pure
+        // duplication. Add it back only if items ever render ungrouped.
         function renderItemRow(item) {
-            const store = item.store_id ? storeName(item.store_id) : null;
-            const storeHtml = store ? `<span class="shopping-item-store">${escapeHtml(store)}</span>` : '';
             const completedHtml = item.completed
                 ? `<div class="shopping-completed-at">${escapeHtml(formatCompletedAgo(item.completed_at))}</div>`
                 : '';
@@ -329,7 +330,7 @@
                                onchange="toggleComplete(${item.id}, this.checked)">
                     </div>
                     <div class="editable-item-content">
-                        <div class="editable-item-title">${escapeHtml(item.name)} ${storeHtml}</div>
+                        <div class="editable-item-title">${escapeHtml(item.name)}</div>
                         ${item.note ? `<div class="editable-item-description">${escapeHtml(item.note)}</div>` : ''}
                         ${completedHtml}
                     </div>


### PR DESCRIPTION
## Summary

Removes the italic store name from each shopping list row. Items are always rendered inside their store's group, so the label only ever repeated the group heading immediately above it — `COSTCO` as the heading, then `Diet cokes · Costco`, `Avocado oil · Costco`, `Zyrtec · Costco` beneath it. The heading is the identity carrier for the group (stores have no colour — Rally is grayscale/e-ink first), so the row label was pure duplication.

## Changes

**Frontend**
- `templates/shopping.html`: drop the `storeHtml` span from `renderItemRow()`. `renderItemRow` has a single call site, inside a group's `.list-container`, so there is no view in which an item appears without its store named above it.
- `static/styles.css`: remove the now-unused `.shopping-item-store` rule.

## Notes for reviewers

- The **autocomplete dropdown keeps** its store label (`.autocomplete-store`). Those rows are not grouped, so there the store is the only thing conveying affinity — and store affinity is the main thing that makes the custom dropdown worth building over a native `datalist`.
- `storeName()` is still used by `groupLabel()` and the suggestion rows, so it stays.
- If items ever render ungrouped (a flat "everything" view, say), the label should come back — there's a comment on `renderItemRow` saying so.

## Testing

- `uv run pytest` — 371 passed. `uv run ruff check .` and `uv run ruff format --check .` clean.
- `node --check` on the page's inline script, and grepped for stale `storeHtml` / `.shopping-item-store` references — none remain.
- Not verified in a browser: no browser automation is available in this environment, so the rendered row was not visually confirmed. The change is a deletion from a template literal with no other call sites.
