### PR TITLE
Report LLM budget exhaustion as truncation, not as a JSON error

### DIFF
--- a/src/rally/generator/generate.py
+++ b/src/rally/generator/generate.py
@@ -20,6 +20,68 @@ from rally.utils.timezone import ensure_utc, now_utc, today_utc
 # sub-topics within the same broader area are still allowed inside the window.
 STEM_REPEAT_WINDOW_DAYS = 60
 
+# Token budget for a single LLM call. On the Anthropic Messages API this cap
+# covers thinking tokens *and* visible output, so a reasoning-heavy call can
+# burn most of it before the JSON body is finished.
+LLM_MAX_TOKENS = 4000
+
+
+class LLMTruncatedError(Exception):
+    """Raised when the model stopped because it exhausted the token budget.
+
+    A truncated response is perfectly well-formed right up to the cut, so it
+    fails JSON parsing exactly like malformed output would. Keeping this
+    distinct from json.JSONDecodeError stops that misdiagnosis at the source.
+    """
+
+
+def _describe_usage(usage) -> str:
+    """Render whichever token counters the provider reported, skipping the rest.
+
+    Providers disagree on names (Anthropic ``input_tokens`` vs OpenAI
+    ``prompt_tokens``) and stubs in the test suite report none at all, so every
+    field is optional and the first name to supply a given label wins.
+    """
+    if usage is None:
+        return "usage=unavailable"
+
+    counters = (
+        ("input_tokens", "input"),
+        ("prompt_tokens", "input"),
+        ("output_tokens", "output"),
+        ("completion_tokens", "output"),
+        ("total_tokens", "total"),
+        ("cache_creation_input_tokens", "cache_write"),
+        ("cache_read_input_tokens", "cache_read"),
+    )
+
+    parts: list[str] = []
+    seen: set[str] = set()
+    for attr, label in counters:
+        value = getattr(usage, attr, None)
+        if value is not None and label not in seen:
+            seen.add(label)
+            parts.append(f"{label}={value}")
+
+    # OpenAI-compatible servers report reasoning tokens in a nested object;
+    # Anthropic folds thinking into output_tokens and reports nothing here.
+    details = getattr(usage, "completion_tokens_details", None)
+    reasoning = getattr(details, "reasoning_tokens", None)
+    if reasoning is not None:
+        parts.append(f"reasoning={reasoning}")
+
+    return ", ".join(parts) if parts else "usage=unavailable"
+
+
+def _error_summary(detail: str) -> dict:
+    """Placeholder summary rendered when generation fails, matching the schema."""
+    return {
+        "greeting": "⚠️ Unable to generate today's summary.",
+        "weather_summary": detail,
+        "schedule": [],
+        "briefing": "The system will retry at the next scheduled interval.",
+    }
+
 
 class SummaryGenerator:
     """Generate daily family summaries with calendar, weather, and todos."""
@@ -749,17 +811,26 @@ class SummaryGenerator:
         base_dir = Path(__file__).resolve().parent.parent.parent.parent
         return (base_dir / "templates" / "dashboard.html").read_text()
 
-    def _call_llm(self, user_prompt: str, system_prompt: str | None = None) -> str:
+    def _call_llm(
+        self, user_prompt: str, system_prompt: str | None = None, label: str = "llm"
+    ) -> str:
         """Call the configured LLM provider and return the response text.
 
         When a system_prompt is provided it is sent as a separate system message.
         For Anthropic, prompt caching is enabled on the system block so that
         static content (voice, context, guidelines) is cached across calls.
+
+        The stop reason and token usage are logged on every call, successful or
+        not, so budget headroom is visible before it becomes an outage. ``label``
+        distinguishes the callers in those log lines.
+
+        Raises:
+            LLMTruncatedError: the model ran out of token budget mid-response.
         """
         if self.provider == "anthropic":
             kwargs: dict = {
                 "model": self.model,
-                "max_tokens": 4000,
+                "max_tokens": LLM_MAX_TOKENS,
                 "messages": [{"role": "user", "content": user_prompt}],
             }
             if system_prompt:
@@ -771,6 +842,21 @@ class SummaryGenerator:
                     }
                 ]
             response = self.client.messages.create(**kwargs)
+
+            usage = getattr(response, "usage", None)
+            stop_reason = getattr(response, "stop_reason", None)
+            print(
+                f"[{label}] stop_reason={stop_reason} max_tokens={LLM_MAX_TOKENS} "
+                f"{_describe_usage(usage)}"
+            )
+            if stop_reason == "max_tokens":
+                raise LLMTruncatedError(
+                    f"LLM response truncated: stop_reason=max_tokens, "
+                    f"output_tokens={getattr(usage, 'output_tokens', 'unknown')}, "
+                    f"max_tokens={LLM_MAX_TOKENS}. Thinking tokens share this budget — "
+                    f"raise LLM_MAX_TOKENS or shorten the prompt."
+                )
+
             # Newer models may return thinking blocks before the text block,
             # so filter by type instead of assuming content[0] is text.
             return "".join(b.text for b in response.content if b.type == "text")
@@ -781,10 +867,27 @@ class SummaryGenerator:
             messages.append({"role": "user", "content": user_prompt})
             response = self.client.chat.completions.create(
                 model=self.model,
-                max_tokens=4000,
+                max_tokens=LLM_MAX_TOKENS,
                 messages=messages,
             )
-            return response.choices[0].message.content if response.choices else ""
+
+            choices = response.choices
+            usage = getattr(response, "usage", None)
+            # OpenAI-compatible servers signal budget exhaustion as "length".
+            finish_reason = getattr(choices[0], "finish_reason", None) if choices else None
+            print(
+                f"[{label}] finish_reason={finish_reason} max_tokens={LLM_MAX_TOKENS} "
+                f"{_describe_usage(usage)}"
+            )
+            if finish_reason == "length":
+                raise LLMTruncatedError(
+                    f"LLM response truncated: finish_reason=length, "
+                    f"completion_tokens={getattr(usage, 'completion_tokens', 'unknown')}, "
+                    f"max_tokens={LLM_MAX_TOKENS}. Reasoning tokens share this budget — "
+                    f"raise LLM_MAX_TOKENS or shorten the prompt."
+                )
+
+            return choices[0].message.content if choices else ""
 
     def _extract_json_object(self, text: str) -> dict | None:
         """Try to extract the first top-level JSON object from arbitrary text.
@@ -1060,7 +1163,9 @@ DINNER PLANS (next 7 days):
 {dinner_plans}{shopping_section}{stem_avoid_block}"""
 
         try:
-            response_text = self._call_llm(user_prompt, system_prompt=system_prompt)
+            response_text = self._call_llm(
+                user_prompt, system_prompt=system_prompt, label="summary"
+            )
             print(f"LLM response:\n{response_text}")
 
             # Try strict JSON first
@@ -1079,27 +1184,24 @@ DINNER PLANS (next 7 days):
             raise json.JSONDecodeError(
                 "Unable to parse JSON from Claude response", response_text or "", 0
             )
+        # Ordered before the JSONDecodeError handler on purpose: a truncated
+        # response is a budget problem, not a formatting one, and reporting it
+        # as the latter is what made this failure mode so hard to diagnose.
+        except LLMTruncatedError as e:
+            print(f"LLM truncation error: {e}")
+            print(
+                f"Response text: {response_text if 'response_text' in locals() else 'No response'}"
+            )
+            return _error_summary(f"Truncation Error: {e}")
         except json.JSONDecodeError as e:
             print(f"JSON decode error: {e}")
             print(
                 f"Response text: {response_text if 'response_text' in locals() else 'No response'}"
             )
-            # Return error structure matching expected schema
-            return {
-                "greeting": "⚠️ Unable to generate today's summary.",
-                "weather_summary": f"JSON Error: {e}",
-                "schedule": [],
-                "briefing": "The system will retry at the next scheduled interval.",
-            }
+            return _error_summary(f"JSON Error: {e}")
         except Exception as e:
             print(f"General error: {e}")
-            # Return error structure matching expected schema
-            return {
-                "greeting": "⚠️ Unable to generate today's summary.",
-                "weather_summary": f"Error: {e}",
-                "schedule": [],
-                "briefing": "The system will retry at the next scheduled interval.",
-            }
+            return _error_summary(f"Error: {e}")
 
     def evaluate_summary(self, summary_data: dict) -> dict:
         """Evaluate generated summary quality using LLM-as-judge.
@@ -1235,7 +1337,7 @@ FAMILY MEMBERS:
 {ctx["family_members"]}"""
 
         try:
-            response_text = self._call_llm(eval_user, system_prompt=eval_system)
+            response_text = self._call_llm(eval_user, system_prompt=eval_system, label="eval")
             print(f"Eval response:\n{response_text}")
 
             try:

--- a/tests/test_generate_llm.py
+++ b/tests/test_generate_llm.py
@@ -10,7 +10,9 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 from zoneinfo import ZoneInfo
 
-from rally.generator.generate import SummaryGenerator
+import pytest
+
+from rally.generator.generate import LLM_MAX_TOKENS, LLMTruncatedError, SummaryGenerator
 
 
 def make_generator(tz: str = "UTC") -> SummaryGenerator:
@@ -28,33 +30,43 @@ def make_generator(tz: str = "UTC") -> SummaryGenerator:
 class FakeAnthropic:
     """Stands in for anthropic.Anthropic — records the create() kwargs."""
 
-    def __init__(self, text, blocks=None):
+    def __init__(self, text, blocks=None, stop_reason="end_turn", usage=None):
         self._text = text
         self._blocks = blocks
+        self._stop_reason = stop_reason
+        self._usage = usage
         self.messages = self
         self.last_kwargs = None
 
     def create(self, **kwargs):
         self.last_kwargs = kwargs
         content = self._blocks or [SimpleNamespace(type="text", text=self._text)]
-        return SimpleNamespace(content=content)
+        return SimpleNamespace(content=content, stop_reason=self._stop_reason, usage=self._usage)
 
 
 class FakeOpenAI:
     """Stands in for openai.OpenAI — records the create() kwargs."""
 
-    def __init__(self, text, choices=None):
+    def __init__(self, text, choices=None, finish_reason="stop", usage=None):
         self._text = text
         self._choices = choices
+        self._finish_reason = finish_reason
+        self._usage = usage
         self.chat = SimpleNamespace(completions=self)
         self.last_kwargs = None
 
     def create(self, **kwargs):
         self.last_kwargs = kwargs
         if self._choices is not None:
-            return SimpleNamespace(choices=self._choices)
+            return SimpleNamespace(choices=self._choices, usage=self._usage)
         return SimpleNamespace(
-            choices=[SimpleNamespace(message=SimpleNamespace(content=self._text))]
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content=self._text),
+                    finish_reason=self._finish_reason,
+                )
+            ],
+            usage=self._usage,
         )
 
 
@@ -125,6 +137,120 @@ def test_call_llm_local_empty_choices_returns_empty_string():
     assert gen._call_llm("hi") == ""
 
 
+# --- truncation detection ------------------------------------------------------
+
+
+def test_call_llm_anthropic_raises_on_max_tokens_stop_reason():
+    gen = make_generator()
+    gen.provider = "anthropic"
+    gen.model = "claude-x"
+    gen.client = FakeAnthropic(
+        '{"greeting": "cut off mid-str',
+        stop_reason="max_tokens",
+        usage=SimpleNamespace(input_tokens=1200, output_tokens=LLM_MAX_TOKENS),
+    )
+
+    with pytest.raises(LLMTruncatedError) as excinfo:
+        gen._call_llm("hi")
+
+    message = str(excinfo.value)
+    assert "stop_reason=max_tokens" in message
+    assert f"output_tokens={LLM_MAX_TOKENS}" in message
+    assert f"max_tokens={LLM_MAX_TOKENS}" in message
+
+
+def test_call_llm_local_raises_on_length_finish_reason():
+    gen = make_generator()
+    gen.provider = "local"
+    gen.model = "llama"
+    gen.client = FakeOpenAI(
+        "partial",
+        finish_reason="length",
+        usage=SimpleNamespace(prompt_tokens=900, completion_tokens=LLM_MAX_TOKENS),
+    )
+
+    with pytest.raises(LLMTruncatedError) as excinfo:
+        gen._call_llm("hi")
+
+    assert "finish_reason=length" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("stop_reason", ["end_turn", "stop_sequence", "refusal", None])
+def test_call_llm_anthropic_other_stop_reasons_do_not_raise(stop_reason):
+    """Only budget exhaustion is a truncation; everything else parses as before."""
+    gen = make_generator()
+    gen.provider = "anthropic"
+    gen.model = "claude-x"
+    gen.client = FakeAnthropic("body", stop_reason=stop_reason)
+
+    assert gen._call_llm("hi") == "body"
+
+
+def test_call_llm_local_other_finish_reasons_do_not_raise():
+    gen = make_generator()
+    gen.provider = "local"
+    gen.model = "llama"
+    gen.client = FakeOpenAI("body", finish_reason="stop")
+
+    assert gen._call_llm("hi") == "body"
+
+
+def test_call_llm_logs_stop_reason_and_usage_on_success(capsys):
+    """Logged on success too — budget headroom must be visible before an outage."""
+    gen = make_generator()
+    gen.provider = "anthropic"
+    gen.model = "claude-x"
+    gen.client = FakeAnthropic(
+        "ok",
+        usage=SimpleNamespace(
+            input_tokens=1500,
+            output_tokens=820,
+            cache_read_input_tokens=1400,
+        ),
+    )
+
+    gen._call_llm("hi", label="summary")
+
+    out = capsys.readouterr().out
+    assert "[summary]" in out
+    assert "stop_reason=end_turn" in out
+    assert "input=1500" in out
+    assert "output=820" in out
+    assert "cache_read=1400" in out
+
+
+def test_call_llm_logs_reasoning_tokens_when_reported(capsys):
+    gen = make_generator()
+    gen.provider = "local"
+    gen.model = "llama"
+    gen.client = FakeOpenAI(
+        "ok",
+        usage=SimpleNamespace(
+            prompt_tokens=100,
+            completion_tokens=900,
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=700),
+        ),
+    )
+
+    gen._call_llm("hi", label="eval")
+
+    out = capsys.readouterr().out
+    assert "[eval]" in out
+    assert "reasoning=700" in out
+
+
+def test_call_llm_logs_when_provider_reports_no_usage(capsys):
+    """Stubs and older servers omit usage entirely — logging must still work."""
+    gen = make_generator()
+    gen.provider = "anthropic"
+    gen.model = "claude-x"
+    gen.client = FakeAnthropic("ok")
+
+    gen._call_llm("hi")
+
+    assert "usage=unavailable" in capsys.readouterr().out
+
+
 # --- generate_summary ----------------------------------------------------------
 
 FROZEN = datetime(2026, 3, 15, 9, 0, tzinfo=UTC)
@@ -176,6 +302,30 @@ def test_generate_summary_unparseable_returns_error_dict(frozen_now):
 
     assert "Unable to generate" in data["greeting"]
     assert data["schedule"] == []
+
+
+def test_generate_summary_truncation_is_not_reported_as_a_json_error(frozen_now, capsys):
+    """The regression this guards: a cut-off response used to surface as
+    'Unable to parse JSON ... line 1 column 1 (char 0)', pointing reviewers at
+    the JSON instead of at the token budget."""
+    frozen_now(FROZEN)
+    gen = _summary_gen('{"greeting": "Happy Monday! Let')
+    gen.client = FakeAnthropic(
+        '{"greeting": "Happy Monday! Let',
+        stop_reason="max_tokens",
+        usage=SimpleNamespace(input_tokens=2000, output_tokens=LLM_MAX_TOKENS),
+    )
+
+    data = gen.generate_summary()
+
+    assert "Unable to generate" in data["greeting"]
+    assert data["weather_summary"].startswith("Truncation Error:")
+    assert "stop_reason=max_tokens" in data["weather_summary"]
+    assert "JSON Error" not in data["weather_summary"]
+
+    out = capsys.readouterr().out
+    assert "LLM truncation error:" in out
+    assert "Unable to parse JSON" not in out
 
 
 def test_generate_summary_local_provider(frozen_now):


### PR DESCRIPTION
## Summary

A response cut off by the token cap is well-formed right up to the cut, so it fails JSON parsing exactly like malformed output would. `generate_summary` reported it as `Unable to parse JSON from Claude response: line 1 column 1 (char 0)` — a malformed-JSON message for what is really a budget problem, with a character position that is a hardcoded literal rather than a real parse offset. This makes `_call_llm` log the stop reason and token usage on every call and raise a distinct `LLMTruncatedError` when the model ran out of budget. Parsing, prompt assembly, and the existing fallback behavior are unchanged.

## Changes

**Backend** (`src/rally/generator/generate.py`)

- Added `LLM_MAX_TOKENS = 4000`, replacing the two hardcoded literals so the cap can be named in error text and changed in one place.
- Added `LLMTruncatedError`, deliberately **not** a `json.JSONDecodeError` subclass.
- Added `_describe_usage()`, which renders whichever token counters the provider reported. Anthropic and OpenAI disagree on names (`input_tokens` vs `prompt_tokens`) and reasoning tokens are nested on OpenAI-compatible servers only, so every field is optional and a response with no `usage` degrades to `usage=unavailable`.
- `_call_llm` takes a `label` and logs `stop_reason` / `finish_reason`, the cap, and usage on **every** call — success included, so budget headroom is visible before it becomes an outage. It raises `LLMTruncatedError` on `stop_reason == "max_tokens"` (Anthropic) or `finish_reason == "length"` (OpenAI-compatible), naming the actual output count and the cap. All other stop reasons behave exactly as before.
- `generate_summary` catches `LLMTruncatedError` **ahead of** the `JSONDecodeError` handler and surfaces `Truncation Error: …` in `weather_summary`.
- Extracted the three duplicated error-placeholder dicts into `_error_summary()`.
- `evaluate_summary` passes `label="eval"` so the two callers are distinguishable in logs.

**Tests** (`tests/test_generate_llm.py`)

- `FakeAnthropic` / `FakeOpenAI` now carry `stop_reason` / `finish_reason` and `usage`.
- Nine new tests: truncation raises on both providers; non-truncating stop reasons (`end_turn`, `stop_sequence`, `refusal`, `None`, `stop`) do not; label, usage, and reasoning-token logging; absent `usage`; and an end-to-end `generate_summary` case asserting the old `Unable to parse JSON` text no longer appears.

## Notes for reviewers

**This makes the failure legible; it does not fix it.** `LLM_MAX_TOKENS` is unchanged at 4000, so the 4 AM job will still fail when reasoning consumes the budget — just with an accurate message instead of a misleading one. Raising the cap is deliberately left out of scope.

The stubs previously had no `stop_reason` attribute at all. I defaulted them to `end_turn` / `stop`, so the pre-existing tests now exercise the non-truncating path explicitly; a dedicated test still covers the attribute-missing case via `usage`. Happy to default them to `None` instead if you'd rather the stubs stay minimal.

`evaluate_summary` needed no new handler — its existing `except Exception` already surfaces the descriptive message.

## Testing

- `.devenv/state/venv/bin/pytest` — **382 passed** (9 new).
- `ruff check .` — clean.
- `ruff format --check .` — clean (the formatter reflowed `tests/test_generate_llm.py`; that reflow is included).

No manual/live verification: exercising the real truncation path would mean a paid API call against the production key, and every test uses stubbed clients by design.

Closes #133
