### PR TITLE
Bring the shopping list in line with the rest of Rally

### DIFF
--- a/src/rally/main.py
+++ b/src/rally/main.py
@@ -91,6 +91,12 @@ def shopping_page(request: Request):
     return templates.TemplateResponse("shopping.html", {"request": request})
 
 
+@app.get("/shopping/purchased", response_class=HTMLResponse)
+def shopping_purchased_page(request: Request):
+    """Serve the read-only page of previously purchased shopping items."""
+    return templates.TemplateResponse("shopping_purchased.html", {"request": request})
+
+
 @app.get("/dinner-planner", response_class=HTMLResponse)
 def dinner_planner_page(request: Request):
     """Serve the meal planner page."""

--- a/src/rally/routers/shopping.py
+++ b/src/rally/routers/shopping.py
@@ -4,7 +4,8 @@ Three tables back this feature, and the split between them is deliberate:
 
 * ``shopping_items`` is the live list. Completed items stay visible until local
   midnight (identical to Tasks) and are deleted outright once they are more than
-  ``PURCHASED_RETENTION_DAYS`` old, so "Show purchased" never grows unbounded.
+  ``PURCHASED_RETENTION_DAYS`` old, so ``/shopping/purchased`` never grows
+  unbounded.
 * ``shopping_item_history`` is a permanent, deduplicated vocabulary with a use
   counter. It powers autocomplete and deliberately outlives the purge — which is
   precisely what makes deleting purchased rows safe.
@@ -14,7 +15,7 @@ Three tables back this feature, and the split between them is deliberate:
 from datetime import timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
-from sqlalchemy import case, func
+from sqlalchemy import case, func, nullslast, or_
 from sqlalchemy.orm import Session
 
 from rally.database import get_db
@@ -224,8 +225,12 @@ def list_items(
 ):
     """List shopping items, hiding items completed before today by default.
 
-    ``include_hidden=true`` is the "Show purchased" view, bounded by the
-    retention purge that runs (at most once per local day) from here.
+    ``include_hidden=true`` returns open and purchased items mixed in one list —
+    a "show me everything" escape hatch for scripted clients, with no caller in
+    the UI. The archive view is `GET /api/shopping/purchased`, which is the
+    exact complement of the default listing rather than a superset of it.
+
+    Bounded by the retention purge that runs (at most once per local day) here.
     """
     purge_old_purchased_items(db)
 
@@ -237,6 +242,42 @@ def list_items(
         )
 
     return query.order_by(ShoppingItem.completed.asc(), ShoppingItem.created_at.desc()).all()
+
+
+@router.get("/purchased", response_model=list[ShoppingItemResponse])
+def list_purchased_items(
+    search: str | None = Query(
+        None, description="Case-insensitive keyword matched against name and note."
+    ),
+    db: Session = Depends(get_db),
+):
+    """List items purchased before today (local time), most recent first.
+
+    An item purchased *today* stays on the shopping list and appears here only
+    once the local date rolls over — the same split `/api/todos/completed`
+    makes. Read-only: nothing here can be edited, restored or deleted.
+
+    No sort, limit or offset: ``PURCHASED_RETENTION_DAYS`` bounds the window, so
+    the whole archive fits in one response. Pagination is the right first
+    addition if that retention ever lengthens.
+    """
+    purge_old_purchased_items(db)
+
+    cutoff = today_start_utc(db)
+    query = db.query(ShoppingItem).filter(
+        ShoppingItem.completed == True,  # noqa: E712
+        # A purchased item with no completed_at is already hidden from the
+        # shopping list, so it belongs here rather than falling through the gap
+        # between the two views — the same guarantee `list_completed_todos`
+        # makes. The complement has to actually be the complement.
+        (ShoppingItem.completed_at < cutoff) | (ShoppingItem.completed_at.is_(None)),
+    )
+
+    if search and search.strip():
+        term = f"%{search.strip()}%"
+        query = query.filter(or_(ShoppingItem.name.ilike(term), ShoppingItem.note.ilike(term)))
+
+    return query.order_by(nullslast(ShoppingItem.completed_at.desc()), ShoppingItem.id.desc()).all()
 
 
 @router.post("/items", response_model=ShoppingItemResponse, status_code=201)

--- a/static/styles.css
+++ b/static/styles.css
@@ -690,9 +690,10 @@ footer a:hover {
     margin-top: 4px;
 }
 
-/* Toggle between the current tasks page and the completed tasks page.
-   Sits directly above the toolbar, in the same spot on both pages. */
-.todo-view-switch {
+/* Toggle between a page and its archive — current tasks and completed tasks,
+   the shopping list and purchased items. Sits directly above the toolbar, in
+   the same spot on both pages of a pair. */
+.view-switch {
     display: inline-block;
     font-family: var(--body-font);
     font-size: 0.9rem;
@@ -702,8 +703,19 @@ footer a:hover {
     margin-top: 4px;
 }
 
-.todo-view-switch:hover {
+.view-switch:hover {
     color: var(--charcoal);
+}
+
+/* A quiet, one-line explanation under a view-switch link — used where a page
+   would otherwise silently withhold something, e.g. the 30-day retention on
+   the purchased items archive. */
+.page-note {
+    font-family: var(--body-font);
+    font-size: 0.85rem;
+    color: var(--medium-gray);
+    font-style: italic;
+    margin-top: 8px;
 }
 
 .load-more-container {
@@ -942,55 +954,20 @@ footer a:hover {
 /**End Todo Page Styles**/
 
 /** Shopping List Styles **/
-/* Quick add: a persistent inline row, not a modal — a modal per item is too
-   much friction for the burst-entry flow a grocery list is built in. */
-.shopping-quick-add {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: stretch;
-    gap: 12px;
-    margin-bottom: 24px;
-}
-
-.shopping-quick-add .autocomplete-wrap {
+/* Anchor for the autocomplete dropdown, which is absolutely positioned against
+   it. Lives in the item modal, so it must not establish any clipping of its own. */
+.autocomplete-wrap {
     position: relative;
-    flex: 1 1 240px;
-    min-width: 0;
-}
-
-.shopping-quick-add input[type="text"] {
-    appearance: none;
-    box-sizing: border-box;
-    width: 100%;
-    min-height: 2.75rem;
-    padding: 10px;
-    border: 1px solid var(--charcoal);
-    background: var(--white);
-    color: var(--charcoal);
-    font-family: var(--body-font);
-    font-size: 1rem;
-}
-
-.shopping-quick-add select {
-    appearance: none;
-    box-sizing: border-box;
-    min-height: 2.75rem;
-    flex: 0 1 180px;
-    padding: 10px 32px 10px 10px;
-    border: 1px solid var(--charcoal);
-    background: var(--white);
-    color: var(--charcoal);
-    font-family: var(--body-font);
-    font-size: 1rem;
-    cursor: pointer;
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23333' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: right 12px center;
 }
 
 /* Autocomplete dropdown. A native <datalist> is nearly free but cannot render
    the two-part name/store row or the per-row dismiss affordance, and store
-   affinity is the main thing that makes this worth building. */
+   affinity is the main thing that makes this worth building.
+
+   The height cap is load-bearing: .modal-body is a scroll box, so the menu is
+   clipped by it rather than spilling down the page. 240px leaves the menu room
+   to open fully inside the modal body, and highlightSuggestion()'s
+   scrollIntoView({ block: 'nearest' }) handles keyboard nav within it. */
 .autocomplete-menu {
     position: absolute;
     top: 100%;
@@ -998,7 +975,7 @@ footer a:hover {
     right: 0;
     z-index: 20;
     margin-top: -1px;
-    max-height: 280px;
+    max-height: 240px;
     overflow-y: auto;
     border: 1px solid var(--charcoal);
     background: var(--white);
@@ -1099,23 +1076,13 @@ footer a:hover {
     margin-top: 4px;
 }
 
-/* Inline "Show purchased" toggle. Unlike Tasks there is no separate archive
-   page: the 30-day purge keeps the set small enough to need no sorting,
-   searching or pagination, which is exactly what /todo/completed exists for. */
-.shopping-toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 0.9rem;
+/* Stands in for the chip row on a fresh database, so store management
+   introduces itself from the toolbar it already lives in. */
+.filter-hint {
+    font-family: var(--body-font);
+    font-size: 0.85rem;
     color: var(--medium-gray);
-    cursor: pointer;
-    white-space: nowrap;
-}
-
-.shopping-toggle input[type="checkbox"] {
-    width: 16px;
-    height: 16px;
-    cursor: pointer;
+    font-style: italic;
 }
 
 .store-manage-row {

--- a/templates/shopping.html
+++ b/templates/shopping.html
@@ -33,34 +33,18 @@
         <div class="header-container">
             <h2>Shopping List</h2>
             <div class="header-actions">
-                <button class="btn-add" id="btn-manage-stores">Manage Stores</button>
+                <button class="btn-add" id="btn-add-item">Add Item</button>
             </div>
         </div>
 
-        <!-- Quick add: type, Enter, keep typing. Grocery lists are built in bursts. -->
-        <form class="shopping-quick-add" id="quick-add-form" autocomplete="off">
-            <div class="autocomplete-wrap">
-                <input type="text" id="quick-add-name" placeholder="Add an item…" aria-label="Item name"
-                       role="combobox" aria-expanded="false" aria-autocomplete="list" aria-controls="suggestion-menu" required>
-                <div class="autocomplete-menu" id="suggestion-menu" role="listbox"></div>
-            </div>
-            <select id="quick-add-store" aria-label="Store">
-                <option value="">Anywhere</option>
-            </select>
-            <button type="submit" class="btn-add">Add</button>
-        </form>
+        <a class="view-switch" href="/shopping/purchased">View purchased items</a>
 
         <div class="filter-toolbar">
             <div class="toolbar-group">
                 <label>Store</label>
                 <div class="filter-chips" id="filter-store-chips"></div>
                 <button type="button" class="filter-clear" id="filter-clear">Clear Filters</button>
-            </div>
-            <div class="toolbar-group">
-                <label class="shopping-toggle">
-                    <input type="checkbox" id="show-purchased">
-                    <span>Show purchased</span>
-                </label>
+                <button type="button" class="filter-clear" id="btn-manage-stores">Manage stores</button>
             </div>
         </div>
 
@@ -69,16 +53,23 @@
         </div>
     </div>
 
-    <!-- Modal for editing an item -->
+    <!-- Modal for adding and editing an item — one modal, two modes, exactly as
+         todo.html does it. The Item field stays first so the autocomplete menu
+         has the whole form beneath it to drop over. -->
     <div class="modal-overlay" id="item-modal-overlay">
         <div class="modal-content">
-            <h3>Edit Item</h3>
+            <h3 id="item-modal-title">Add Item</h3>
             <div class="modal-scroll">
             <div class="modal-body">
-                <form id="item-form">
+                <form id="item-form" autocomplete="off">
                     <div class="form-group">
                         <label>Item</label>
-                        <input type="text" id="item-name" placeholder="Item name" required>
+                        <div class="autocomplete-wrap">
+                            <input type="text" id="item-name" placeholder="Item name"
+                                   role="combobox" aria-expanded="false" aria-autocomplete="list"
+                                   aria-controls="suggestion-menu" required>
+                            <div class="autocomplete-menu" id="suggestion-menu" role="listbox"></div>
+                        </div>
                     </div>
                     <div class="form-group">
                         <label>Note (optional)</label>
@@ -94,7 +85,7 @@
                 <div class="modal-actions">
                     <button type="submit" form="item-form" class="btn-primary">Save</button>
                     <button type="button" class="btn-cancel" id="btn-cancel-item">Cancel</button>
-                    <button type="button" class="btn-delete modal-delete" id="btn-delete-item">Delete</button>
+                    <button type="button" class="btn-delete modal-delete" id="btn-delete-item" style="display:none">Delete</button>
                 </div>
             </div>
             </div>
@@ -133,9 +124,10 @@
         const ANYWHERE = 'anywhere';
         const REFRESH_MS = 60000;   // multi-device sync + the local-midnight rollover
 
-        const nameInput = document.getElementById('quick-add-name');
-        const storeSelect = document.getElementById('quick-add-store');
+        const nameInput = document.getElementById('item-name');
+        const storeSelect = document.getElementById('item-store');
         const suggestionMenu = document.getElementById('suggestion-menu');
+        const modalBody = document.querySelector('#item-modal-overlay .modal-body');
 
         function escapeHtml(text) {
             const div = document.createElement('div');
@@ -160,12 +152,10 @@
             const response = await fetch('/api/shopping/stores');
             stores = await response.json();
             renderStoreOptions();
-            renderStoreChips();
         }
 
         async function fetchItems() {
-            const includeHidden = document.getElementById('show-purchased').checked;
-            const response = await fetch(`/api/shopping/items?include_hidden=${includeHidden}`);
+            const response = await fetch('/api/shopping/items');
             items = await response.json();
             renderItems();
         }
@@ -196,54 +186,58 @@
         }
 
         // ── Store select + filter chips ──
+        //
+        // The select lists every store — chips describe what is on the list, the
+        // select describes where an item can go, and filing the first item at a
+        // store you just created has to work.
         function renderStoreOptions() {
-            [storeSelect, document.getElementById('item-store')].forEach(select => {
-                const previous = select.value;
-                select.innerHTML = '<option value="">Anywhere</option>' + stores.map(s =>
-                    `<option value="${s.id}">${escapeHtml(s.name)}</option>`
-                ).join('');
-                // Keep a selection alive across a store list refresh.
-                if (previous && select.querySelector(`option[value="${previous}"]`)) {
-                    select.value = previous;
-                }
-            });
+            const previous = storeSelect.value;
+            storeSelect.innerHTML = '<option value="">Anywhere</option>' + stores.map(s =>
+                `<option value="${s.id}">${escapeHtml(s.name)}</option>`
+            ).join('');
+            // Keep a selection alive across a store list refresh.
+            if (previous && storeSelect.querySelector(`option[value="${previous}"]`)) {
+                storeSelect.value = previous;
+            }
         }
 
+        // Chips describe the list, not the store table: a store earns a chip when
+        // it has an item on screen, or when it is currently selected. The second
+        // clause is load-bearing — tick off the last Costco item while filtered
+        // to Costco and without it the chip vanishes with the filter still on.
         function renderStoreChips() {
             const chips = document.getElementById('filter-store-chips');
-            const parts = [`<button type="button" class="filter-chip" data-value="all">All</button>`];
+            const present = new Set(items.map(chipValueForItem));
+            const parts = [];
             stores.forEach(s => {
-                parts.push(`<button type="button" class="filter-chip" data-value="${s.id}">${escapeHtml(s.name)}</button>`);
+                const value = String(s.id);
+                if (present.has(value) || selectedStores.has(value)) {
+                    parts.push(`<button type="button" class="filter-chip" data-value="${value}">${escapeHtml(s.name)}</button>`);
+                }
             });
-            parts.push(`<button type="button" class="filter-chip" data-value="${ANYWHERE}">Anywhere</button>`);
+            if (present.has(ANYWHERE) || selectedStores.has(ANYWHERE)) {
+                parts.push(`<button type="button" class="filter-chip" data-value="${ANYWHERE}">Anywhere</button>`);
+            }
+
+            // First-run discovery, without a pop-in or a second overlay: the
+            // "Manage stores" button is already sitting right beside this hint.
+            if (stores.length === 0 && selectedStores.size === 0) {
+                chips.innerHTML = '<span class="filter-hint">No stores yet — everything lands under "Anywhere".</span>';
+                return;
+            }
+
             chips.innerHTML = parts.join('');
             syncChipState();
         }
 
         function syncChipState() {
             document.querySelectorAll('#filter-store-chips .filter-chip').forEach(chip => {
-                const isAll = chip.dataset.value === 'all';
-                const active = isAll ? selectedStores.size === 0 : selectedStores.has(chip.dataset.value);
-                chip.classList.toggle('active', active);
+                chip.classList.toggle('active', selectedStores.has(chip.dataset.value));
             });
-        }
-
-        // The quick-add store defaults to the filtered store when exactly one is
-        // filtered — but never overrides a choice the user made themselves.
-        function syncQuickAddStoreDefault() {
-            if (storeSelect.dataset.touched === 'true') return;
-            const only = selectedStores.size === 1 ? [...selectedStores][0] : null;
-            if (only && only !== ANYWHERE && storeSelect.querySelector(`option[value="${only}"]`)) {
-                storeSelect.value = only;
-            } else {
-                storeSelect.value = '';
-            }
         }
 
         function clearFilters() {
             selectedStores.clear();
-            syncChipState();
-            syncQuickAddStoreDefault();
             renderItems();
         }
 
@@ -264,6 +258,9 @@
 
         function renderItems() {
             const container = document.getElementById('groups-container');
+            // The chip set derives from the items, so it is rebuilt here — the
+            // one function on every path that can change what is on the list.
+            renderStoreChips();
             const visible = visibleItems();
 
             const groups = new Map();
@@ -290,7 +287,7 @@
             // always contributes its own (possibly empty) group above.
             if (keys.length === 0) {
                 container.innerHTML =
-                    '<div class="container-empty-state">Nothing on the list yet. Type an item above to get started.</div>';
+                    '<div class="container-empty-state">Nothing on the list yet. Click "Add Item" to get started.</div>';
                 return;
             }
 
@@ -405,6 +402,10 @@
                 closeSuggestions();
                 return;
             }
+            // .modal-body is a scroll box, so the menu cannot spill outside it the
+            // way it spilled down the page. Scrolling the name field near the top
+            // gives the (height-capped) menu room to open below it.
+            modalBody.scrollTop = 0;
             suggestionMenu.innerHTML = suggestions.map((s, index) => {
                 const store = s.store_id ? storeName(s.store_id) : null;
                 return `
@@ -459,7 +460,13 @@
             }
         }
 
-        nameInput.addEventListener('input', scheduleSuggestions);
+        // Autocomplete is wired only in add mode: editing an existing item is a
+        // correction, not a lookup, and a dropdown covering the fields you are
+        // trying to fix is noise.
+        nameInput.addEventListener('input', () => {
+            if (editingItemId) return;
+            scheduleSuggestions();
+        });
 
         nameInput.addEventListener('keydown', (e) => {
             const open = suggestionMenu.classList.contains('open');
@@ -500,34 +507,6 @@
             if (option) acceptSuggestion(parseInt(option.dataset.index, 10));
         });
 
-        // ── Quick add ──
-        storeSelect.addEventListener('change', () => {
-            storeSelect.dataset.touched = 'true';
-        });
-
-        document.getElementById('quick-add-form').addEventListener('submit', async (e) => {
-            e.preventDefault();
-            const name = nameInput.value.trim();
-            if (!name) return;
-
-            const storeValue = storeSelect.value;
-            closeSuggestions();
-            try {
-                await createItem({
-                    name,
-                    store_id: storeValue ? parseInt(storeValue, 10) : null
-                });
-                nameInput.value = '';
-                storeSelect.dataset.touched = 'false';
-                syncQuickAddStoreDefault();
-                nameInput.focus();   // straight back into the burst
-                await fetchItems();
-            } catch (error) {
-                console.error('Error adding item:', error);
-                alert('Failed to add item');
-            }
-        });
-
         // ── Item actions ──
         async function toggleComplete(id, completed) {
             try {
@@ -540,31 +519,55 @@
             }
         }
 
+        // Store reads "Anywhere" on every open, whatever the chips say — matching
+        // openAddModal() on /todo, which resets the assignee and ignores the
+        // active filter. Preselecting the filtered store was genuinely useful;
+        // operating exactly like Tasks is worth more.
+        function openAddModal() {
+            editingItemId = null;
+            document.getElementById('item-modal-title').textContent = 'Add Item';
+            document.getElementById('item-form').reset();
+            storeSelect.value = '';
+            document.getElementById('btn-delete-item').style.display = 'none';
+            closeSuggestions();
+            showModalOverlay('item-modal-overlay');
+            nameInput.focus();
+        }
+
         function openEditModal(id) {
             const item = items.find(i => i.id === id);
             if (!item) return;
             editingItemId = id;
-            document.getElementById('item-name').value = item.name;
+            document.getElementById('item-modal-title').textContent = 'Edit Item';
+            nameInput.value = item.name;
             document.getElementById('item-note').value = item.note || '';
-            document.getElementById('item-store').value = item.store_id ? String(item.store_id) : '';
+            storeSelect.value = item.store_id ? String(item.store_id) : '';
+            document.getElementById('btn-delete-item').style.display = '';
+            closeSuggestions();
             showModalOverlay('item-modal-overlay');
         }
 
         function closeItemModal() {
             document.getElementById('item-modal-overlay').style.display = 'none';
+            closeSuggestions();
             editingItemId = null;
         }
 
+        // Save closes the modal in both modes. Adding a second item means opening
+        // it again — the same trade every other add button in Rally makes.
         document.getElementById('item-form').addEventListener('submit', async (e) => {
             e.preventDefault();
-            if (!editingItemId) return;
-            const storeValue = document.getElementById('item-store').value;
+            const name = nameInput.value.trim();
+            if (!name) return;
+            const storeValue = storeSelect.value;
+            const storeId = storeValue ? parseInt(storeValue, 10) : null;
+            const note = document.getElementById('item-note').value || null;
             try {
-                await updateItem(editingItemId, {
-                    name: document.getElementById('item-name').value,
-                    note: document.getElementById('item-note').value || null,
-                    store_id: storeValue ? parseInt(storeValue, 10) : null
-                });
+                if (editingItemId) {
+                    await updateItem(editingItemId, { name, note, store_id: storeId });
+                } else {
+                    await createItem({ name, note, store_id: storeId });
+                }
                 closeItemModal();
                 await fetchItems();
             } catch (error) {
@@ -572,6 +575,8 @@
                 alert('Failed to save item');
             }
         });
+
+        document.getElementById('btn-add-item').addEventListener('click', openAddModal);
 
         document.getElementById('btn-delete-item').addEventListener('click', async () => {
             if (!editingItemId) return;
@@ -680,20 +685,15 @@
             const chip = e.target.closest('.filter-chip');
             if (!chip) return;
             const value = chip.dataset.value;
-            if (value === 'all') {
-                selectedStores.clear();
-            } else if (selectedStores.has(value)) {
+            if (selectedStores.has(value)) {
                 selectedStores.delete(value);
             } else {
                 selectedStores.add(value);
             }
-            syncChipState();
-            syncQuickAddStoreDefault();
             renderItems();
         });
 
         document.getElementById('filter-clear').addEventListener('click', clearFilters);
-        document.getElementById('show-purchased').addEventListener('change', fetchItems);
 
         // Show a modal and compute its fade state once it's laid out.
         function showModalOverlay(overlayId) {

--- a/templates/shopping_purchased.html
+++ b/templates/shopping_purchased.html
@@ -1,0 +1,323 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Rally - Purchased Items</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📰</text></svg>">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="/static/styles.css?v={{ css_version }}" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <h1>Rally</h1>
+        <div class="subtitle">Shopping List</div>
+    </header>
+
+    <nav>
+        <a href="/dashboard">Dashboard</a>
+        <a href="/todo">Tasks</a>
+        <a href="/shopping" class="active">Shopping</a>
+        <div class="nav-dropdown" id="meal-dropdown">
+            <button class="nav-dropdown-btn" onclick="toggleMealDropdown(event)">Meal Planner</button>
+            <div class="nav-dropdown-content">
+                <a href="/dinner-planner">Current &amp; Upcoming</a>
+                <a href="/meal-history">Previous Meals</a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="section-container">
+        <div class="header-container">
+            <h2>Shopping List</h2>
+        </div>
+
+        <a class="view-switch" href="/shopping">Back to shopping list</a>
+
+        <!-- Required, not decorative: without it the page silently loses history
+             and reads as broken next to the tasks archive, which keeps everything. -->
+        <div class="page-note">Purchased items are kept for 30 days.</div>
+
+        <div class="filter-toolbar">
+            <div class="toolbar-group">
+                <label>Store</label>
+                <div class="filter-chips" id="filter-store-chips"></div>
+                <button type="button" class="filter-clear" id="filter-clear">Clear Filters</button>
+            </div>
+            <div class="toolbar-group toolbar-search">
+                <label for="search-input">Search</label>
+                <input type="text" id="search-input" class="search-input"
+                       placeholder="Search purchased items" autocomplete="off">
+                <button type="button" class="search-btn" id="search-btn" disabled>Search</button>
+                <button type="button" class="filter-clear" id="search-clear">Clear Search</button>
+            </div>
+            <div class="search-results-count" id="search-results-count" hidden></div>
+        </div>
+
+        <div id="groups-container">
+            <div class="container-loading-state">Loading purchased items…</div>
+        </div>
+    </div>
+
+    <script>
+        // ── State ──
+        let items = [];
+        let stores = [];
+        let selectedStores = new Set();   // chip values: store ids as strings, or 'anywhere'
+
+        const ANYWHERE = 'anywhere';
+
+        // The currently submitted search term ('' when no search is active).
+        // Search runs only on submit (button click or Enter), never on keystroke.
+        let searchTerm = '';
+        // Guards against a slow earlier request overwriting a newer one's results.
+        let requestToken = 0;
+
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        function storeName(storeId) {
+            const store = stores.find(s => s.id === storeId);
+            return store ? store.name : null;
+        }
+
+        // ── API ──
+        async function fetchStores() {
+            const response = await fetch('/api/shopping/stores');
+            stores = await response.json();
+        }
+
+        // Search filters server-side — it is the one control that would need
+        // pagination if retention ever grew, so it lives in the query string
+        // from the start. Store chips filter client-side; see renderItems().
+        async function fetchItems() {
+            const token = ++requestToken;
+            const params = new URLSearchParams();
+            if (searchTerm) params.set('search', searchTerm);
+            const query = params.toString();
+            try {
+                const response = await fetch(`/api/shopping/purchased${query ? '?' + query : ''}`);
+                if (!response.ok) throw new Error('Failed to load purchased items');
+                const data = await response.json();
+                if (token !== requestToken) return;   // superseded by a newer request
+                items = data;
+                renderItems();
+            } catch (error) {
+                if (token !== requestToken) return;
+                console.error('Error loading purchased items:', error);
+                document.getElementById('groups-container').innerHTML =
+                    '<div class="container-empty-state">Could not load purchased items. Please try again.</div>';
+            }
+        }
+
+        // ── Filter chips ──
+        //
+        // Chips describe what is on the page, not what stores exist. A store
+        // that is currently selected keeps its chip even with nothing under it,
+        // or filtering to it would leave a filter with no visible way to undo it.
+        function renderStoreChips() {
+            const present = new Set(items.map(chipValueForItem));
+            const parts = [];
+            stores.forEach(s => {
+                const value = String(s.id);
+                if (present.has(value) || selectedStores.has(value)) {
+                    parts.push(`<button type="button" class="filter-chip" data-value="${value}">${escapeHtml(s.name)}</button>`);
+                }
+            });
+            if (present.has(ANYWHERE) || selectedStores.has(ANYWHERE)) {
+                parts.push(`<button type="button" class="filter-chip" data-value="${ANYWHERE}">Anywhere</button>`);
+            }
+            document.getElementById('filter-store-chips').innerHTML = parts.join('');
+            syncChipState();
+        }
+
+        function syncChipState() {
+            document.querySelectorAll('#filter-store-chips .filter-chip').forEach(chip => {
+                chip.classList.toggle('active', selectedStores.has(chip.dataset.value));
+            });
+        }
+
+        function clearFilters() {
+            selectedStores.clear();
+            renderItems();
+        }
+
+        // ── Rendering ──
+        function chipValueForItem(item) {
+            return item.store_id ? String(item.store_id) : ANYWHERE;
+        }
+
+        function visibleItems() {
+            if (selectedStores.size === 0) return items;
+            return items.filter(item => selectedStores.has(chipValueForItem(item)));
+        }
+
+        function groupLabel(value) {
+            if (value === ANYWHERE) return 'Anywhere';
+            return storeName(parseInt(value, 10)) || 'Anywhere';
+        }
+
+        function updateSearchCount(total) {
+            const el = document.getElementById('search-results-count');
+            if (!searchTerm) {
+                el.hidden = true;
+                return;
+            }
+            el.hidden = false;
+            el.textContent = total === 1 ? '1 matching item.' : `${total} matching items.`;
+        }
+
+        function renderItems() {
+            const container = document.getElementById('groups-container');
+            renderStoreChips();
+            updateSearchCount(items.length);
+
+            const visible = visibleItems();
+
+            const groups = new Map();
+            visible.forEach(item => {
+                const key = chipValueForItem(item);
+                if (!groups.has(key)) groups.set(key, []);
+                groups.get(key).push(item);
+            });
+
+            // An explicitly filtered store renders even when empty, so filtering
+            // to it reads as "nothing here" rather than as a vanished group.
+            selectedStores.forEach(value => {
+                if (!groups.has(value)) groups.set(value, []);
+            });
+
+            // Named stores alphabetically, the catch-all last — the same order
+            // as the shopping list you just came from.
+            const keys = [...groups.keys()].sort((a, b) => {
+                if (a === ANYWHERE) return 1;
+                if (b === ANYWHERE) return -1;
+                return groupLabel(a).localeCompare(groupLabel(b));
+            });
+
+            if (keys.length === 0) {
+                const message = searchTerm
+                    ? `No purchased items match "${escapeHtml(searchTerm)}".`
+                    : 'Nothing purchased yet.';
+                container.innerHTML = `<div class="container-empty-state">${message}</div>`;
+                return;
+            }
+
+            container.innerHTML = keys.map(key => {
+                const groupItems = groups.get(key);
+                const countLabel = `${groupItems.length} item${groupItems.length === 1 ? '' : 's'}`;
+                const rows = groupItems.length === 0
+                    ? '<div class="container-empty-state">Nothing here right now.</div>'
+                    : `<div class="list-container">${groupItems.map(renderItemRow).join('')}</div>`;
+                return `
+                    <div class="shopping-group-header">
+                        <span class="shopping-group-name">${escapeHtml(groupLabel(key))}</span>
+                        <span class="shopping-group-rule"></span>
+                        <span class="shopping-group-count">${countLabel}</span>
+                    </div>
+                    ${rows}
+                `;
+            }).join('');
+        }
+
+        // Read-only: no checkbox, no Edit, no delete. Re-buying something is
+        // "Add Item" on the list, where autocomplete already knows every item
+        // the family has ever bought.
+        function renderItemRow(item) {
+            return `
+                <div class="editable-item" data-id="${item.id}">
+                    <div class="editable-item-content">
+                        <div class="editable-item-title">${escapeHtml(item.name)}</div>
+                        ${item.note ? `<div class="editable-item-description">${escapeHtml(item.note)}</div>` : ''}
+                        ${formatPurchasedDate(item.completed_at)}
+                    </div>
+                </div>
+            `;
+        }
+
+        // A weekday and date, not "3d ago": relative time is right for something
+        // you ticked off an hour ago, absolute is right for an archive.
+        function formatPurchasedDate(value) {
+            if (!value) return '';
+            const date = new Date(value.endsWith('Z') || value.includes('+') ? value : value + 'Z');
+            if (isNaN(date)) return '';
+            return `<div class="shopping-completed-at">Purchased ${formatDayMonth(date)}</div>`;
+        }
+
+        function formatDayMonth(date) {
+            const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+            const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+            return `${dayNames[date.getDay()]}, ${monthNames[date.getMonth()]} ${date.getDate()}`;
+        }
+
+        // ── Search ──
+        function updateSearchButton() {
+            const hasText = document.getElementById('search-input').value.trim().length > 0;
+            document.getElementById('search-btn').disabled = !hasText;
+        }
+
+        function submitSearch() {
+            const value = document.getElementById('search-input').value.trim();
+            if (!value) return;
+            searchTerm = value;
+            // Chips describe what is on screen, so a search legitimately narrows
+            // the chip set. Clearing the selection keeps the two consistent.
+            selectedStores.clear();
+            fetchItems();
+        }
+
+        function clearSearch() {
+            searchTerm = '';
+            document.getElementById('search-input').value = '';
+            updateSearchButton();
+            selectedStores.clear();
+            fetchItems();
+        }
+
+        // ── Event handlers ──
+        document.getElementById('filter-store-chips').addEventListener('click', (e) => {
+            const chip = e.target.closest('.filter-chip');
+            if (!chip) return;
+            const value = chip.dataset.value;
+            if (selectedStores.has(value)) {
+                selectedStores.delete(value);
+            } else {
+                selectedStores.add(value);
+            }
+            renderItems();
+        });
+
+        document.getElementById('filter-clear').addEventListener('click', clearFilters);
+        document.getElementById('search-btn').addEventListener('click', submitSearch);
+        document.getElementById('search-clear').addEventListener('click', clearSearch);
+        document.getElementById('search-input').addEventListener('input', updateSearchButton);
+        document.getElementById('search-input').addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                submitSearch();
+            }
+        });
+
+        // ── Initialize ──
+        fetchStores().then(fetchItems);
+
+        // Nav dropdown toggle (for touch devices)
+        function toggleMealDropdown(e) {
+            e.stopPropagation();
+            document.getElementById('meal-dropdown').classList.toggle('open');
+        }
+        document.addEventListener('click', function() {
+            document.getElementById('meal-dropdown').classList.remove('open');
+        });
+    </script>
+
+    <footer>
+        <a href="/settings">Settings</a>
+    </footer>
+</body>
+</html>

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -37,7 +37,7 @@
             </div>
         </div>
 
-        <a class="todo-view-switch" href="/todo/completed">View completed tasks</a>
+        <a class="view-switch" href="/todo/completed">View completed tasks</a>
 
         <div class="filter-toolbar">
             <div class="toolbar-group">

--- a/templates/todo_completed.html
+++ b/templates/todo_completed.html
@@ -34,7 +34,7 @@
             <h2>Tasks</h2>
         </div>
 
-        <a class="todo-view-switch" href="/todo">Back to current tasks</a>
+        <a class="view-switch" href="/todo">Back to current tasks</a>
 
         <div class="filter-toolbar">
             <div class="toolbar-group">

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -5,7 +5,15 @@ import pytest
 
 @pytest.mark.parametrize(
     "path",
-    ["/todo", "/todo/completed", "/shopping", "/dinner-planner", "/meal-history", "/settings"],
+    [
+        "/todo",
+        "/todo/completed",
+        "/shopping",
+        "/shopping/purchased",
+        "/dinner-planner",
+        "/meal-history",
+        "/settings",
+    ],
 )
 def test_page_renders_html(client, path):
     resp = client.get(path)
@@ -20,6 +28,7 @@ def test_page_renders_html(client, path):
         "/todo",
         "/todo/completed",
         "/shopping",
+        "/shopping/purchased",
         "/dinner-planner",
         "/meal-history",
         "/settings",

--- a/tests/test_shopping.py
+++ b/tests/test_shopping.py
@@ -450,3 +450,102 @@ def test_deleting_a_suggestion_leaves_shopping_items_alone(
 
 def test_deleting_a_missing_suggestion_is_404(client):
     assert client.delete("/api/shopping/suggestions/999").status_code == 404
+
+
+# --- Purchased archive ---------------------------------------------------------
+#
+# The exact complement of the default `/api/shopping/items` listing: what that
+# endpoint hides, this one shows, with nothing falling through the gap.
+
+
+def test_purchased_lists_items_bought_before_today(
+    client, make_shopping_item, frozen_now, local_timezone
+):
+    local_timezone("America/Chicago")
+    frozen_now(NOON)
+    make_shopping_item("Coffee beans", completed=True, completed_at=BEFORE_LOCAL_MIDNIGHT)
+
+    assert item_names(client.get("/api/shopping/purchased").json()) == ["Coffee beans"]
+
+
+def test_purchased_excludes_items_bought_today(
+    client, make_shopping_item, frozen_now, local_timezone
+):
+    """Bought today, so it is still on the shopping list — not yet in the archive."""
+    local_timezone("America/Chicago")
+    frozen_now(NOON)
+    make_shopping_item("Coffee beans", completed=True, completed_at=AFTER_LOCAL_MIDNIGHT)
+
+    assert client.get("/api/shopping/purchased").json() == []
+
+
+def test_purchased_includes_completed_rows_with_no_timestamp(
+    client, make_shopping_item, frozen_now, local_timezone
+):
+    """The complement guarantee: `/items` hides these, so `/purchased` must show
+    them or they are invisible in the entire application."""
+    local_timezone("America/Chicago")
+    frozen_now(NOON)
+    make_shopping_item("Ancient milk", completed=True, completed_at=None)
+
+    assert client.get("/api/shopping/items").json() == []
+    assert item_names(client.get("/api/shopping/purchased").json()) == ["Ancient milk"]
+
+
+def test_purchased_excludes_open_items(client, make_shopping_item, frozen_now, local_timezone):
+    local_timezone("America/Chicago")
+    frozen_now(NOON)
+    make_shopping_item("Milk")
+    make_shopping_item("Eggs", completed=True, completed_at=BEFORE_LOCAL_MIDNIGHT)
+
+    assert item_names(client.get("/api/shopping/purchased").json()) == ["Eggs"]
+
+
+def test_purchased_orders_most_recent_first(client, make_shopping_item, frozen_now, local_timezone):
+    local_timezone("America/Chicago")
+    frozen_now(NOON)
+    make_shopping_item(
+        "Older", completed=True, completed_at=BEFORE_LOCAL_MIDNIGHT - timedelta(days=2)
+    )
+    make_shopping_item("Newer", completed=True, completed_at=BEFORE_LOCAL_MIDNIGHT)
+
+    assert item_names(client.get("/api/shopping/purchased").json()) == ["Newer", "Older"]
+
+
+def test_purchased_search_matches_name_and_note(
+    client, make_shopping_item, frozen_now, local_timezone
+):
+    local_timezone("America/Chicago")
+    frozen_now(NOON)
+    make_shopping_item("Eggs", completed=True, completed_at=BEFORE_LOCAL_MIDNIGHT)
+    make_shopping_item(
+        "Bread", note="the good EGGY loaf", completed=True, completed_at=BEFORE_LOCAL_MIDNIGHT
+    )
+    make_shopping_item("Milk", completed=True, completed_at=BEFORE_LOCAL_MIDNIGHT)
+
+    matches = client.get("/api/shopping/purchased", params={"search": "egg"}).json()
+    assert sorted(item_names(matches)) == ["Bread", "Eggs"]
+
+
+def test_purchased_search_with_no_match_is_empty(
+    client, make_shopping_item, frozen_now, local_timezone
+):
+    local_timezone("America/Chicago")
+    frozen_now(NOON)
+    make_shopping_item("Eggs", completed=True, completed_at=BEFORE_LOCAL_MIDNIGHT)
+
+    assert client.get("/api/shopping/purchased", params={"search": "zzz"}).json() == []
+
+
+def test_purchased_is_independent_of_include_hidden(
+    client, make_shopping_item, frozen_now, local_timezone
+):
+    """The two endpoints answer different questions; neither changes the other."""
+    local_timezone("America/Chicago")
+    frozen_now(NOON)
+    make_shopping_item("Milk")
+    make_shopping_item("Eggs", completed=True, completed_at=BEFORE_LOCAL_MIDNIGHT)
+
+    client.get("/api/shopping/items", params={"include_hidden": "true"})
+    assert item_names(client.get("/api/shopping/purchased").json()) == ["Eggs"]
+    assert item_names(client.get("/api/shopping/items").json()) == ["Milk"]


### PR DESCRIPTION
## Summary

Five things on the shopping page fought the muscle memory the rest of Rally builds. The header button — the one place your hand already goes — managed stores instead of adding an item; adding happened in an inline row rather than a modal; every store got a filter chip whether or not it had anything on the list; the chip row led with an `All` that was redundant with `Clear Filters` and confusing next to `Anywhere`; and `Show purchased` was a checkbox that changed what the list meant underneath you. This brings all five in line with `/todo`, which already answers each of these questions.

Existing API behavior is unchanged: no schema, model or migration changes, and every test in `tests/test_shopping.py` passes **unmodified** — the new tests are added alongside them. `include_hidden` on `GET /api/shopping/items` is kept and loses its only UI caller, exactly as `include_hidden` on `GET /api/todos` already sits today.

## Changes

**Backend**
- New `GET /api/shopping/purchased` in `src/rally/routers/shopping.py` — the exact complement of the default items listing, most-recent-first, with optional `search` across name and note. Runs `purge_old_purchased_items()` first, and includes completed rows whose `completed_at` is `NULL` so nothing falls through the gap between the two views.
- New `/shopping/purchased` page route in `src/rally/main.py`.
- No sort, limit or offset: `PURCHASED_RETENTION_DAYS = 30` is what bounds the response.

**Frontend**
- `templates/shopping_purchased.html` — new read-only archive page. Grouped by store, store chips and search only, `Purchased Thursday, Aug 6` lines, and the required 30-day retention note.
- `templates/shopping.html` — `Add Item` header button; `.shopping-quick-add` removed entirely and its two controls folded into the item modal; `#item-modal-overlay` made dual-mode following `todo.html` (`#item-modal-title`, hidden `Delete`, submit branching on `editingItemId`); autocomplete moved into the modal and wired in add mode only; `Manage stores` moved into the Store toolbar group as a `.filter-clear`; chips derived from items with the selected-but-empty clause; `All` chip removed; `Show purchased` removed; `syncQuickAddStoreDefault()` deleted with both call sites; empty-state copy updated.
- `renderStoreChips()` moved out of `fetchStores()` into `renderItems()`, the one function on every path that can change the item set.
- Zero-stores hint in the Store toolbar group, scoped to `stores.length === 0 && selectedStores.size === 0`.
- `.todo-view-switch` → `.view-switch` across `static/styles.css`, `templates/todo.html`, `templates/todo_completed.html`, plus the two new links. No back-compat alias; those were every usage.
- `static/styles.css` — dropped `.shopping-quick-add` and `.shopping-toggle`; added `.page-note` and `.filter-hint`; capped `.autocomplete-menu` at `240px`; promoted `.autocomplete-wrap` to a standalone rule now that it lives in the modal.

**Tests**
- Eight new tests in `tests/test_shopping.py` covering the boundary in both directions, the `completed_at IS NULL` complement guarantee, ordering, search across name and note, and independence from `include_hidden`.
- `/shopping/purchased` added to both parametrized lists in `tests/test_pages.py`.

## Notes for reviewers

- **Escape does not close the item modal, and this PR does not add it.** The issue's manual test plan expects `Escape` to close the modal "as it does everywhere else", but no modal in Rally closes on Escape today — `todo.html`, `dinner_planner.html` and the store modal are all overlay-click and Cancel only. Adding it to the shopping modal alone would create exactly the one-page-only behavior this issue exists to remove, so it is left for a follow-up that does all of them. Escape still closes the autocomplete menu, which is existing behavior.
- **Autocomplete clipping is mitigated but not visually confirmed.** `.modal-body` is `overflow-y: auto`, so the menu is clipped by that scroll box rather than spilling down the page. Both mitigations from the issue are in: the menu is capped at `240px` with its own scroll, and `renderSuggestions()` scrolls `.modal-body` to the top so the name field sits near the top with room beneath it. The stacking check against `.modal-scroll::before/::after` is reasoned about, not eyeballed — see Testing.
- **Burst entry is given up**, per the decision log. `Save` closes the modal; adding eight items is eight trips through the header button.
- The purchased page duplicates `escapeHtml`, `storeName`, `groupLabel` and the grouping logic from `shopping.html`. Acceptable at two templates; the `_meal_edit_modal.html` + `static/meal_edit_modal.js` pair is the precedent if a third appears.

## Testing

- `uv run pytest` — **392 passed**, up from 384. All 44 pre-existing `tests/test_shopping.py` tests pass unmodified.
- `uv run ruff check .` and `uv run ruff format --check .` — clean.
- Every `<script>` block in the four touched templates parses under `node --check`.
- A structural check against the issue's spec, run through `TestClient`: 26 assertions covering the header button, quick-add and checkbox removal, the store modal surviving intact, the dual-mode modal markup, autocomplete's new position inside the overlay, all four `.view-switch` call sites, the retention note, and the CSS additions and deletions. All pass.
- **Not done: the browser walkthrough.** There is no headless browser in this environment, so the manual test plan in the issue — autocomplete rendering inside the modal, the chip row at phone width, keyboard nav, the store-delete-while-filtered path — has not been walked. The autocomplete clipping mitigation in particular is the item most worth a human eyeballing before this ships.

Closes #136
