### PR TITLE
Visual design system: audit, and the system built from it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,3 +28,26 @@ jobs:
 
       - name: Check formatting
         run: uv run ruff format --check .
+
+  # The design-system regression suite drives a real browser, so it needs a
+  # Chromium download and runs on its own. tests/visual skips itself in the job
+  # above, where Playwright is deliberately not installed.
+  visual:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --group visual
+
+      - name: Install Chromium
+        run: uv run playwright install --with-deps chromium
+
+      - name: Run visual regression tests
+        run: uv run pytest tests/visual -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,6 +292,20 @@ uv run pytest
 test-generate
 ```
 
+The design-system regression suite needs a browser and is **not** part of the
+default run — `tests/visual/` skips itself when Playwright is absent, and CI
+runs it as a separate job. To run it locally:
+
+```bash
+uv sync --group visual
+uv run playwright install chromium
+uv run pytest tests/visual -v
+```
+
+Note that `uv sync --group visual` drops the editable `rally` install. Tests
+still work (pytest puts `src/` on the path), but a bare `uvicorn rally.main:app`
+will then need `PYTHONPATH=src`. Re-run plain `uv sync` to restore it.
+
 ### Starting Development Server
 
 **Interactive (for humans):**
@@ -537,7 +551,9 @@ rally/
 │       ├── family.py        # Family member CRUD API
 │       └── settings.py      # Settings and calendar management API
 ├── static/
-│   └── styles.css           # Application stylesheet
+│   ├── styles.css           # Application stylesheet (see the Design System section)
+│   ├── modal.js             # Shared modal chassis: scroll fade, show/hide
+│   └── meal_edit_modal.js   # Shared meal add/edit modal behaviour
 ├── templates/
 │   ├── dashboard.html       # Generated dashboard template
 │   ├── todo.html            # Todo management page
@@ -682,8 +698,40 @@ rally/
   - Robust against server timezone settings
 - ✅ Environment mode detection (dev/production)
 - ✅ Elegant grayscale design with serif typography
-- ✅ Static CSS stylesheet (`static/styles.css`)
+- ✅ Static CSS stylesheet (`static/styles.css`), organised in token/base/primitive/component layers
+- ✅ Design system: tokens, layout primitives, one button family, one modal chassis (`docs/visual-design-system.md`, `/styleguide`)
+- ✅ Design-system regression tests: static stylesheet lint plus a Playwright suite (`tests/test_stylesheet.py`, `tests/visual/`)
 - ✅ uv-based dependency management
+
+## Design System
+
+`static/styles.css` is organised in layers — tokens, base, layout primitives,
+components, page-specific, responsive — in that order. A rule's position tells
+you its blast radius. Full rationale and the audit that produced it:
+`docs/visual-design-system.md`. Live reference: `/styleguide`.
+
+When touching the UI:
+
+- **Use tokens, never literals.** `var(--space-4)`, `var(--text-sm)`,
+  `var(--ink-muted)`. A raw px or hex in a component is a bug unless it is a
+  1px hairline. `tests/test_stylesheet.py` fails the build otherwise.
+- **Text is `--ink`, `--ink-muted` or `--ink-subtle`.** `--rule` and
+  `--rule-subtle` are hairlines and fail WCAG AA as text.
+- **Buttons are `.btn` plus `--secondary`, `--quiet`, `--sm`.** Do not add a
+  new button class; Save must look the same everywhere it appears.
+- **Never write `outline: none`.** One `:focus-visible` rule in the base layer
+  covers everything.
+- **Page structure is `.page.stack` > `.page-header` + `.toolbar` + content.**
+  Spacing between blocks comes from `.stack`, not from component margins.
+- **Toolbars own their reset slot.** `Clear Filters` goes in `.toolbar-reset`
+  as the toolbar's last child, never inside a `.toolbar-group`.
+- **Modals are `.modal-content > h3 + .modal-scroll > .modal-body`**, and the
+  page loads `/static/modal.js`.
+- **Hit areas are `var(--target-min)`**, which is 44px on coarse pointers and
+  narrow viewports.
+
+Run `uv run pytest tests/test_stylesheet.py` for the static checks, and the
+visual suite (above) before shipping a layout change.
 
 ## Application Routes
 
@@ -696,6 +744,7 @@ rally/
 - `/shopping/purchased` - Read-only page of items purchased before today (local time), grouped by store; reachable only via the `View purchased items` link on `/shopping`, not from the nav bar
 - `/dinner-planner` - Dinner planning page with date picker and plan management
 - `/settings` - Settings, family member, calendar, and followed-team management page
+- `/styleguide` - Design system reference: every component and state rendered from the real stylesheet. Unlinked from the nav, but it ships — a styleguide that exists only in development stops matching production
 
 ### API Routes
 - `/api/dashboard/regenerate` - Force dashboard regeneration and save new snapshot

--- a/docs/visual-design-system.md
+++ b/docs/visual-design-system.md
@@ -1,0 +1,387 @@
+# Visual design system: audit and remediation plan
+
+**Status:** proposed. Nothing in this document is implemented yet.
+
+Rally's look is deliberate — an editorial, monochrome, serif command center that
+reads well on a wall tablet and prints cleanly. That identity is not in
+question here and this plan does not change it.
+
+What is in question is *consistency*. Every page was built by hand against a
+single 1,723-line stylesheet with no shared vocabulary, so the same idea is
+expressed a slightly different way on each page. Individually the differences
+are small. Together they are why the app feels assembled rather than designed,
+and why every new page costs more than the last one.
+
+This document is the audit, the design system proposed to fix it, and the
+staged plan to get there.
+
+## How this was measured
+
+Every page was loaded in headless Chromium at three widths — 1440×900,
+834×1112, 390×844 — and measured in the DOM rather than eyeballed. Screenshots
+were captured alongside, but the findings below are geometry, not impressions:
+element boxes, computed styles, focus rings after actually focusing, and a
+census of every distinct value in use.
+
+Pages: `/dashboard`, `/todo`, `/todo/completed`, `/shopping`,
+`/shopping/purchased`, `/dinner-planner`, `/meal-history`, `/settings`.
+Modals: all 11, opened and measured at desktop and mobile.
+
+The measuring code is the reason this is worth doing as a *system*: it is
+directly reusable as the enforcement mechanism (see "Enforcement" below), so
+the audit becomes a regression test rather than a one-time cleanup.
+
+## Findings
+
+Grouped by cause, not by page. Each finding names the evidence.
+
+### A. Page frame and vertical rhythm
+
+**A1. Every content page has a 2px horizontal jog on desktop.**
+At ≥1024px the body content box is 804px wide (`max-width: 900px` minus
+`padding: 64px 48px`), but `.section-container` caps itself at `max-width:
+800px` and centres, insetting 2px on each side. Measured left edges on all six
+content pages: `.header`, `nav`, `footer` at x=318; `.section-container`,
+`.header-container`, `.filter-toolbar`, `.list-container` at x=320. The rule
+under the wordmark is 4px wider than the rule under the page title, on every
+page. Two nested max-widths are one too many.
+
+**A2. The gap between the page title and the toolbar is three different sizes.**
+Measured from the bottom of the `.header-container` rule to the top of
+`.filter-toolbar`: 32px on Meal Planner and Meal History; 61.2px on Tasks,
+Completed Tasks and Shopping; 92.3px on Purchased Items. The difference is
+whether the page happens to have a `.view-switch` link and a `.page-note`,
+which sit as loose siblings contributing their own margins instead of belonging
+to a defined header block.
+
+**A3. The `.view-switch` link is visually attached to the wrong thing.**
+It sits 36px below the title rule but 0.7px above the toolbar, so "View
+completed tasks" reads as part of the filter bar rather than as a page-level
+action.
+
+**A4. On mobile, page chrome consumes the entire first screen.**
+Y-coordinate of the first content row against an 844px viewport:
+
+| Page | First content row | Share of first screen |
+|---|---|---|
+| Completed Tasks | 981px | 116% |
+| Tasks | 864px | 102% |
+| Meal History | 861px | 102% |
+| Purchased Items | 830px | 98% |
+| Shopping | 760px | 90% |
+| Meal Planner | 730px | 86% |
+| Dashboard | 687px | 81% |
+| Settings | 623px | 74% |
+
+On four of eight pages you must scroll before seeing a single task, item or
+meal. This is the "shoves the usable content downwards" complaint, quantified.
+The cost is fixed and repeated: 3rem wordmark, subtitle, rule, four stacked
+full-width nav buttons, rule, title, rule, toolbar — before any content.
+
+**A5. Two pages opt out of the page-title pattern.** Six pages open with an
+`.header-container` (uppercase `h2` + rule). Dashboard and Settings do not.
+Settings further wraps each section in `.border-container` (32px padding +
+1px border), so its content sits 33px inset from where content sits on every
+other page.
+
+**A6. Three different "space between major blocks" values.** 64px between
+stacked `.section-container`s, 48px between `.border-container`s, 32px between
+everything else — none of them derived from a shared scale.
+
+### B. The filter toolbar
+
+This is the single largest source of visible inconsistency, and it is where the
+original report started.
+
+**B1. Whether a filter label sits beside its chips or above them is decided by
+chip count, not by design.** `.toolbar-group` is a wrapping flex row; the
+`.filter-chips` block is a single flex item, so it drops to its own line the
+moment its content no longer fits. At 390px:
+
+| Page | Group | Chips | Label beside chips? |
+|---|---|---|---|
+| Tasks | Assignee | 5 | no |
+| Meal History | Meal Type | 4 | no |
+| Meal Planner | Meal Type | 4 | no |
+| Meal History | Rating | 3 | **yes** |
+| Shopping | Store | 3 | **yes** |
+
+Meal History exhibits both behaviours *in the same toolbar*: "Meal Type" above
+its chips, "Rating" beside its chips, "Sort" beside its select. Adding a family
+member or a store silently changes the layout of the page.
+
+**B2. "Clear Filters" lands wherever the preceding chips end.** It is a child of
+whichever `.toolbar-group` each template happened to put it in, so it has no
+fixed slot. Measured x-position and row at 1440px:
+
+| Page | Attached to | x | Row |
+|---|---|---|---|
+| Tasks | Assignee | 771 | 1 |
+| Meal Planner | Meal Type | 732 | 1 |
+| Shopping | Store | 654 | 1 |
+| Meal History | Rating | 628 | **2** |
+| Purchased Items | Store | 384 | 1 |
+
+Between Meal Planner and Meal History — two views of the same feature, reached
+from the same nav dropdown — the control changes both column and row. On Meal
+History it is stranded mid-row between the Rating chips and the Sort label, so
+it reads as if it belongs to Sort.
+
+**B3. `.filter-clear` styles two unrelated kinds of action.** It is both the
+reset control ("Clear Filters", "Clear Search") and a navigation control
+("Manage stores", which opens a modal). Identical appearance, entirely
+different consequence, sitting side by side in the Shopping toolbar.
+
+**B4. Three treatments for "quiet, link-like control".** `.view-switch`
+(0.9rem), `.filter-clear` (0.85rem), `.btn-ghost` (0.9rem) — all underlined
+grey text, all different padding, no rule for which to use.
+
+**B5. The toolbar is the heaviest block on mobile.** Measured heights at 390px:
+110px (Shopping) to 370px (Completed Tasks). The Completed Tasks toolbar alone
+is 44% of the viewport.
+
+### C. Tokens: there is no shared vocabulary
+
+**C1. 17 distinct `font-size` declarations**, nine of them inside the
+0.7–1.1rem band (0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1, 1.05, 1.1) — differences
+too small to read as intentional but each individually specified. Rendered
+desktop pages use 11 distinct computed sizes. `:root` declares colours and two
+font families; there are no type or spacing tokens at all.
+
+**C2. 18 distinct spacing values**, including the one-offs 5px, 14px, 26px and
+28px. There is no 4px or 8px grid to snap to.
+
+**C3. 7 distinct `letter-spacing` values** across an identity that leans
+heavily on letter-spacing.
+
+**C4. The palette is named by appearance, not role.** `--charcoal`,
+`--dark-gray`, `--medium-gray`, `--light-gray`, `--pale-gray`, `--silver`,
+`--off-white`. Nothing in the name says "this is a border", "this is secondary
+text", or "this is a sunken surface", so there is no way to reason about a
+change, and no path to a dark or e-ink variant.
+
+**C5. `--light-gray` (#999999) fails WCAG AA as a text colour and is used as
+one in 10 rules.** Contrast on white is **2.85:1**, below the 4.5:1 minimum for
+body text and below even the 3:1 large-text minimum. It carries real
+information: `.shopping-completed-at`, `.no-review-text`, `.recurring-paused`,
+`.recurring-meta`, `.todo-meta`, `.todo-completed-date`, `.shopping-group-count`.
+For reference: `--medium-gray` #666 is 5.74:1 and passes.
+
+**C6. Four sizes for one heading idea.** Uppercase, letter-spaced, serif
+headings exist at 1rem (`.shopping-group-name`), 1.1rem (`.card-header`),
+1.3rem (`.modal-content h3`) and 1.5rem (`h2`) — four steps with no scale
+relating them.
+
+### D. Components
+
+**D1. Two primary buttons, both labelled "Save", both on the Settings page.**
+`.btn-save` (padding 10px 24px, 1rem) is used by Settings' nine inline forms;
+`.btn-primary` (padding 8px 16px, 0.9rem) is used by all 11 modals — including
+the four modals that open *from* Settings. Measured: **80×43 at 16px** versus
+**61×37 at 14.4px**. Same word, two controls, one page. Note which one is
+correct: `.btn-save` at 43px nearly meets the 44px touch target that
+`.btn-primary` misses by seven.
+
+**D2. The modal chassis is split in two.** Five modals (task, recurring, item,
+stores) use `.modal-scroll` + `.modal-body` and get the scroll-fade affordance
+and a body that flexes. Six (meal, review, member, calendar, team) do not, and
+fall back to `.modal-content { overflow: auto }`. At 390px the Add Team modal
+fills 89.8% of the viewport and the Add Meal modal 88%, both with no fade to
+signal that content continues.
+
+**D3. Two modal id conventions.** `#modal-overlay` (todo, meal edit) versus
+namespaced `#item-modal-overlay`, `#review-modal-overlay`, and so on.
+
+**D4. Four paddings for "a box of content".** 16px (`.editable-item`,
+`.history-card`), 20px (`.plan-card`), 24px (`.card`), 32px
+(`.border-container`).
+
+**D5. Two checkbox appearances.** `.todo-checkbox input` is sized 18×18 with a
+`border` declaration that native checkboxes ignore; `.checkbox-label input` is
+left at the browser default 13×13 with `accent-color`. Both appear on Settings.
+
+**D6. Body copy is justified on desktop and ragged on mobile.**
+`.card-content p` sets `text-align: justify`, overridden to `left` under 768px.
+Justified serif text in an 800px measure with no hyphenation produces uneven
+word spacing on the Dashboard's summary cards.
+
+### E. Accessibility
+
+**E1. The toolbar has no visible keyboard focus at all.** `.filter-chip`,
+`.filter-clear`, `.search-input` and `.search-btn` each set `outline: none` on
+`:focus` with no replacement. Verified by focusing each control and reading the
+computed style: no outline, no box-shadow, no border change. Every other
+control in the app relies on the browser default, so focus styling is both
+absent where it is suppressed and undesigned where it is not.
+
+**E2. Interactive targets below 44px are the norm, not the exception.**
+Measured at 390px: `.btn-edit` 49×32 (36 instances across the app),
+`.filter-chip` ~29px tall, `.filter-clear` 26px, `.view-switch` 24.5px,
+and the todo/shopping checkbox 18×18 — which is the primary "check it off"
+gesture on a touch device. Form fields inside modals already set
+`min-height: 2.75rem` (44px), so the convention exists; it just is not applied
+outside forms.
+
+**E3. One default-blue link.** The `forecast.weather.gov` help link on Settings
+renders at `rgb(0, 0, 238)` — the only non-grayscale pixel in the app.
+
+**E4. A third font family appears unstyled.** `<code>` is used in seven places
+on Settings and renders in the browser's monospace default.
+
+### F. Stylesheet health
+
+**F1. Verbatim duplicate rules.** `footer`, `footer a` and `footer a:hover` are
+declared twice, identically (lines 79–98 and 132–151, both under a
+`/** Footer Styles **/` banner). `.modal-scroll::after` and
+`.nav-dropdown-btn.active` are also declared twice.
+
+**F2. Dead rules.** The entire `.plan-*` family (`.plan-card`, `.plan-date`,
+`.plan-content`, `.plan-actions`, `.plan-meta`, `.plan-meta-row`) is unused —
+Meal Planner now renders `.editable-item`. Also unused: `.assignee-badge`,
+`.todo-meta`, `.member-badge`, `.settings-actions`, `.settings-status`,
+`.history-card-meta`, `.form-actions`.
+
+**F3. Organised by page, not by layer.** One flat 1,723-line file where a
+global rule and a shopping-only rule sit at the same level, so there is no
+signal about blast radius when editing.
+
+## The proposed system
+
+Five layers, smallest first. Each is independently useful.
+
+### 1. Tokens — `static/tokens.css`
+
+Raw greys stay as private primitives; everything else references roles.
+
+```
+/* space — one 4px-based scale, replacing 18 ad hoc values */
+--space-1: 4px;   --space-2: 8px;   --space-3: 12px;  --space-4: 16px;
+--space-5: 24px;  --space-6: 32px;  --space-7: 48px;  --space-8: 64px;
+
+/* type — six steps, replacing 17 sizes */
+--text-xs: 0.75rem;  --text-sm: 0.875rem;  --text-base: 1rem;
+--text-lg: 1.125rem; --text-xl: 1.5rem;    --text-display: 3rem;
+
+/* colour by role, not appearance */
+--ink: #1a1a1a;          /* primary text, strong rules   */
+--ink-muted: #666666;    /* secondary text — 5.74:1      */
+--ink-subtle: #767676;   /* tertiary text — 4.54:1       */
+--rule: #cccccc;         /* hairlines — never text       */
+--rule-subtle: #e5e5e5;
+--surface: #ffffff;
+--surface-sunken: #f5f5f5;
+--inverse: #ffffff;      /* text on --ink                */
+```
+
+The one substantive colour change: `--ink-subtle` (#767676) replaces
+`--light-gray` (#999999) wherever it carries text, clearing WCAG AA at 4.54:1.
+#999 survives only as a non-text hairline/disabled affordance.
+
+Rule to enforce: **no token used for text may fall below 4.5:1 on `--surface`.**
+
+### 2. Layout primitives
+
+- `.page` — the single content column. One max-width in the whole app, ending
+  the A1 jog by construction.
+- `.page-header` — title, actions, optional view-switch and note as *one*
+  block with defined internal spacing. Collapses A2, A3 and A5 into one rule
+  and makes Dashboard and Settings conform.
+- `.stack` — vertical rhythm via `> * + *`, so block spacing comes from one
+  place instead of per-component margins (A6).
+- `.toolbar` — see below.
+
+### 3. Component contracts
+
+Every component documents its states — default, hover, `:focus-visible`,
+active, disabled — and its minimum target size. The button family collapses
+from nine ad hoc classes (`.btn-add`, `.btn-primary`, `.btn-save`,
+`.btn-cancel`, `.btn-edit`, `.btn-delete`, `.btn-ghost`, `.btn-load-more`,
+`.filter-clear`) to four roles: **primary**, **secondary**, **quiet**,
+**destructive**, each in one size plus a `--sm` modifier. `.view-switch`
+becomes quiet-with-icon rather than its own thing.
+
+Also specified: chip, field, card, modal, list row, section header.
+
+### 4. Toolbar — the one deliberate shape change
+
+- Label placement becomes explicit rather than emergent: **stacked above the
+  chips below 768px, inline at and above it**, using a grid rather than flex
+  wrapping. Chip count stops affecting layout (B1).
+- **"Clear Filters" gets a fixed slot** — the end of the toolbar, right-aligned
+  on desktop, full-width row on mobile — identical on every page (B2). It is
+  rendered by the toolbar itself, not placed by each template.
+- **"Manage stores" moves out of the filter bar** to a secondary action beside
+  the page title, where its consequence matches its position (B3).
+
+### 5. Documentation
+
+- `docs/design-system.md` — the tokens, the primitives, the component
+  contracts, and the rules ("text is never `--rule`", "targets are ≥44px",
+  "spacing comes from the scale").
+- A `/styleguide` route rendering every component and every state from the real
+  stylesheet, so the documentation cannot drift from the code.
+
+## Enforcement
+
+Playwright, in `tests/visual/`, run in CI as its own job (it needs
+`playwright install chromium`). Three layers, cheapest first:
+
+1. **Geometry assertions** — the audit script generalised into tests. These
+   catch the class of bug this document is about, and unlike screenshots they
+   say *why* they failed:
+   - every top-level block shares a left edge, at every width;
+   - the label/chip relationship is identical across all pages at a given width;
+   - "Clear Filters" occupies the same slot on every page that has one;
+   - no interactive target under 44×44 at mobile width;
+   - no horizontal overflow at any width;
+   - the first content row is above the fold at 390×844.
+2. **Token linting** — walk the rendered DOM and fail on any computed
+   font-size, colour or spacing outside the token set. This is what stops the
+   17-font-size problem from growing back.
+3. **Screenshot baselines** — per page × {mobile, desktop}, small pixel
+   tolerance, refreshed deliberately in the PR that changes them. These are the
+   backstop for what geometry cannot express.
+
+## Delivery
+
+Staged so each step is independently reviewable and shippable, and so the
+safety net exists before anything moves.
+
+| Step | Scope | Fixes |
+|---|---|---|
+| 0 | This document. No code. | — |
+| 1 | Playwright harness, CI job, geometry assertions and baselines of the **current** state | — |
+| 2 | Tokens + `/styleguide`; mechanical substitution. **No intended visual change** — baselines prove it | C1–C4, C6 |
+| 3 | Layout primitives: `.page`, `.page-header`, `.stack` | A1, A2, A3, A5, A6 |
+| 4 | Toolbar rebuild | B1–B5 |
+| 5 | Button/control consolidation, `:focus-visible`, 44px targets, contrast fix | C5, D1, E1–E4 |
+| 6 | Modal chassis unification | D2, D3 |
+| 7 | Density pass to reclaim the mobile fold | A4 |
+| 8 | Stylesheet split into layers, dead-rule removal | D4, F1–F3 |
+
+Step 1 lands before step 2 on purpose: the mechanical token substitution is
+exactly the kind of change that is safe *if* something is watching, and
+unreviewable if nothing is.
+
+## Non-goals
+
+- **No redesign.** The serif, monochrome, editorial identity is the point of
+  Rally and does not change. Every finding here is about applying it
+  consistently.
+- **No CSS framework, no build step, no JS framework.** Plain CSS with custom
+  properties, matching how the app is written today.
+- **No dark mode now.** Role-based tokens make it possible later; shipping it
+  is not part of this.
+- **No behaviour changes** beyond the two deliberate ones called out in the
+  toolbar section.
+
+## Open questions
+
+1. **Density target for A4.** How aggressive should the mobile fold reclamation
+   be — tighten spacing only, or also shrink the wordmark and collapse the nav
+   into a compact row on small screens? The second reclaims far more but
+   touches the most recognisable part of the identity.
+2. **Should `/styleguide` ship in production**, or be gated to development?
+3. **Screenshot baselines in-repo?** They add roughly 2–4MB and some churn, but
+   they are the only check that catches purely visual regressions. Geometry
+   assertions and token linting alone would keep the repo lean.

--- a/docs/visual-design-system.md
+++ b/docs/visual-design-system.md
@@ -1,10 +1,12 @@
-# Visual design system: audit and remediation plan
+# Visual design system: audit and implementation
 
-**Status:** proposed. Nothing in this document is implemented yet.
+**Status:** implemented. The audit below is what was found; the sections after
+it are the system that was built in response, and the tests that hold it in
+place.
 
 Rally's look is deliberate — an editorial, monochrome, serif command center that
 reads well on a wall tablet and prints cleanly. That identity is not in
-question here and this plan does not change it.
+question here and this work did not change it.
 
 What is in question is *consistency*. Every page was built by hand against a
 single 1,723-line stylesheet with no shared vocabulary, so the same idea is
@@ -12,8 +14,8 @@ expressed a slightly different way on each page. Individually the differences
 are small. Together they are why the app feels assembled rather than designed,
 and why every new page costs more than the last one.
 
-This document is the audit, the design system proposed to fix it, and the
-staged plan to get there.
+This document is the audit, the design system built to fix it, and the
+enforcement that keeps it from drifting back.
 
 ## How this was measured
 
@@ -33,7 +35,10 @@ the audit becomes a regression test rather than a one-time cleanup.
 
 ## Findings
 
-Grouped by cause, not by page. Each finding names the evidence.
+Grouped by cause, not by page. This is the state before the rebuild; each
+finding names the evidence, and each is closed by the system described after
+it. The measurements are quoted throughout so the fixes can be checked against
+something specific.
 
 ### A. Page frame and vertical rhythm
 
@@ -245,143 +250,182 @@ Meal Planner now renders `.editable-item`. Also unused: `.assignee-badge`,
 global rule and a shopping-only rule sit at the same level, so there is no
 signal about blast radius when editing.
 
-## The proposed system
+## The system, as built
 
-Five layers, smallest first. Each is independently useful.
+Five layers, smallest first. `static/styles.css` is now organised in exactly
+this order, so a rule's position tells you its blast radius.
 
-### 1. Tokens — `static/tokens.css`
+### 1. Tokens
 
-Raw greys stay as private primitives; everything else references roles.
+Raw greys stay as private primitives; everything else references a role. Every
+token override — the responsive page padding, the touch target — lives in this
+layer too, so the scales have one home.
 
-```
+```css
 /* space — one 4px-based scale, replacing 18 ad hoc values */
---space-1: 4px;   --space-2: 8px;   --space-3: 12px;  --space-4: 16px;
---space-5: 24px;  --space-6: 32px;  --space-7: 48px;  --space-8: 64px;
+--space-1: 0.25rem;  --space-2: 0.5rem;   --space-3: 0.75rem;  --space-4: 1rem;
+--space-5: 1.5rem;   --space-6: 2rem;     --space-7: 3rem;     --space-8: 4rem;
 
-/* type — six steps, replacing 17 sizes */
---text-xs: 0.75rem;  --text-sm: 0.875rem;  --text-base: 1rem;
---text-lg: 1.125rem; --text-xl: 1.5rem;    --text-display: 3rem;
+/* type — six steps, replacing 17 declared sizes */
+--text-xs: 0.75rem;  --text-sm: 0.875rem; --text-base: 1rem;
+--text-lg: 1.25rem;  --text-xl: 1.5rem;   --text-display: 3rem;
 
 /* colour by role, not appearance */
 --ink: #1a1a1a;          /* primary text, strong rules   */
 --ink-muted: #666666;    /* secondary text — 5.74:1      */
 --ink-subtle: #767676;   /* tertiary text — 4.54:1       */
+--ink-strong: #000000;   /* emphasis inside body copy    */
 --rule: #cccccc;         /* hairlines — never text       */
 --rule-subtle: #e5e5e5;
 --surface: #ffffff;
 --surface-sunken: #f5f5f5;
 --inverse: #ffffff;      /* text on --ink                */
+
+--target-min: 2.25rem;   /* 2.75rem under (pointer: coarse) and below 768px */
 ```
 
-The one substantive colour change: `--ink-subtle` (#767676) replaces
-`--light-gray` (#999999) wherever it carries text, clearing WCAG AA at 4.54:1.
-#999 survives only as a non-text hairline/disabled affordance.
+The one substantive colour change: `--ink-subtle` (#767676) replaced
+`--light-gray` (#999999) everywhere it carried text, clearing WCAG AA at
+4.54:1. #999 no longer exists.
 
-Rule to enforce: **no token used for text may fall below 4.5:1 on `--surface`.**
+Three steps carry the headings — 1rem, 1.25rem, 1.5rem — so the four unrelated
+uppercase sizes collapsed to three related ones (C6): `.shopping-group-name`
+at base, `.card-header` and every modal `h3` at lg, page `h2` at xl.
 
 ### 2. Layout primitives
 
-- `.page` — the single content column. One max-width in the whole app, ending
-  the A1 jog by construction.
-- `.page-header` — title, actions, optional view-switch and note as *one*
-  block with defined internal spacing. Collapses A2, A3 and A5 into one rule
-  and makes Dashboard and Settings conform.
-- `.stack` — vertical rhythm via `> * + *`, so block spacing comes from one
-  place instead of per-component margins (A6).
-- `.toolbar` — see below.
+- **`.page`** — the content column. Width is owned by `body` alone; the second
+  `max-width` that put every desktop page 2px out of line with its own header
+  is gone (A1).
+- **`.page-header`** — title, actions, and any secondary links as *one* block
+  with defined internal spacing. The archive switch and retention note are now
+  inside it instead of being loose siblings with their own margins (A2, A3).
+  Dashboard and Settings use the same primitives; Settings gained a page-level
+  `h2` and its section headings became `h3` (A5).
+- **`.stack`** — vertical rhythm via `> * + *`. The space between blocks comes
+  from one declaration, tightened one step on mobile (A6).
 
-### 3. Component contracts
+### 3. Components
 
-Every component documents its states — default, hover, `:focus-visible`,
-active, disabled — and its minimum target size. The button family collapses
-from nine ad hoc classes (`.btn-add`, `.btn-primary`, `.btn-save`,
-`.btn-cancel`, `.btn-edit`, `.btn-delete`, `.btn-ghost`, `.btn-load-more`,
-`.filter-clear`) to four roles: **primary**, **secondary**, **quiet**,
-**destructive**, each in one size plus a `--sm` modifier. `.view-switch`
-becomes quiet-with-icon rather than its own thing.
+The button family collapsed from nine ad hoc classes (`.btn-add`,
+`.btn-primary`, `.btn-save`, `.btn-cancel`, `.btn-edit`, `.btn-delete`,
+`.btn-ghost`, `.btn-load-more`, `.filter-clear`) to `.btn` plus three
+modifiers: `--secondary`, `--quiet`, `--sm`. Save is now the same control
+everywhere it appears, including on Settings, where it used to be two different
+sizes on one page (D1).
 
-Also specified: chip, field, card, modal, list row, section header.
+Everything focusable shows a ring: one `:focus-visible` rule in the base layer,
+and no component may switch it off (E1). Hit areas are ≥44px wherever a finger
+is likely — keyed off `(pointer: coarse)` as well as width, because the wall
+tablet is a coarse pointer at desktop size (E2).
 
-### 4. Toolbar — the one deliberate shape change
+### 4. The toolbar
 
-- Label placement becomes explicit rather than emergent: **stacked above the
-  chips below 768px, inline at and above it**, using a grid rather than flex
-  wrapping. Chip count stops affecting layout (B1).
-- **"Clear Filters" gets a fixed slot** — the end of the toolbar, right-aligned
-  on desktop, full-width row on mobile — identical on every page (B2). It is
-  rendered by the toolbar itself, not placed by each template.
-- **"Manage stores" moves out of the filter bar** to a secondary action beside
-  the page title, where its consequence matches its position (B3).
+The one deliberate shape change.
+
+- Label placement is explicit — **stacked below 768px, inline at and above it**
+  — rather than emergent from flex wrapping. Chip count no longer affects
+  layout (B1).
+- The toolbar is **one grid**, not one grid per group: `display: contents`
+  promotes each group's label and control into it, so every label shares a
+  column and every control starts at the same x.
+- **"Clear Filters" has a fixed slot**, rendered by the toolbar as its last
+  block. It sits at an identical position on all six pages at every width (B2).
+- **"Manage stores" moved out of the filter bar** to the page header, where its
+  consequence matches its position (B3).
 
 ### 5. Documentation
 
-- `docs/design-system.md` — the tokens, the primitives, the component
-  contracts, and the rules ("text is never `--rule`", "targets are ≥44px",
-  "spacing comes from the scale").
-- A `/styleguide` route rendering every component and every state from the real
-  stylesheet, so the documentation cannot drift from the code.
+- This file — the tokens, the primitives, the rules.
+- **`/styleguide`** — every component and state, rendered from the real
+  stylesheet, reading its scales back out of the cascade so it cannot describe
+  a scale the CSS no longer has.
 
 ## Enforcement
 
-Playwright, in `tests/visual/`, run in CI as its own job (it needs
-`playwright install chromium`). Three layers, cheapest first:
+Two suites, cheapest first.
 
-1. **Geometry assertions** — the audit script generalised into tests. These
-   catch the class of bug this document is about, and unlike screenshots they
-   say *why* they failed:
-   - every top-level block shares a left edge, at every width;
-   - the label/chip relationship is identical across all pages at a given width;
-   - "Clear Filters" occupies the same slot on every page that has one;
-   - no interactive target under 44×44 at mobile width;
-   - no horizontal overflow at any width;
-   - the first content row is above the fold at 390×844.
-2. **Token linting** — walk the rendered DOM and fail on any computed
-   font-size, colour or spacing outside the token set. This is what stops the
-   17-font-size problem from growing back.
-3. **Screenshot baselines** — per page × {mobile, desktop}, small pixel
-   tolerance, refreshed deliberately in the PR that changes them. These are the
-   backstop for what geometry cannot express.
+**`tests/test_stylesheet.py`** — static, no browser, runs in the ordinary test
+job. Asserts that no selector is declared twice in the same context, that no
+rule suppresses the focus ring, and that colours, type sizes and spacing are
+taken from tokens rather than typed. It earned its place immediately: it caught
+a stale duplicate `.toolbar-search` rule that was silently overriding the new
+grid, and a second `:root` block in the same media query.
 
-## Delivery
+**`tests/visual/`** — the audit's measuring code turned into assertions, run in
+its own CI job against a real browser and a seeded database. Every test names
+the finding it protects against:
 
-Staged so each step is independently reviewable and shippable, and so the
-safety net exists before anything moves.
+| Test | Guards |
+|---|---|
+| page blocks share a left edge | A1 |
+| header is the same distance from the next block everywhere | A2, A3 |
+| content starts above the fold on a phone | A4 |
+| filter labels are placed by rule, not chip count | B1 |
+| Clear Filters occupies one fixed slot on every page | B2 |
+| type sizes come from the scale | C1 |
+| colours come from the palette | C4 |
+| text meets WCAG AA contrast | C5 |
+| every modal uses the shared chassis | D2 |
+| every control shows a focus ring | E1 |
+| touch targets meet 44px on a phone | E2 |
+| no horizontal overflow | — |
 
-| Step | Scope | Fixes |
+They are geometric rather than pixel-based on purpose: when one fails it says
+which rule broke and by how much, which a screenshot diff cannot. The suite
+skips itself when Playwright is absent, so `uv run pytest` stays fast and
+browser-free for anyone not working on the design system.
+
+To run it locally:
+
+```bash
+uv sync --group visual
+uv run playwright install chromium
+uv run pytest tests/visual -v
+```
+
+## What changed, measured
+
+| | Before | After |
 |---|---|---|
-| 0 | This document. No code. | — |
-| 1 | Playwright harness, CI job, geometry assertions and baselines of the **current** state | — |
-| 2 | Tokens + `/styleguide`; mechanical substitution. **No intended visual change** — baselines prove it | C1–C4, C6 |
-| 3 | Layout primitives: `.page`, `.page-header`, `.stack` | A1, A2, A3, A5, A6 |
-| 4 | Toolbar rebuild | B1–B5 |
-| 5 | Button/control consolidation, `:focus-visible`, 44px targets, contrast fix | C5, D1, E1–E4 |
-| 6 | Modal chassis unification | D2, D3 |
-| 7 | Density pass to reclaim the mobile fold | A4 |
-| 8 | Stylesheet split into layers, dead-rule removal | D4, F1–F3 |
-
-Step 1 lands before step 2 on purpose: the mechanical token substitution is
-exactly the kind of change that is safe *if* something is watching, and
-unreviewable if nothing is.
+| Distinct rendered font sizes | 11 | 6, all tokens |
+| Declared `font-size` values | 17 | 6 tokens |
+| Declared spacing values | 18 | 8 tokens |
+| Positions of "Clear Filters" across pages | 5 | 1 |
+| Label/chip placement rules | emergent, chip-count dependent | 1 per breakpoint |
+| Pages with content below the mobile fold | 4 of 8 | 0 of 8 |
+| Text below WCAG AA | 10 rules | 0 |
+| Controls with no focus ring | 4 | 0 |
+| Modals missing the scroll chassis | 6 of 11 | 0 |
+| Duplicate rule blocks | 4 | 0, enforced |
 
 ## Non-goals
 
 - **No redesign.** The serif, monochrome, editorial identity is the point of
-  Rally and does not change. Every finding here is about applying it
-  consistently.
+  Rally and did not change. Every change here applies it consistently.
 - **No CSS framework, no build step, no JS framework.** Plain CSS with custom
-  properties, matching how the app is written today.
-- **No dark mode now.** Role-based tokens make it possible later; shipping it
-  is not part of this.
-- **No behaviour changes** beyond the two deliberate ones called out in the
-  toolbar section.
+  properties, matching how the app is written.
+- **No dark mode.** Role-based tokens make it possible later; shipping it was
+  not part of this.
 
-## Open questions
+## Decisions taken
 
-1. **Density target for A4.** How aggressive should the mobile fold reclamation
-   be — tighten spacing only, or also shrink the wordmark and collapse the nav
-   into a compact row on small screens? The second reclaims far more but
-   touches the most recognisable part of the identity.
-2. **Should `/styleguide` ship in production**, or be gated to development?
-3. **Screenshot baselines in-repo?** They add roughly 2–4MB and some churn, but
-   they are the only check that catches purely visual regressions. Geometry
-   assertions and token linting alone would keep the repo lean.
+- **The density pass tightened spacing and the nav; it did not touch the
+  wordmark's identity.** On mobile the four stacked full-width nav buttons
+  became a 2×2 grid and the wordmark stepped down one size on the type scale.
+  That was enough to bring every page's first content row above the fold, so
+  nothing more aggressive was needed.
+- **`/styleguide` ships in production.** It is unlinked from the nav, and a
+  styleguide that only exists in development stops matching what production
+  looks like.
+- **No screenshot baselines in the repo.** The geometry assertions and the
+  stylesheet lint cover the failures worth catching, and they explain
+  themselves when they break. Baselines would add churn and a binary diff for
+  every intentional change.
+- **The verification dialog keeps a variant.** `.modal-content--narrow` with no
+  scroll wrapper: it has no title and no form, just a centred status block. The
+  test exempts titleless modals rather than pretending the variant does not
+  exist.
+- **`/dashboard` still has no `h2`.** The wordmark and today's date above it
+  are already the page title. It uses the same `.page`/`.stack` primitives as
+  everywhere else; only the redundant heading is omitted.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,11 @@ dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
 ]
+# Design-system regression tests. Kept out of `dev` so the ordinary test run
+# needs no browser download; tests/visual skips itself when this is absent.
+visual = [
+    "playwright>=1.48",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/rally/main.py
+++ b/src/rally/main.py
@@ -119,3 +119,16 @@ def meal_planner_redirect():
 def settings_page(request: Request):
     """Serve the settings page."""
     return templates.TemplateResponse("settings.html", {"request": request})
+
+
+@app.get("/styleguide", response_class=HTMLResponse)
+def styleguide_page(request: Request):
+    """Serve the design system reference.
+
+    Renders every component and state from the real stylesheet, so the
+    documentation cannot drift from the code the way a written spec would. It
+    is unlinked from the nav — a reference for whoever is changing the CSS, not
+    a page the family visits — but it ships, because a styleguide that only
+    exists in development stops matching what production actually looks like.
+    """
+    return templates.TemplateResponse("styleguide.html", {"request": request})

--- a/static/meal_edit_modal.js
+++ b/static/meal_edit_modal.js
@@ -110,7 +110,7 @@
             document.querySelectorAll('.attendee-cb').forEach(cb => cb.checked = false);
             document.getElementById('plan-cook').value = '';
             document.getElementById('btn-delete-plan').style.display = 'none';
-            this.overlay.style.display = 'flex';
+            showModalOverlay('modal-overlay');
         }
 
         openEdit(plan) {
@@ -129,7 +129,7 @@
             });
             document.getElementById('plan-cook').value = plan.cook_id || '';
             document.getElementById('btn-delete-plan').style.display = '';
-            this.overlay.style.display = 'flex';
+            showModalOverlay('modal-overlay');
         }
 
         close() {

--- a/static/modal.js
+++ b/static/modal.js
@@ -1,0 +1,75 @@
+/* The modal chassis, shared by every modal in Rally.
+ *
+ * Markup contract:
+ *
+ *   .modal-overlay > .modal-content > h3 + .modal-scroll > .modal-body
+ *
+ * .modal-body is the scroll box; .modal-scroll paints a fade over whichever
+ * edge is currently hiding content. Modals used to be split between those that
+ * had this wrapper and those that fell back to scrolling .modal-content, so
+ * half of them offered no signal that the form continued below the fold — most
+ * visibly on a phone, where a modal fills ~90% of the viewport.
+ *
+ * Loaded on every page that owns a modal; the wiring below is idempotent and
+ * runs against whatever is in the DOM at load.
+ */
+(function () {
+    'use strict';
+
+    function updateModalFade(scroll) {
+        const body = scroll.querySelector('.modal-body');
+        if (!body) return;
+        const maxScroll = body.scrollHeight - body.clientHeight;
+        // A 1px tolerance: sub-pixel layout otherwise leaves the bottom fade on
+        // permanently for content that actually fits.
+        scroll.toggleAttribute('data-overflow-top', body.scrollTop > 1);
+        scroll.toggleAttribute('data-overflow-bottom', body.scrollTop < maxScroll - 1);
+    }
+
+    function wire(scroll) {
+        if (scroll.dataset.fadeWired) return;
+        scroll.dataset.fadeWired = 'true';
+        const body = scroll.querySelector('.modal-body');
+        if (!body) return;
+        const refresh = () => updateModalFade(scroll);
+        body.addEventListener('scroll', refresh);
+        // The fade must also settle when the content changes height — a
+        // conditional field appearing (custom recurrence), or a list
+        // re-rendering. Field handlers run before this bubbles.
+        body.addEventListener('change', refresh);
+        if (typeof ResizeObserver !== 'undefined') {
+            new ResizeObserver(refresh).observe(body);
+        }
+    }
+
+    function wireAll() {
+        document.querySelectorAll('.modal-scroll').forEach(wire);
+    }
+
+    /* Show a modal and compute its fade state once it has been laid out. */
+    function showModalOverlay(overlayId) {
+        const overlay = document.getElementById(overlayId);
+        if (!overlay) return;
+        overlay.style.display = 'flex';
+        const scroll = overlay.querySelector('.modal-scroll');
+        if (scroll) {
+            wire(scroll);
+            requestAnimationFrame(() => updateModalFade(scroll));
+        }
+    }
+
+    function hideModalOverlay(overlayId) {
+        const overlay = document.getElementById(overlayId);
+        if (overlay) overlay.style.display = 'none';
+    }
+
+    window.showModalOverlay = showModalOverlay;
+    window.hideModalOverlay = hideModalOverlay;
+    window.updateModalFade = updateModalFade;
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', wireAll);
+    } else {
+        wireAll();
+    }
+})();

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,271 +1,783 @@
-/** Global Styles **/
+/* Rally stylesheet.
+
+   Organised in layers, not by page: tokens, base, layout primitives,
+   components, then the handful of genuinely page-specific rules. A rule's
+   position tells you its blast radius. See docs/visual-design-system.md.
+
+   Two rules hold everywhere:
+   - Values come from the token scale. A literal px or rem in a component is a
+     bug unless it is a hairline or an optical nudge, and says so.
+   - Text colours are --ink, --ink-muted or --ink-subtle. --rule and
+     --rule-subtle are hairlines and never carry text: they fail WCAG AA.
+*/
+
+/** ============================================================
+    1. Tokens
+    ============================================================ */
 :root {
-    --black: #000000;
-    --charcoal: #1a1a1a;
-    --dark-gray: #333333;
-    --medium-gray: #666666;
-    --light-gray: #999999;
-    --pale-gray: #cccccc;
-    --silver: #e5e5e5;
-    --off-white: #f5f5f5;
-    --white: #ffffff;
-    --header-font: 'Playfair Display', 'Georgia', serif;
-    --body-font: 'Crimson Text', 'Georgia', serif;
+    /* Space — one 4px-based scale. */
+    --space-1: 0.25rem;  /*  4px */
+    --space-2: 0.5rem;   /*  8px */
+    --space-3: 0.75rem;  /* 12px */
+    --space-4: 1rem;     /* 16px */
+    --space-5: 1.5rem;   /* 24px */
+    --space-6: 2rem;     /* 32px */
+    --space-7: 3rem;     /* 48px */
+    --space-8: 4rem;     /* 64px */
+
+    /* Type — six steps. 1 / 1.25 / 1.5 carry the three heading levels. */
+    --text-xs: 0.75rem;
+    --text-sm: 0.875rem;
+    --text-base: 1rem;
+    --text-lg: 1.25rem;
+    --text-xl: 1.5rem;
+    --text-display: 3rem;
+
+    --tracking-normal: 0.02em;
+    --tracking-wide: 0.05em;
+    --tracking-wider: 0.1em;
+    --tracking-widest: 0.15em;
+
+    --leading-tight: 1.3;
+    --leading-normal: 1.7;
+
+    /* Colour by role. Greys stay private primitives below. */
+    --ink: #1a1a1a;          /* primary text, strong rules          */
+    --ink-muted: #666666;    /* secondary text — 5.74:1 on surface  */
+    --ink-subtle: #767676;   /* tertiary text — 4.54:1 on surface   */
+    --ink-strong: #000000;   /* emphasis inside body copy           */
+    --rule: #cccccc;         /* hairlines — never text              */
+    --rule-subtle: #e5e5e5;
+    --surface: #ffffff;
+    --surface-sunken: #f5f5f5;
+    --inverse: #ffffff;      /* text on --ink                       */
+
+    --font-display: 'Playfair Display', 'Georgia', serif;
+    --font-body: 'Crimson Text', 'Georgia', serif;
+
+    /* Comfortable pointer default. Coarse pointers get 44px below. */
+    --target-min: 2.25rem;
+
+    --page-max: 900px;
+    --page-pad-x: var(--space-6);
+    --page-pad-y: var(--space-7);
 }
 
-* {
+/* Every token override lives here, in the tokens layer, so the scales have one
+   home and later layers only ever read them.
+
+   44px targets apply on anything likely to be touched, via two triggers: a
+   wall tablet is a coarse pointer at desktop width, and a phone is a narrow
+   viewport whether or not the browser reports its pointer honestly. */
+@media (pointer: coarse) {
+    :root { --target-min: 2.75rem; }
+}
+
+@media screen and (max-width: 767px) {
+    :root {
+        --target-min: 2.75rem;
+        --page-pad-x: var(--space-4);
+        --page-pad-y: var(--space-5);
+    }
+}
+
+@media screen and (min-width: 1024px) {
+    :root {
+        --page-pad-x: var(--space-7);
+        --page-pad-y: var(--space-8);
+    }
+}
+
+/** ============================================================
+    2. Base
+    ============================================================ */
+*,
+*::before,
+*::after {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
 }
 
 body {
-    font-family: var(--body-font);
-    background: var(--white);
-    color: var(--charcoal);
-    line-height: 1.7;
-    padding: 40px 32px;
-    max-width: 800px;
+    font-family: var(--font-body);
+    font-size: var(--text-base);
+    background: var(--surface);
+    color: var(--ink);
+    line-height: var(--leading-normal);
+    padding: var(--page-pad-y) var(--page-pad-x);
+    max-width: var(--page-max);
     margin: 0 auto;
-    overflow-y: scroll; /* Always show scrollbar to prevent layout shift */
+    overflow-y: scroll; /* Always show the scrollbar to prevent layout shift. */
 }
-/** End Global Styles **/
 
-/** Header Styles**/
-h2 {
-    font-size: 1.5rem;
-    font-family: var(--header-font);
+h1, h2, h3 {
+    font-family: var(--font-display);
     font-weight: 600;
+    line-height: var(--leading-tight);
     text-transform: uppercase;
-    letter-spacing: 0.1em;
+    letter-spacing: var(--tracking-wider);
+    text-wrap: balance;
 }
 
+h1 { font-size: var(--text-display); font-weight: 400; }
+h2 { font-size: var(--text-xl); }
+h3 { font-size: var(--text-lg); }
+
+/* One visible focus treatment for everything. Individual components must not
+   set `outline: none` — an invisible focus state is the bug this replaces. */
+:focus-visible {
+    outline: 2px solid var(--ink);
+    outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+}
+
+/** ============================================================
+    3. Layout primitives
+    ============================================================ */
+
+/* The single content column. Width is owned by `body` alone — a second
+   max-width here is what put every desktop page 2px out of line with its own
+   header and footer. */
+.page {
+    width: 100%;
+}
+
+.page + .page {
+    margin-top: var(--space-8);
+}
+
+/* Vertical rhythm for a column of blocks, so spacing lives in one place
+   instead of in each component's margin. */
+.stack > * + * {
+    margin-top: var(--space-6);
+}
+
+/* Page title, its actions, and any secondary links, as one block with defined
+   internal spacing. These used to be loose siblings, so the gap between the
+   title rule and the toolbar came out at 32, 61 or 92px by accident. The block
+   carries no bottom margin: `.stack` owns the space between blocks, so the
+   distance from the title rule to whatever follows is one value in one place. */
+.page-header-row {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-3);
+    padding-bottom: var(--space-4);
+    border-bottom: 1px solid var(--ink);
+}
+
+.page-header-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+}
+
+/* Secondary links and notes below the rule — the archive switch, retention
+   notes, store management. Always the same distance from the rule. */
+.page-header-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: var(--space-2) var(--space-4);
+    margin-top: var(--space-4);
+}
+
+.page-note {
+    flex-basis: 100%;
+    font-size: var(--text-sm);
+    color: var(--ink-muted);
+    font-style: italic;
+}
+
+/* Header block above the nav: wordmark and page subtitle. */
 .header {
     text-align: center;
-    border-bottom: 1px solid var(--charcoal);
-    padding-bottom: 24px;
-    margin-bottom: 32px;
+    border-bottom: 1px solid var(--ink);
+    padding-bottom: var(--space-5);
+    margin-bottom: var(--space-5);
 }
 
 .header h1 {
-    font-size: 3rem;
-    font-weight: 400;
-    letter-spacing: 0.15em;
-    text-transform: uppercase;
-    color: var(--charcoal);
-    margin-bottom: 8px;
-    font-family: var(--header-font);
+    letter-spacing: var(--tracking-widest);
+    color: var(--ink);
+    margin-bottom: var(--space-1);
 }
 
 .header .subtitle {
-    font-size: 0.95rem;
-    color: var(--medium-gray);
-    font-weight: 400;
-    letter-spacing: 0.05em;
+    font-size: var(--text-sm);
+    color: var(--ink-muted);
+    letter-spacing: var(--tracking-wide);
     font-style: italic;
 }
 
-.header-container {
-    display: flex;
-    justify-content: space-between;
+footer {
+    text-align: center;
+    color: var(--ink-muted);
+    font-size: var(--text-xs);
+    padding-top: var(--space-5);
+    border-top: 1px solid var(--rule);
+    margin-top: var(--space-6);
+    letter-spacing: var(--tracking-wide);
+    font-style: italic;
+}
+
+footer a {
+    display: inline-flex;
     align-items: center;
-    margin-bottom: 32px;
-    padding-bottom: 16px;
-    border-bottom: 1px solid var(--charcoal);
-}
-/** End Header Styles**/
-
-/** Footer Styles **/
-footer {
-    text-align: center;
-    color: var(--medium-gray);
-    font-size: 0.75rem;
-    padding: 24px 0 0 0;
-    border-top: 1px solid var(--pale-gray);
-    margin-top: 32px;
-    letter-spacing: 0.05em;
-    font-style: italic;
-}
-
-footer a {
-    color: var(--medium-gray);
+    justify-content: center;
+    min-height: var(--target-min);
+    padding: 0 var(--space-2);
+    color: var(--ink-muted);
     text-decoration: none;
     transition: color 0.2s;
 }
 
 footer a:hover {
-    color: var(--charcoal);
+    color: var(--ink);
 }
-/** End Footer Styles **/
 
-/** Navigation Styles**/
+/** ============================================================
+    4. Components
+    ============================================================ */
+
+/* ---- Navigation ---- */
 nav {
-    text-align: center;
-    margin-bottom: 32px;
-    padding-bottom: 24px;
-    border-bottom: 1px solid var(--pale-gray);
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--space-2);
+    margin-bottom: var(--space-5);
+    padding-bottom: var(--space-5);
+    border-bottom: 1px solid var(--rule);
 }
 
-nav a {
-    color: var(--charcoal);
+nav a,
+.nav-dropdown-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: var(--target-min);
+    padding: var(--space-2) var(--space-4);
+    border: 1px solid var(--ink);
+    background: var(--surface);
+    color: var(--ink);
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    letter-spacing: var(--tracking-wide);
     text-decoration: none;
-    padding: 8px 16px;
-    border: 1px solid var(--charcoal);
-    margin: 0 8px;
-    display: inline-block;
-    transition: background 0.2s;
-    font-size: 0.9rem;
-    letter-spacing: 0.05em;
-}
-
-nav a:hover {
-    background: var(--off-white);
-}
-
-nav a.active {
-    background: var(--charcoal);
-    color: var(--white);
-}
-/** End Navigation Styles**/
-
-/** Footer Styles **/
-footer {
-    text-align: center;
-    color: var(--medium-gray);
-    font-size: 0.75rem;
-    padding: 24px 0 0 0;
-    border-top: 1px solid var(--pale-gray);
-    margin-top: 32px;
-    letter-spacing: 0.05em;
-    font-style: italic;
-}
-
-footer a {
-    color: var(--medium-gray);
-    text-decoration: none;
-    transition: color 0.2s;
-}
-
-footer a:hover {
-    color: var(--charcoal);
-}
-/** End Footer Styles **/
-
-/** All Button Styles **/
-.btn-add, .btn-primary, .btn-cancel, .btn-edit, .btn-delete, .btn-save {
-    border: 1px solid var(--charcoal);
-    background: var(--white);
-    color: var(--charcoal);
-    font-family: var(--body-font);
     cursor: pointer;
     transition: background 0.2s, color 0.2s;
-    letter-spacing: 0.02em;
 }
 
-.btn-add, .btn-primary, .btn-cancel {
-    padding: 8px 16px;
-    font-size: 0.9rem;
+nav a:hover,
+.nav-dropdown-btn:hover {
+    background: var(--surface-sunken);
 }
 
-.btn-edit, .btn-delete {
-    padding: 6px 12px;
-    font-size: 0.85rem;
+nav a.active,
+.nav-dropdown-btn.active {
+    background: var(--ink);
+    color: var(--inverse);
 }
 
-.btn-save {
-    padding: 10px 24px;
-    font-size: 1rem;
+.nav-dropdown {
+    position: relative;
+    display: inline-flex;
 }
 
-.btn-add:hover, .btn-primary:hover, .btn-edit:hover, .btn-save:hover {
-    background: var(--charcoal);
-    color: var(--white);
+.nav-dropdown-btn::after {
+    content: "";
+    display: inline-block;
+    margin-left: var(--space-1);
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 5px solid currentColor;
 }
 
-.btn-cancel:hover, .btn-delete:hover {
-    background: var(--off-white);
+.nav-dropdown-content {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    min-width: 100%;
+    width: max-content;
+    max-width: 90vw;
+    background: var(--surface);
+    border: 1px solid var(--ink);
+    border-top: none;
+    z-index: 100;
 }
-/** End All Button Styles **/
 
-/** Container Styling **/
-.section-container {
-    max-width: 800px;
-    margin: 0 auto;
+.nav-dropdown-content a {
+    display: flex;
+    justify-content: flex-start;
+    border: none;
+    width: 100%;
 }
 
-.section-container + .section-container {
-    margin-top: 64px;
+.nav-dropdown.open .nav-dropdown-content {
+    display: block;
 }
+
+@media (hover: hover) and (min-width: 768px) {
+    .nav-dropdown:hover .nav-dropdown-content {
+        display: block;
+    }
+}
+
+/* ---- Buttons ----
+   One family, four roles. `.btn` is the outlined default that inverts on
+   hover; `--secondary` is the quieter partner for Cancel and Delete;
+   `--quiet` is borderless for resets and inline links. Size is a modifier,
+   never a new role: Save is the same control everywhere it appears. */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    min-height: var(--target-min);
+    padding: var(--space-2) var(--space-4);
+    border: 1px solid var(--ink);
+    background: var(--surface);
+    color: var(--ink);
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    letter-spacing: var(--tracking-normal);
+    text-decoration: none;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+
+.btn:hover:not(:disabled) {
+    background: var(--ink);
+    color: var(--inverse);
+}
+
+.btn--secondary:hover:not(:disabled) {
+    background: var(--surface-sunken);
+    color: var(--ink);
+}
+
+/* Reads as text, so it aligns like text: no horizontal padding, or its
+   underline would start inset from the column edge it sits against. Spacing
+   from its neighbours comes from the parent's gap. */
+.btn--quiet {
+    border-color: transparent;
+    background: none;
+    color: var(--ink-muted);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    padding-left: 0;
+    padding-right: 0;
+}
+
+.btn--quiet:hover:not(:disabled) {
+    background: none;
+    color: var(--ink);
+}
+
+/* Compact only where a row would otherwise grow — still 44px on touch. */
+.btn--sm {
+    padding: var(--space-1) var(--space-3);
+    font-size: var(--text-sm);
+}
+
+.btn:disabled {
+    color: var(--ink-subtle);
+    border-color: var(--rule);
+    cursor: default;
+}
+
+/* A quiet link that behaves like `.btn--quiet` but is genuinely a link:
+   the archive switches at the top of paired pages. */
+.link-quiet {
+    display: inline-flex;
+    align-items: center;
+    min-height: var(--target-min);
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--ink-muted);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+}
+
+.link-quiet:hover {
+    color: var(--ink);
+}
+
+/* ---- Toolbar ----
+   Label placement is explicit: stacked below 768px, inline above. It used to
+   be emergent — a wrapping flex row where the chip block dropped to its own
+   line once it stopped fitting, so three chips sat inline and four did not. */
+.toolbar {
+    display: grid;
+    gap: var(--space-4) var(--space-3);
+    padding-bottom: var(--space-4);
+    border-bottom: 1px solid var(--rule);
+}
+
+.toolbar-group,
+.toolbar-search {
+    display: grid;
+    gap: var(--space-2);
+    min-width: 0;
+}
+
+.toolbar-search-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2);
+    min-width: 0;
+}
+
+.toolbar-label {
+    font-family: var(--font-display);
+    font-size: var(--text-base);
+    font-weight: 400;
+    color: var(--ink);
+    white-space: nowrap;
+}
+
+/* The reset slot. Rendered last by the toolbar itself rather than placed
+   inside whichever filter group a template happened to pick, which is why the
+   control used to land in five different positions across five pages. */
+.toolbar-reset {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    justify-self: start;
+}
+
+/* One grid for the whole toolbar, not one per group: `display: contents`
+   promotes each group's label and control into the toolbar's own grid, so
+   every label shares a column and every control starts at the same x. Nested
+   grids sized their `max-content` column independently and left the controls
+   ragged. */
+@media (min-width: 768px) {
+    .toolbar {
+        grid-template-columns: max-content minmax(0, 1fr);
+        align-items: center;
+    }
+
+    .toolbar-group,
+    .toolbar-search {
+        display: contents;
+    }
+
+    .toolbar-label {
+        grid-column: 1;
+    }
+
+    .filter-chips,
+    .toolbar-control,
+    .toolbar-search-controls {
+        grid-column: 2;
+    }
+
+    .search-results-count,
+    .toolbar-reset {
+        grid-column: 1 / -1;
+    }
+
+    .toolbar-reset {
+        justify-self: end;
+    }
+}
+
+.toolbar-control {
+    justify-self: start;
+}
+
+.filter-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+}
+
+.filter-chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: var(--target-min);
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    padding: var(--space-1) var(--space-4);
+    border: 1px solid var(--rule);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--ink);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.filter-chip:hover {
+    border-color: var(--ink-muted);
+}
+
+.filter-chip.active {
+    background: var(--ink);
+    color: var(--inverse);
+    border-color: var(--ink);
+}
+
+.filter-hint {
+    font-size: var(--text-sm);
+    color: var(--ink-muted);
+    font-style: italic;
+}
+
+/* Grows to a comfortable measure and stops, so the Search and Clear buttons
+   stay on the same row as the field instead of being pushed beneath it. */
+.search-input {
+    flex: 0 1 20rem;
+    min-width: 0;
+    min-height: var(--target-min);
+    padding: var(--space-1) var(--space-3);
+    border: 1px solid var(--rule);
+    border-radius: 0;
+    background: var(--surface);
+    font-family: var(--font-body);
+    font-size: var(--text-base);
+    color: var(--ink);
+}
+
+.search-input:focus {
+    border-color: var(--ink-muted);
+}
+
+.search-results-count {
+    font-size: var(--text-sm);
+    color: var(--ink-muted);
+    font-style: italic;
+}
+
+/* ---- Selects ---- */
+.select {
+    appearance: none;
+    min-height: var(--target-min);
+    color: var(--ink);
+    padding: var(--space-1) var(--space-6) var(--space-1) var(--space-3);
+    border: 1px solid var(--rule);
+    border-radius: 0;
+    background-color: var(--surface);
+    font-family: var(--font-body);
+    font-size: var(--text-base);
+    cursor: pointer;
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23666' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right var(--space-2) center;
+}
+
+/* ---- Containers ---- */
+/* Settings' section chassis. It sits inside a `.stack`, so the space between
+   sections comes from the stack rather than a margin of its own. */
 .border-container {
-    margin-bottom: 48px;
-    padding: 32px;
-    border: 1px solid var(--charcoal);
-    background: var(--white);
+    padding: var(--space-6);
+    border: 1px solid var(--ink);
+    background: var(--surface);
 }
 
 .list-container {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: var(--space-3);
 }
 
-.container-empty-state {
-    text-align: center;
-    padding: 64px 32px;
-    color: var(--medium-gray);
-    font-style: italic;
-    border: 1px solid var(--pale-gray);
-}
-
+.container-empty-state,
 .container-loading-state {
     text-align: center;
-    padding: 64px 32px;
-    color: var(--medium-gray);
+    padding: var(--space-7) var(--space-6);
+    color: var(--ink-muted);
     font-style: italic;
-    border: 1px solid var(--pale-gray);
+    border: 1px solid var(--rule);
 }
-/** End Container Styling **/
 
-/** Modal Styles **/
+.load-more-container {
+    display: flex;
+    justify-content: center;
+    margin-top: var(--space-5);
+}
+
+/* ---- Forms ---- */
+.form-group {
+    margin-bottom: var(--space-5);
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: var(--space-1);
+    font-size: var(--text-sm);
+    font-weight: 500;
+    letter-spacing: var(--tracking-normal);
+}
+
+.form-group input[type="text"],
+.form-group input[type="password"],
+.form-group input[type="date"],
+.form-group textarea,
+.form-group select,
+.remind-days-input {
+    appearance: none;
+    min-height: 2.75rem;
+    color: var(--ink);
+    width: 100%;
+    padding: var(--space-3);
+    border: 1px solid var(--ink);
+    border-radius: 0;
+    background: var(--surface);
+    font-family: var(--font-body);
+    font-size: var(--text-base);
+}
+
+.form-group select {
+    cursor: pointer;
+    padding-right: var(--space-6);
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23333' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right var(--space-3) center;
+}
+
+.form-group textarea {
+    resize: vertical;
+    min-height: 6rem;
+}
+
+.form-group small {
+    display: block;
+    margin-top: var(--space-1);
+    color: var(--ink-muted);
+    font-size: var(--text-xs);
+    font-style: italic;
+}
+
+.form-group small a {
+    color: var(--ink);
+    text-underline-offset: 2px;
+}
+
+.remind-days-input {
+    width: 5em;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+/* One checkbox appearance. Native controls ignore `border`, so size and
+   accent-color are the whole styling surface. */
+input[type="checkbox"],
+input[type="radio"] {
+    width: 1.15rem;
+    height: 1.15rem;
+    accent-color: var(--ink);
+    cursor: pointer;
+    flex-shrink: 0;
+    margin: 0;
+    /* Native controls otherwise keep the browser's 13.33px default, which
+       shows up in a type audit as a size nobody chose. */
+    font-size: var(--text-base);
+}
+
+@media (pointer: coarse) {
+    input[type="checkbox"],
+    input[type="radio"] {
+        width: 1.4rem;
+        height: 1.4rem;
+    }
+}
+
+.checkbox-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    margin-top: var(--space-1);
+}
+
+.checkbox-label,
+.weekday-label,
+.radio-options label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-height: var(--target-min);
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--ink);
+    cursor: pointer;
+    user-select: none;
+}
+
+.weekday-checkboxes {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-top: var(--space-1);
+}
+
+.weekday-label {
+    padding: var(--space-1) var(--space-2);
+    border: 1px solid var(--rule);
+    background: var(--surface);
+}
+
+.radio-options {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    margin-top: var(--space-1);
+}
+
+.custom-recurrence-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    align-items: center;
+}
+
+/* ---- Modal ----
+   Every modal uses the same chassis: .modal-content > h3 + .modal-scroll >
+   .modal-body. The scroll wrapper's ::before/::after paint the fade that
+   signals more content, and only appear when content is actually hidden. */
 .modal-overlay {
     display: none;
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    inset: 0;
     background: rgba(0, 0, 0, 0.5);
     align-items: center;
     justify-content: center;
     z-index: 1000;
+    padding: var(--space-4);
 }
 
 .modal-content {
-    background: var(--white);
-    border: 1px solid var(--charcoal);
-    padding: 32px;
-    width: 90%;
+    background: var(--surface);
+    border: 1px solid var(--ink);
+    padding: var(--space-6);
+    width: 100%;
     max-width: 500px;
     max-height: 90vh;
     display: flex;
     flex-direction: column;
-    /* Fallback scroll for modals without a .modal-body wrapper. Modals that
-       use .modal-body never trigger this — their body flexes to fit. */
-    overflow: auto;
+}
+
+.modal-content--narrow {
+    max-width: 360px;
 }
 
 .modal-content h3 {
-    font-size: 1.3rem;
-    font-family: var(--header-font);
-    margin-bottom: 24px;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
+    margin-bottom: var(--space-5);
     flex-shrink: 0;
 }
 
-/* Wrapper positioned over the scroll viewport. Its ::before/::after paint a
-   fade in the modal's background colour over the top/bottom edges — a plain
-   overlay rather than a CSS mask.*/
 .modal-scroll {
     position: relative;
     flex: 1;
@@ -274,13 +786,11 @@ footer a:hover {
     flex-direction: column;
 }
 
-/* Scrollable inner area — the form and actions scroll together. */
 .modal-body {
     overflow-y: auto;
     flex: 1;
     min-height: 0;
-    /* Padding so content isn't clipped under the scrollbar. */
-    padding: 0 4px 0 0;
+    padding-right: var(--space-1);
 }
 
 .modal-scroll::before,
@@ -289,7 +799,7 @@ footer a:hover {
     position: absolute;
     left: 0;
     right: 0;
-    height: 32px;
+    height: var(--space-6);
     pointer-events: none;
     opacity: 0;
     transition: opacity 0.15s ease;
@@ -298,121 +808,41 @@ footer a:hover {
 
 .modal-scroll::before {
     top: 0;
-    background: linear-gradient(to bottom, var(--white), transparent);
+    background: linear-gradient(to bottom, var(--surface), transparent);
 }
 
 .modal-scroll::after {
     bottom: 0;
-    background: linear-gradient(to top, var(--white), transparent);
+    background: linear-gradient(to top, var(--surface), transparent);
 }
 
-/* Fade an edge only when content is actually hidden in that direction, so the
-   Save/Cancel buttons render crisp once you scroll to the bottom. */
 .modal-scroll[data-overflow-top]::before { opacity: 1; }
 .modal-scroll[data-overflow-bottom]::after { opacity: 1; }
 
 .modal-actions {
     display: flex;
-    gap: 12px;
-    margin-top: 24px;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    margin-top: var(--space-5);
 }
 
 .modal-delete {
     margin-left: auto;
 }
-/** End Modal Styles **/
 
-/** Form Styles **/
-.form-group {
-    margin-bottom: 20px;
-}
-
-.form-group label {
-    display: block;
-    margin-bottom: 6px;
-    font-size: 0.9rem;
-    font-weight: 500;
-    letter-spacing: 0.02em;
-}
-
-.form-group input[type="text"], .form-group input[type="password"], .form-group input[type="date"], .form-group textarea {
-    appearance: none;
-    box-sizing: border-box;
-    min-height: 2.75rem;
-    color: var(--charcoal);
-    width: 100%;
-    padding: 10px;
-    border: 1px solid var(--charcoal);
-    background: var(--white);
-    font-family: var(--body-font);
-    font-size: 1rem;
-}
-
-.form-group small {
-    display: block;
-    margin-top: 4px;
-    color: var(--medium-gray);
-    font-size: 0.8rem;
-    font-style: italic;
-}
-
-.form-group textarea {
-    resize: vertical;
-    min-height: 100px;
-}
-
-.form-group label input[type="checkbox"] {
-    margin-right: 6px;
-    vertical-align: middle;
-}
-
-.remind-days-input {
-    appearance: none;
-    box-sizing: border-box;
-    min-height: 2.75rem;
-    color: var(--charcoal);
-    width: 5em;
-    padding: 10px;
-    border: 1px solid var(--charcoal);
-    background: var(--white);
-    font-family: var(--body-font);
-    font-size: 1rem;
-    display: inline-block;
-    vertical-align: middle;
-}
-
-.form-group select {
-    appearance: none;
-    box-sizing: border-box;
-    min-height: 2.75rem;
-    color: var(--charcoal);
-    width: 100%;
-    padding: 10px;
-    border: 1px solid var(--charcoal);
-    background: var(--white);
-    font-family: var(--body-font);
-    font-size: 1rem;
-    cursor: pointer;
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23333' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: right 12px center;
-    padding-right: 32px;
-}
-/** End Form Styles **/
-
-/** Editable Item Styles **/
+/* ---- List rows ---- */
 .editable-item {
     display: flex;
-    gap: 16px;
-    padding: 16px;
-    border: 1px solid var(--pale-gray);
-    background: var(--white);
+    gap: var(--space-4);
+    padding: var(--space-4);
+    border: 1px solid var(--rule);
+    background: var(--surface);
     align-items: flex-start;
     transition: background 0.2s;
 }
 
 .editable-item:hover {
-    background: var(--off-white);
+    background: var(--surface-sunken);
 }
 
 .editable-item.completed {
@@ -420,7 +850,7 @@ footer a:hover {
 }
 
 .editable-item.completed .editable-item-title {
-    color: var(--medium-gray);
+    color: var(--ink-muted);
 }
 
 .editable-item-content {
@@ -429,198 +859,167 @@ footer a:hover {
 }
 
 .editable-item-title {
-    font-size: 1rem;
+    font-size: var(--text-base);
     font-weight: 500;
-    margin-bottom: 4px;
-    word-wrap: break-word;
+    margin-bottom: var(--space-1);
+    overflow-wrap: break-word;
 }
 
 .editable-item-actions {
     display: flex;
-    gap: 8px;
+    gap: var(--space-2);
     flex-shrink: 0;
 }
 
 .editable-item-description {
-    font-size: 0.9rem;
-    color: var(--medium-gray);
-    margin-bottom: 6px;
+    font-size: var(--text-sm);
+    color: var(--ink-muted);
+    margin-bottom: var(--space-1);
     font-style: italic;
-    word-wrap: break-word;
-}
-/** End Editable Item Styles **/
-
-/** Assignee Badge Styles **/
-.assignee-badge {
-    display: inline-block;
-    font-size: 0.7rem;
-    font-weight: 600;
-    color: var(--white);
-    padding: 2px 8px;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    vertical-align: middle;
-    margin-left: 8px;
+    overflow-wrap: break-word;
 }
 
 .assignee-label {
-    font-family: var(--body-font);
     font-style: italic;
-    font-size: 0.9rem;
-    color: var(--medium-gray);
-    margin-left: 6px;
-    vertical-align: baseline;
+    font-size: var(--text-sm);
+    color: var(--ink-muted);
+    margin-left: var(--space-1);
 }
-/** End Assignee Badge Styles **/
 
-/** Dashboard Page Styles **/
-/* Greeting */
+/* ---- Cards ---- */
+.card {
+    background: var(--surface);
+    border: 1px solid var(--ink);
+    padding: var(--space-5);
+    break-inside: avoid;
+}
+
+.card-header {
+    font-family: var(--font-display);
+    font-size: var(--text-lg);
+    font-weight: 600;
+    color: var(--ink);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wider);
+    border-bottom: 1px solid var(--ink);
+    padding-bottom: var(--space-2);
+    margin-bottom: var(--space-4);
+}
+
+.card-content {
+    font-size: var(--text-base);
+    line-height: var(--leading-normal);
+}
+
+.card-content p,
+.card-content ul,
+.card-content ol {
+    margin-bottom: var(--space-3);
+}
+
+.card-content ul,
+.card-content ol {
+    padding-left: var(--space-5);
+}
+
+.card-content p:last-child,
+.card-content ul:last-child,
+.card-content ol:last-child,
+.card-content li:last-child {
+    margin-bottom: 0;
+}
+
+.card-content li {
+    margin-bottom: var(--space-2);
+}
+
+.card-content strong {
+    font-weight: 600;
+    color: var(--ink-strong);
+}
+
+/** ============================================================
+    5. Page-specific
+    ============================================================ */
+
+/* ---- Dashboard ---- */
 .greeting {
-    font-size: 1.05rem;
+    font-size: var(--text-base);
     text-align: center;
-    margin-bottom: 24px;
-    color: var(--dark-gray);
+    margin-bottom: var(--space-5);
+    color: var(--ink-muted);
     font-style: italic;
 }
 
-/* Briefing Section */
 .briefing {
-    background: var(--charcoal);
-    color: var(--white);
-    padding: 20px 32px;
+    background: var(--ink);
+    color: var(--inverse);
+    padding: var(--space-5) var(--space-6);
     text-align: center;
-    font-size: 1rem;
-    font-weight: 400;
-    margin-bottom: 32px;
-    border: 1px solid var(--charcoal);
-    letter-spacing: 0.02em;
+    font-size: var(--text-base);
+    margin-bottom: var(--space-6);
+    border: 1px solid var(--ink);
+    letter-spacing: var(--tracking-normal);
 }
 
 .briefing-title {
     font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.1em;
-    margin-bottom: 8px;
-    font-size: 0.9rem;
+    letter-spacing: var(--tracking-wider);
+    margin-bottom: var(--space-2);
+    font-size: var(--text-sm);
 }
 
-/* Content Container and Cards */
 .dashboard-grid {
     display: flex;
     flex-direction: column;
-    gap: 24px;
+    gap: var(--space-5);
 }
 
-.card {
-    background: var(--white);
-    border: 1px solid var(--charcoal);
-    padding: 24px;
-    break-inside: avoid;
-}
-
-.card-header {
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: var(--charcoal);
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    border-bottom: 1px solid var(--charcoal);
-    padding-bottom: 8px;
-    margin-bottom: 16px;
-    font-family: var(--header-font);
-}
-
-.card-content {
-    font-size: 0.95rem;
-    line-height: 1.7;
-}
-
-.card-content p {
-    margin-bottom: 12px;
-    text-align: justify;
-}
-
-.card-content p:last-child {
-    margin-bottom: 0;
-}
-
-.card-content ul, .card-content ol {
-    padding-left: 24px;
-    margin-bottom: 12px;
-}
-
-.card-content ul:last-child, .card-content ol:last-child {
-    margin-bottom: 0;
-}
-
-.card-content li {
-    margin-bottom: 8px;
-}
-
-.card-content li:last-child {
-    margin-bottom: 0;
-}
-
-.card-content strong {
-    font-weight: 600;
-    color: var(--black);
-}
-
-.card-content em {
-    font-style: italic;
-}
-
-/* Schedule items */
 .schedule-item {
-    padding: 16px 0;
-    border-bottom: 1px solid var(--pale-gray);
+    padding: var(--space-4) 0;
+    border-bottom: 1px solid var(--rule);
 }
 
 .schedule-item:last-child {
     border-bottom: none;
+    padding-bottom: 0;
 }
 
 .schedule-time {
     font-weight: 600;
-    color: var(--medium-gray);
-    font-size: 0.9rem;
-    margin-bottom: 6px;
+    color: var(--ink-muted);
+    font-size: var(--text-sm);
+    margin-bottom: var(--space-1);
 }
 
 .schedule-title {
     font-weight: 500;
-    font-size: 1rem;
-    margin-bottom: 6px;
+    font-size: var(--text-base);
+    margin-bottom: var(--space-1);
 }
 
 .schedule-notes {
-    color: var(--medium-gray);
-    font-size: 0.9rem;
+    color: var(--ink-muted);
+    font-size: var(--text-sm);
     font-style: italic;
-    line-height: 1.5;
 }
 
-/* Featured schedule card */
-.card--featured {
-    border: 1px solid var(--charcoal);
-}
-
-/* STEM Concept of the Day card */
 .stem-field {
     text-transform: uppercase;
-    letter-spacing: 0.12em;
-    font-size: 0.75rem;
+    letter-spacing: var(--tracking-wider);
+    font-size: var(--text-xs);
     font-weight: 600;
-    color: var(--medium-gray);
-    margin-bottom: 4px;
+    color: var(--ink-muted);
+    margin-bottom: var(--space-1);
 }
 
 .stem-title {
-    font-family: var(--header-font);
-    font-size: 1.2rem;
+    font-family: var(--font-display);
+    font-size: var(--text-lg);
     font-weight: 600;
-    color: var(--black);
-    margin-bottom: 10px;
+    color: var(--ink-strong);
+    margin-bottom: var(--space-2);
 }
 
 .stem-activities {
@@ -630,8 +1029,8 @@ footer a:hover {
 }
 
 .stem-activities li {
-    padding: 10px 0;
-    border-bottom: 1px solid var(--pale-gray);
+    padding: var(--space-2) 0;
+    border-bottom: 1px solid var(--rule);
 }
 
 .stem-activities li:last-child {
@@ -642,288 +1041,57 @@ footer a:hover {
 .stem-audience {
     display: inline-block;
     font-weight: 600;
-    font-size: 0.8rem;
+    font-size: var(--text-xs);
     text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--medium-gray);
-    margin-right: 6px;
+    letter-spacing: var(--tracking-wide);
+    color: var(--ink-muted);
+    margin-right: var(--space-1);
 }
-/** End Dashboard Page Styles **/
 
-/**Todo Page Styles**/
+/* ---- Tasks ---- */
+/* Checking a task off is the primary gesture on this page, so the hit area is
+   a full target square even though the control itself stays small. */
 .todo-checkbox {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: var(--target-min);
+    min-height: var(--target-min);
     flex-shrink: 0;
-    padding-top: 2px;
-}
-
-.todo-checkbox input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
-    cursor: pointer;
-    border: 1px solid var(--charcoal);
-}
-
-.todo-meta {
-    font-size: 0.8rem;
-    color: var(--light-gray);
-    letter-spacing: 0.05em;
 }
 
 .todo-due-date {
-    font-size: 0.85rem;
-    color: var(--medium-gray);
+    font-size: var(--text-sm);
+    color: var(--ink-muted);
     font-weight: 500;
-    letter-spacing: 0.02em;
-    margin-top: 4px;
+    letter-spacing: var(--tracking-normal);
+    margin-top: var(--space-1);
 }
 
 .todo-due-date.overdue {
-    color: var(--charcoal);
+    color: var(--ink);
     font-weight: 600;
 }
 
-.todo-completed-date {
-    font-size: 0.85rem;
-    color: var(--light-gray);
-    letter-spacing: 0.02em;
+.todo-completed-date,
+.shopping-completed-at {
+    font-size: var(--text-sm);
+    color: var(--ink-subtle);
+    letter-spacing: var(--tracking-normal);
     font-style: italic;
-    margin-top: 4px;
-}
-
-/* Toggle between a page and its archive — current tasks and completed tasks,
-   the shopping list and purchased items. Sits directly above the toolbar, in
-   the same spot on both pages of a pair. */
-.view-switch {
-    display: inline-block;
-    font-family: var(--body-font);
-    font-size: 0.9rem;
-    color: var(--medium-gray);
-    text-decoration: underline;
-    text-underline-offset: 3px;
-    margin-top: 4px;
-}
-
-.view-switch:hover {
-    color: var(--charcoal);
-}
-
-/* A quiet, one-line explanation under a view-switch link — used where a page
-   would otherwise silently withhold something, e.g. the 30-day retention on
-   the purchased items archive. */
-.page-note {
-    font-family: var(--body-font);
-    font-size: 0.85rem;
-    color: var(--medium-gray);
-    font-style: italic;
-    margin-top: 8px;
-}
-
-.load-more-container {
-    display: flex;
-    justify-content: center;
-    margin-top: 24px;
-}
-
-.btn-load-more {
-    font-family: var(--body-font);
-    font-size: 0.9rem;
-    padding: 8px 24px;
-    border: 1px solid var(--pale-gray);
-    background: var(--white);
-    color: var(--charcoal);
-    cursor: pointer;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    transition: border-color 0.15s, background 0.15s;
-}
-
-.btn-load-more:hover:not(:disabled) {
-    border-color: var(--medium-gray);
-    background: var(--off-white);
-}
-
-.btn-load-more:disabled {
-    color: var(--light-gray);
-    cursor: default;
-}
-
-
-.filter-toolbar {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: 32px;
-    margin-bottom: 32px;
-    padding: 20px 0;
-    border-bottom: 1px solid var(--pale-gray);
-}
-
-.toolbar-group {
-    display: flex;
-    align-items: baseline;
-    gap: 12px;
-    flex-wrap: wrap;
-}
-
-.toolbar-group label {
-    font-family: var(--header-font);
-    font-size: 1.05rem;
-    font-weight: 400;
-    color: var(--charcoal);
-    white-space: nowrap;
-}
-
-.toolbar-group select {
-    -webkit-appearance: none;
-    appearance: none;
-    box-sizing: border-box;
-    min-height: 2.25rem;
-    color: var(--charcoal);
-    padding: 4px 28px 4px 10px;
-    border: 1px solid var(--pale-gray);
-    border-radius: 0;
-    background: var(--white);
-    font-family: var(--body-font);
-    font-size: 1rem;
-    cursor: pointer;
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23999' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: right 8px center;
-}
-.filter-chips {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: 8px;
-}
-
-.filter-chip {
-    font-family: var(--body-font);
-    font-size: 0.9rem;
-    padding: 4px 14px;
-    border: 1px solid var(--pale-gray);
-    border-radius: 20px;
-    background: var(--white);
-    color: var(--charcoal);
-    cursor: pointer;
-    transition: background 0.15s, border-color 0.15s;
-    white-space: nowrap;
-}
-
-.filter-chip:hover {
-    border-color: var(--medium-gray);
-}
-
-.filter-chip:focus {
-    outline: none;
-    border-color: var(--pale-gray);
-}
-
-.filter-chip.active {
-    background: var(--charcoal);
-    color: var(--white);
-    border-color: var(--charcoal);
-}
-
-.filter-chip.active:focus {
-    outline: none;
-    border-color: var(--charcoal);
-}
-
-.filter-clear {
-    font-family: var(--body-font);
-    font-size: 0.85rem;
-    padding: 4px 10px;
-    border: none;
-    background: none;
-    color: var(--medium-gray);
-    cursor: pointer;
-    white-space: nowrap;
-    text-decoration: underline;
-    text-underline-offset: 2px;
-}
-
-.filter-clear:hover {
-    color: var(--charcoal);
-}
-
-.filter-clear:focus {
-    outline: none;
-    color: var(--medium-gray);
-}
-
-/* Keyword search: its own full-width row at the bottom of the toolbar, below
-   both the assignee filters and the sort control. */
-.toolbar-search {
-    flex-basis: 100%;
-}
-
-.search-input {
-    box-sizing: border-box;
-    min-height: 2.25rem;
-    min-width: 240px;
-    padding: 4px 10px;
-    border: 1px solid var(--pale-gray);
-    border-radius: 0;
-    background: var(--white);
-    font-family: var(--body-font);
-    font-size: 1rem;
-    color: var(--charcoal);
-}
-
-.search-input:focus {
-    outline: none;
-    border-color: var(--medium-gray);
-}
-
-.search-btn {
-    font-family: var(--body-font);
-    font-size: 0.9rem;
-    padding: 8px 24px;
-    border: 1px solid var(--pale-gray);
-    background: var(--white);
-    color: var(--charcoal);
-    cursor: pointer;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    transition: border-color 0.15s, background 0.15s;
-}
-
-.search-btn:hover:not(:disabled) {
-    border-color: var(--medium-gray);
-}
-
-.search-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-}
-
-/* Deemphasized match count, shown only while a search is active. Sits on its
-   own row below the search bar and above the toolbar's bottom divider. */
-.search-results-count {
-    flex-basis: 100%;
-    font-family: var(--body-font);
-    font-size: 0.85rem;
-    color: var(--medium-gray);
-    font-style: italic;
-}
-
-.header-actions {
-    display: flex;
-    gap: 12px;
+    margin-top: var(--space-1);
 }
 
 .todo-recurring-icon {
     flex-shrink: 0;
-    font-size: 1.1rem;
-    color: var(--medium-gray);
-    padding-top: 2px;
+    font-size: var(--text-base);
+    color: var(--ink-muted);
 }
 
 .recurring-indicator {
-    font-size: 0.85rem;
-    color: var(--light-gray);
-    margin-left: 4px;
+    font-size: var(--text-sm);
+    color: var(--ink-subtle);
+    margin-left: var(--space-1);
 }
 
 .recurring-template {
@@ -931,43 +1099,33 @@ footer a:hover {
 }
 
 .recurring-schedule {
-    font-size: 0.85rem;
-    color: var(--medium-gray);
+    font-size: var(--text-sm);
+    color: var(--ink-muted);
     font-style: italic;
-    margin-top: 2px;
 }
 
 .recurring-meta {
-    font-size: 0.8rem;
-    color: var(--light-gray);
-    margin-left: 6px;
+    font-size: var(--text-xs);
+    color: var(--ink-subtle);
+    margin-left: var(--space-1);
 }
 
 .recurring-paused {
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--light-gray);
-    margin-left: 8px;
+    letter-spacing: var(--tracking-wide);
+    color: var(--ink-subtle);
+    margin-left: var(--space-2);
 }
-/**End Todo Page Styles**/
 
-/** Shopping List Styles **/
-/* Anchor for the autocomplete dropdown, which is absolutely positioned against
-   it. Lives in the item modal, so it must not establish any clipping of its own. */
+/* ---- Shopping ---- */
 .autocomplete-wrap {
     position: relative;
 }
 
-/* Autocomplete dropdown. A native <datalist> is nearly free but cannot render
-   the two-part name/store row or the per-row dismiss affordance, and store
-   affinity is the main thing that makes this worth building.
-
-   The height cap is load-bearing: .modal-body is a scroll box, so the menu is
-   clipped by it rather than spilling down the page. 240px leaves the menu room
-   to open fully inside the modal body, and highlightSuggestion()'s
-   scrollIntoView({ block: 'nearest' }) handles keyboard nav within it. */
+/* The height cap is load-bearing: .modal-body is a scroll box, so the menu is
+   clipped by it rather than spilling down the page. */
 .autocomplete-menu {
     position: absolute;
     top: 100%;
@@ -975,10 +1133,10 @@ footer a:hover {
     right: 0;
     z-index: 20;
     margin-top: -1px;
-    max-height: 240px;
+    max-height: 15rem;
     overflow-y: auto;
-    border: 1px solid var(--charcoal);
-    background: var(--white);
+    border: 1px solid var(--ink);
+    background: var(--surface);
     display: none;
 }
 
@@ -988,11 +1146,12 @@ footer a:hover {
 
 .autocomplete-option {
     display: flex;
-    align-items: baseline;
-    gap: 8px;
-    padding: 8px 10px;
+    align-items: center;
+    gap: var(--space-2);
+    min-height: var(--target-min);
+    padding: var(--space-2) var(--space-3);
     cursor: pointer;
-    border-bottom: 1px solid var(--silver);
+    border-bottom: 1px solid var(--rule-subtle);
 }
 
 .autocomplete-option:last-child {
@@ -1001,20 +1160,19 @@ footer a:hover {
 
 .autocomplete-option.active,
 .autocomplete-option:hover {
-    background: var(--off-white);
+    background: var(--surface-sunken);
 }
 
 .autocomplete-name {
     flex: 1;
     min-width: 0;
-    font-size: 1rem;
-    word-wrap: break-word;
+    overflow-wrap: break-word;
 }
 
 .autocomplete-store {
     font-style: italic;
-    font-size: 0.85rem;
-    color: var(--medium-gray);
+    font-size: var(--text-sm);
+    color: var(--ink-muted);
     white-space: nowrap;
 }
 
@@ -1022,16 +1180,16 @@ footer a:hover {
     flex-shrink: 0;
     border: none;
     background: none;
-    color: var(--light-gray);
-    font-family: var(--body-font);
-    font-size: 1rem;
+    color: var(--ink-subtle);
+    font-family: var(--font-body);
+    font-size: var(--text-base);
     line-height: 1;
-    padding: 2px 4px;
+    padding: var(--space-1) var(--space-2);
     cursor: pointer;
 }
 
 .autocomplete-dismiss:hover {
-    color: var(--charcoal);
+    color: var(--ink);
 }
 
 /* Store group heading: the identity carrier, since stores have no colour —
@@ -1039,8 +1197,8 @@ footer a:hover {
 .shopping-group-header {
     display: flex;
     align-items: baseline;
-    gap: 12px;
-    margin: 32px 0 12px;
+    gap: var(--space-3);
+    margin: var(--space-6) 0 var(--space-3);
 }
 
 .shopping-group-header:first-child {
@@ -1048,471 +1206,173 @@ footer a:hover {
 }
 
 .shopping-group-name {
-    font-family: var(--header-font);
-    font-size: 1rem;
+    font-family: var(--font-display);
+    font-size: var(--text-base);
     font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.1em;
+    letter-spacing: var(--tracking-wider);
     white-space: nowrap;
 }
 
 .shopping-group-rule {
     flex: 1;
-    border-bottom: 1px solid var(--pale-gray);
+    border-bottom: 1px solid var(--rule);
 }
 
 .shopping-group-count {
-    font-size: 0.8rem;
-    letter-spacing: 0.05em;
-    color: var(--light-gray);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wide);
+    color: var(--ink-subtle);
     white-space: nowrap;
-}
-
-.shopping-completed-at {
-    font-size: 0.85rem;
-    color: var(--light-gray);
-    letter-spacing: 0.02em;
-    font-style: italic;
-    margin-top: 4px;
-}
-
-/* Stands in for the chip row on a fresh database, so store management
-   introduces itself from the toolbar it already lives in. */
-.filter-hint {
-    font-family: var(--body-font);
-    font-size: 0.85rem;
-    color: var(--medium-gray);
-    font-style: italic;
 }
 
 .store-manage-row {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 10px 0;
-    border-bottom: 1px solid var(--silver);
+    gap: var(--space-2);
+    padding: var(--space-2) 0;
+    border-bottom: 1px solid var(--rule-subtle);
 }
 
 .store-manage-row input[type="text"] {
     appearance: none;
-    box-sizing: border-box;
     flex: 1;
     min-width: 0;
-    min-height: 2.5rem;
-    padding: 8px 10px;
-    border: 1px solid var(--pale-gray);
-    background: var(--white);
-    color: var(--charcoal);
-    font-family: var(--body-font);
-    font-size: 1rem;
-}
-/** End Shopping List Styles **/
-
-/** Dinner Planner Styles **/
-.plan-card {
-    padding: 20px;
-    border: 1px solid var(--pale-gray);
-    background: var(--white);
-    transition: background 0.2s;
+    min-height: var(--target-min);
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--rule);
+    background: var(--surface);
+    color: var(--ink);
+    font-family: var(--font-body);
+    font-size: var(--text-base);
 }
 
-.plan-card:hover {
-    background: var(--off-white);
-}
-
-.plan-date {
-    font-size: 0.85rem;
-    color: var(--medium-gray);
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    margin-bottom: 8px;
-}
-
-.plan-content {
-    font-size: 1rem;
-    margin-bottom: 12px;
-    line-height: 1.6;
-}
-
-.plan-actions {
-    display: flex;
-    gap: 12px;
-}
-
-.plan-meta-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
-    margin-bottom: 10px;
-}
-
-.plan-meta {
-    font-size: 0.85rem;
-    color: var(--medium-gray);
-    font-style: italic;
-}
-
-.checkbox-group {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-    margin-top: 4px;
-}
-
-.checkbox-label {
-    font-family: var(--body-font);
-    font-size: 0.9rem;
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    cursor: pointer;
-    color: var(--charcoal);
-}
-
-.checkbox-label input[type="checkbox"] {
-    accent-color: var(--charcoal);
-}
-
-.form-actions {
-    display: flex;
-    gap: 12px;
-    align-items: center;
-}
-/** End Dinner Planner Styles **/
-
-/** Nav Dropdown Styles **/
-.nav-dropdown {
-    display: inline-block;
-    position: relative;
-    margin: 0 8px;
-}
-
-.nav-dropdown-btn {
-    color: var(--charcoal);
-    text-decoration: none;
-    padding: 8px 16px;
-    border: 1px solid var(--charcoal);
-    display: inline-block;
-    transition: background 0.2s;
-    font-size: 0.9rem;
-    letter-spacing: 0.05em;
-    font-family: var(--body-font);
-    cursor: pointer;
-    background: var(--white);
-    line-height: inherit;
-}
-
-.nav-dropdown-btn::after {
-    content: "";
-    display: inline-block;
-    margin-left: 6px;
-    border-left: 4px solid transparent;
-    border-right: 4px solid transparent;
-    border-top: 5px solid var(--charcoal);
-    vertical-align: middle;
-}
-
-.nav-dropdown-btn:hover,
-.nav-dropdown-btn.active {
-    background: var(--off-white);
-}
-
-.nav-dropdown-btn.active {
-    background: var(--charcoal);
-    color: var(--white);
-}
-
-.nav-dropdown-content {
-    display: none;
-    position: absolute;
-    left: 0;
-    top: 100%;
-    background: var(--white);
-    border: 1px solid var(--charcoal);
-    border-top: none;
-    min-width: 180px;
-    z-index: 100;
-}
-
-.nav-dropdown-content a {
-    display: block;
-    padding: 8px 16px;
-    color: var(--charcoal);
-    text-decoration: none;
-    font-size: 0.9rem;
-    letter-spacing: 0.05em;
-    border: none;
-    margin: 0;
-    transition: background 0.15s;
-}
-
-.nav-dropdown-content a:hover {
-    background: var(--off-white);
-}
-
-.nav-dropdown-content a.active {
-    background: var(--charcoal);
-    color: var(--white);
-}
-
-/* Click toggle (mobile) */
-.nav-dropdown.open .nav-dropdown-content {
-    display: block;
-}
-
-/* Desktop: show on hover */
-@media (min-width: 768px) {
-    .nav-dropdown:hover .nav-dropdown-content {
-        display: block;
-    }
-}
-
-/* Mobile layout: stack nav vertically */
-@media screen and (max-width: 767px) {
-    nav {
-        display: flex;
-        flex-direction: column;
-        gap: 12px;
-        align-items: stretch;
-    }
-
-    nav > a {
-        margin: 0;
-    }
-
-    .nav-dropdown {
-        margin: 0;
-        width: 100%;
-        text-align: center;
-    }
-
-    .nav-dropdown-btn {
-        width: 100%;
-    }
-
-    .nav-dropdown-content {
-        position: static;
-        border: 1px solid var(--charcoal);
-        border-top: none;
-        margin-top: -1px;
-    }
-}
-/** End Nav Dropdown Styles **/
-
-/** Star Rating Styles **/
-.star-rating {
+/* ---- Meal history ---- */
+.star-rating,
+.star-rating-input {
     display: inline-flex;
-    gap: 2px;
+    gap: var(--space-1);
+    user-select: none;
+}
+
+.star-rating {
     cursor: default;
 }
 
-.star-rating .star {
-    font-size: 1.1rem;
-    color: var(--pale-gray);
-    user-select: none;
-}
-
-.star-rating .star.filled {
-    color: var(--charcoal);
-}
-
-/* Interactive star rating (for review modal) */
 .star-rating-input {
-    display: inline-flex;
-    gap: 4px;
     cursor: pointer;
 }
 
+.star-rating .star,
 .star-rating-input .star {
-    font-size: 1.4rem;
-    color: var(--pale-gray);
+    color: var(--rule);
     transition: color 0.1s;
-    user-select: none;
 }
 
+.star-rating .star { font-size: var(--text-base); }
+.star-rating-input .star { font-size: var(--text-lg); }
+
+.star-rating .star.filled,
 .star-rating-input .star.filled {
-    color: var(--charcoal);
+    color: var(--ink);
 }
 
 .star-rating-input .star.hover {
-    color: var(--medium-gray);
+    color: var(--ink-muted);
 }
-/** End Star Rating Styles **/
 
-/** Meal History Styles **/
 .history-card {
-    padding: 16px;
-    border: 1px solid var(--pale-gray);
-    background: var(--white);
+    padding: var(--space-4);
+    border: 1px solid var(--rule);
+    background: var(--surface);
     transition: background 0.2s;
 }
 
 .history-card:hover {
-    background: var(--off-white);
+    background: var(--surface-sunken);
 }
 
 .history-card-header {
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
-    align-items: flex-start;
-    gap: 16px;
-    margin-bottom: 8px;
+    align-items: baseline;
+    gap: var(--space-2) var(--space-4);
+    margin-bottom: var(--space-2);
 }
 
 .history-card-title {
-    font-size: 1rem;
+    font-size: var(--text-base);
     font-weight: 500;
-    word-wrap: break-word;
+    overflow-wrap: break-word;
 }
 
-.history-card-date {
-    font-size: 0.85rem;
-    color: var(--medium-gray);
-    letter-spacing: 0.05em;
+/* The date label on a list row. Shared by Meal Planner and Meal History:
+   they had two class names for one idea, and the planner's went unstyled the
+   moment its page-specific block was retired. */
+.meta-date {
+    font-size: var(--text-sm);
+    color: var(--ink-muted);
+    letter-spacing: var(--tracking-wide);
     text-transform: uppercase;
     flex-shrink: 0;
 }
 
-.history-card-meta {
-    font-size: 0.9rem;
-    color: var(--medium-gray);
-    font-style: italic;
-    margin-bottom: 8px;
-}
-
 .history-card-review {
-    font-size: 0.95rem;
-    color: var(--dark-gray);
+    font-size: var(--text-sm);
+    color: var(--ink-muted);
     font-style: italic;
-    margin-top: 8px;
-    padding-top: 8px;
-    border-top: 1px solid var(--silver);
-    line-height: 1.6;
+    margin-top: var(--space-2);
+    padding-top: var(--space-2);
+    border-top: 1px solid var(--rule-subtle);
 }
 
 .history-card-rating-row {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
-    gap: 8px;
-    margin-top: 6px;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
 }
 
 .no-review-text {
-    font-size: 0.85rem;
-    color: var(--light-gray);
+    font-size: var(--text-sm);
+    color: var(--ink-subtle);
     font-style: italic;
 }
-/** End Meal History Styles **/
 
-/** Custom Recurrence Styles **/
-.custom-recurrence-row {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-}
-
-.weekday-checkboxes {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-top: 4px;
-}
-
-.weekday-label {
-    font-family: var(--body-font);
-    font-size: 0.9rem;
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    cursor: pointer;
-    color: var(--charcoal);
-    padding: 4px 8px;
-    border: 1px solid var(--light-gray);
-    background: var(--white);
-    user-select: none;
-}
-
-.weekday-label input[type="checkbox"],
-.weekday-label input[type="radio"] {
-    accent-color: var(--charcoal);
-    margin: 0;
-}
-
-/* A vertical list of plain (borderless) radio options — used for the custom
-   recurrence anchor and the monthly "day vs. weekday" mode selectors. */
-.radio-options {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    margin-top: 6px;
-}
-
-.radio-options label {
-    font-family: var(--body-font);
-    font-size: 0.9rem;
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    cursor: pointer;
-    color: var(--charcoal);
-    user-select: none;
-}
-
-.radio-options input[type="radio"] {
-    accent-color: var(--charcoal);
-    margin: 0;
-}
-/** End Custom Recurrence Styles **/
-
-/** Settings Page Styles **/
-.settings-actions {
-    margin-top: 24px;
-}
-
-.settings-status {
-    display: inline-block;
-    margin-left: 12px;
-    font-size: 0.85rem;
-    font-style: italic;
-    color: var(--medium-gray);
-    opacity: 0;
-    transition: opacity 0.3s;
-}
-
-.settings-status.visible {
-    opacity: 1;
-}
-
-.llm-fields-local, .llm-fields-anthropic {
+/* ---- Settings ---- */
+.llm-fields-local,
+.llm-fields-anthropic {
     display: none;
 }
 
-.llm-fields-local.active, .llm-fields-anthropic.active {
+.llm-fields-local.active,
+.llm-fields-anthropic.active {
     display: block;
 }
 
-/* Family Member Badge */
-.member-badge {
-    width: 32px;
-    height: 32px;
-    flex-shrink: 0;
-    margin-top: 2px;
+.ai-field-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-3);
+    margin-top: var(--space-3);
 }
 
-/* Verification Modal */
 .verify-status {
     text-align: center;
-    padding: 32px 0 8px;
+    padding: var(--space-6) 0 var(--space-2);
 }
 
 .verify-spinner {
-    width: 28px;
-    height: 28px;
-    border: 2px solid var(--silver);
-    border-top-color: var(--charcoal);
+    width: 1.75rem;
+    height: 1.75rem;
+    border: 2px solid var(--rule-subtle);
+    border-top-color: var(--ink);
     border-radius: 50%;
     animation: verify-spin 0.8s linear infinite;
-    margin: 0 auto 20px;
+    margin: 0 auto var(--space-5);
 }
 
 @keyframes verify-spin {
@@ -1520,204 +1380,179 @@ footer a:hover {
 }
 
 .verify-icon {
-    font-size: 1.6rem;
-    margin-bottom: 12px;
-    color: var(--charcoal);
+    font-size: var(--text-xl);
+    margin-bottom: var(--space-3);
+    color: var(--ink);
     font-weight: 600;
 }
 
 .verify-message {
-    font-family: var(--body-font);
-    font-size: 1rem;
-    color: var(--dark-gray);
+    font-size: var(--text-base);
+    color: var(--ink-muted);
     font-style: italic;
 }
 
 .verify-detail {
-    font-family: var(--body-font);
-    font-size: 0.85rem;
-    color: var(--medium-gray);
-    margin-top: 12px;
+    font-size: var(--text-sm);
+    color: var(--ink-muted);
+    margin-top: var(--space-3);
     word-break: break-word;
-    max-height: 120px;
+    max-height: 7.5rem;
     overflow-y: auto;
 }
 
-/* AI Settings Version History */
-.ai-field-actions {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    margin-top: 10px;
-}
-
-.btn-ghost {
-    border: none;
-    background: transparent;
-    color: var(--medium-gray);
-    font-family: var(--body-font);
-    font-size: 0.9rem;
-    letter-spacing: 0.02em;
-    text-decoration: underline;
-    cursor: pointer;
-    padding: 10px 8px;
-    transition: color 0.2s;
-}
-
-.btn-ghost:hover {
-    color: var(--charcoal);
-}
-
+/* No max-height or overflow of its own: .modal-body is the scroll box now, and
+   a second one nested inside it would trap the wheel. */
 .history-list {
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    max-height: 55vh;
-    overflow-y: auto;
+    gap: var(--space-3);
 }
 
 .history-item {
-    border: 1px solid var(--pale-gray);
-    padding: 12px 16px;
+    border: 1px solid var(--rule);
+    padding: var(--space-3) var(--space-4);
     cursor: pointer;
     transition: border-color 0.2s;
 }
 
 .history-item.selected {
-    border-color: var(--charcoal);
+    border-color: var(--ink);
 }
 
 .history-item-header {
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: var(--space-2);
 }
 
 .history-radio {
-    color: var(--charcoal);
+    color: var(--ink);
     flex-shrink: 0;
 }
 
 .history-timestamp {
-    font-family: var(--body-font);
-    font-size: 0.9rem;
-    color: var(--charcoal);
+    font-size: var(--text-sm);
+    color: var(--ink);
 }
 
 .history-current-badge {
-    border: 1px solid var(--charcoal);
-    padding: 2px 8px;
-    font-family: var(--body-font);
-    font-size: 0.7rem;
+    border: 1px solid var(--ink);
+    padding: 0 var(--space-2);
+    font-size: var(--text-xs);
     text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--charcoal);
+    letter-spacing: var(--tracking-wider);
+    color: var(--ink);
 }
 
 .history-value-toggle {
     border: none;
     background: transparent;
-    color: var(--medium-gray);
-    font-family: var(--body-font);
-    font-size: 0.85rem;
+    color: var(--ink-muted);
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
     cursor: pointer;
-    padding: 6px 0 0 26px;
-    transition: color 0.2s;
+    padding: var(--space-1) 0 0 var(--space-6);
+    text-decoration: underline;
+    text-underline-offset: 3px;
 }
 
 .history-value-toggle:hover {
-    color: var(--charcoal);
+    color: var(--ink);
 }
 
 .history-value {
-    margin: 8px 0 0 26px;
-    padding: 12px;
-    border: 1px solid var(--pale-gray);
-    background: var(--off-white);
-    font-family: var(--body-font);
-    font-size: 0.9rem;
-    color: var(--charcoal);
+    margin: var(--space-2) 0 0 var(--space-6);
+    padding: var(--space-3);
+    border: 1px solid var(--rule);
+    background: var(--surface-sunken);
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--ink);
     white-space: pre-wrap;
     word-break: break-word;
 }
 
-/** End Settings Page Styles **/
-
-/** Responsive Design **/
-/* Desktop */
-@media screen and (min-width: 1024px) {
-    body {
-        padding: 64px 48px;
-        max-width: 900px;
-    }
-
-    .header h1 {
-        font-size: 3.5rem;
-    }
+/* Inline literals in help text. Without this they fall back to the browser's
+   monospace default, a third font family the design never chose. */
+code {
+    font-family: var(--font-body);
+    font-style: normal;
+    background: var(--surface-sunken);
+    padding: 0 var(--space-1);
+    border: 1px solid var(--rule-subtle);
 }
 
-/* Tablet */
-@media screen and (min-width: 768px) and (max-width: 1023px) {
-    body {
-        padding: 48px 40px;
-        max-width: 750px;
-    }
-
-    .header h1 {
-        font-size: 2.5rem;
-    }
-}
-
-/* Mobile */
+/** ============================================================
+    6. Responsive and print
+    ============================================================ */
 @media screen and (max-width: 767px) {
-    body {
-        padding: 24px 16px;
-    }
-
+    /* Density: the wordmark and a four-item stacked nav used to consume the
+       whole first screen, so no page showed content above the fold. */
     .header h1 {
-        font-size: 3rem;
-        letter-spacing: 0.1em;
+        font-size: var(--text-xl);
+        letter-spacing: var(--tracking-wider);
     }
 
-    .greeting {
-        font-size: 1rem;
+    .header {
+        padding-bottom: var(--space-4);
+        margin-bottom: var(--space-4);
+    }
+
+    nav {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        margin-bottom: var(--space-4);
+        padding-bottom: var(--space-4);
+    }
+
+    .nav-dropdown {
+        display: flex;
+    }
+
+    .nav-dropdown-btn {
+        width: 100%;
+    }
+
+    /* Tighter block rhythm on a phone. The generous desktop spacing is what
+       pushed the first row of every list below the fold. */
+    .stack > * + * {
+        margin-top: var(--space-5);
+    }
+
+    .toolbar {
+        gap: var(--space-3);
     }
 
     .briefing {
-        font-size: 0.95rem;
-        padding: 16px 20px;
+        padding: var(--space-4) var(--space-5);
     }
 
     .card {
-        padding: 20px;
+        padding: var(--space-4);
     }
 
-    .card-content {
-        text-align: left;
-    }
-
-    .card-content p {
-        text-align: left;
-    }
-
-    .header-actions {
-        gap: 8px;
+    .container-empty-state,
+    .container-loading-state {
+        padding: var(--space-6) var(--space-4);
     }
 }
 
-/* Print styles */
 @media print {
     body {
-        background: white;
+        background: var(--surface);
         padding: 0;
+        max-width: none;
     }
 
-    .header h1 {
-        font-size: 2.5rem;
+    nav,
+    .page-header-actions,
+    .toolbar,
+    footer {
+        display: none;
     }
 
     .card {
         page-break-inside: avoid;
     }
 }
-/** End Responsive Design **/

--- a/templates/_meal_edit_modal.html
+++ b/templates/_meal_edit_modal.html
@@ -9,6 +9,8 @@
 <div class="modal-overlay" id="modal-overlay">
     <div class="modal-content">
         <h3 id="modal-title">Add Meal Plan</h3>
+        <div class="modal-scroll">
+        <div class="modal-body">
         <form id="plan-form">
             <input type="hidden" id="plan-edit-id">
             <div class="form-group">
@@ -41,10 +43,12 @@
                 </select>
             </div>
             <div class="modal-actions">
-                <button type="submit" class="btn-primary">Save</button>
-                <button type="button" class="btn-cancel" id="btn-cancel">Cancel</button>
-                <button type="button" class="btn-delete modal-delete" id="btn-delete-plan" style="display:none">Delete</button>
+                <button type="submit" class="btn">Save</button>
+                <button type="button" class="btn btn--secondary" id="btn-cancel">Cancel</button>
+                <button type="button" class="btn btn--secondary modal-delete" id="btn-delete-plan" style="display:none">Delete</button>
             </div>
         </form>
+        </div>
+        </div>
     </div>
 </div>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -29,6 +29,10 @@
         </div>
     </nav>
 
+    <!-- The dashboard is the one page with no <h2>: the wordmark and today's
+         date above are already its title, so a second one would only repeat
+         them. It uses the same .page/.stack primitives as everywhere else. -->
+    <div class="page stack">
     <!-- Greeting -->
     <div class="greeting">{{greeting}}</div>
 
@@ -48,6 +52,7 @@
         </section>
 
         {{stem_section}}
+    </div>
     </div>
 
     <footer>

--- a/templates/dinner_planner.html
+++ b/templates/dinner_planner.html
@@ -29,25 +29,29 @@
         </div>
     </nav>
 
-    <div class="section-container">
-        <div class="header-container">
-            <h2>Meal Planner</h2>
-            <div class="header-actions">
-                <button class="btn-add" id="btn-add-meal">Add Meal</button>
+    <div class="page stack">
+        <header class="page-header">
+            <div class="page-header-row">
+                <h2>Meal Planner</h2>
+                <div class="page-header-actions">
+                    <button class="btn" id="btn-add-meal">Add Meal</button>
+                </div>
             </div>
-        </div>
+        </header>
 
         <!-- Filter toolbar (filters first; this page has no sort control) -->
-        <div class="filter-toolbar">
+        <div class="toolbar">
             <div class="toolbar-group">
-                <label>Meal Type</label>
-                <div class="filter-chips" id="meal-type-filters">
+                <span class="toolbar-label" id="meal-type-label">Meal Type</span>
+                <div class="filter-chips" id="meal-type-filters" role="group" aria-labelledby="meal-type-label">
                     <button type="button" class="filter-chip" data-meal="Breakfast">Breakfast</button>
                     <button type="button" class="filter-chip" data-meal="Lunch">Lunch</button>
                     <button type="button" class="filter-chip" data-meal="Dinner">Dinner</button>
                     <button type="button" class="filter-chip" data-meal="Snacks">Snacks</button>
                 </div>
-                <button type="button" class="filter-clear" id="filter-clear">Clear Filters</button>
+            </div>
+            <div class="toolbar-reset">
+                <button type="button" class="btn btn--quiet" id="filter-clear">Clear Filters</button>
             </div>
         </div>
 
@@ -59,6 +63,7 @@
     <!-- Shared meal add/edit modal (see templates/_meal_edit_modal.html) -->
     {% include "_meal_edit_modal.html" %}
 
+    <script src="/static/modal.js?v={{ css_version }}"></script>
     <script src="/static/meal_edit_modal.js?v={{ css_version }}"></script>
     <script>
         // State
@@ -181,10 +186,10 @@
                         <div class="editable-item-content">
                             <div class="editable-item-title"><strong>${escapeHtml(mealType)}:</strong> ${escapeHtml(plan.plan)}</div>
                             ${metaHtml}
-                            <div class="plan-date">${escapeHtml(formatDate(plan.date))}</div>
+                            <div class="meta-date">${escapeHtml(formatDate(plan.date))}</div>
                         </div>
                         <div class="editable-item-actions">
-                            <button class="btn-edit" onclick="openEditModal(${plan.id})">Edit</button>
+                            <button class="btn btn--sm" onclick="openEditModal(${plan.id})">Edit</button>
                         </div>
                     </div>
                 `;

--- a/templates/meal_history.html
+++ b/templates/meal_history.html
@@ -29,16 +29,18 @@
         </div>
     </nav>
 
-    <div class="section-container">
-        <div class="header-container">
-            <h2>Meal History</h2>
-        </div>
+    <div class="page stack">
+        <header class="page-header">
+            <div class="page-header-row">
+                <h2>Meal History</h2>
+            </div>
+        </header>
 
-        <!-- Filter/sort toolbar (filters first, sort last) -->
-        <div class="filter-toolbar">
+        <!-- Filter/sort toolbar (filters first, sort last, reset in its own slot) -->
+        <div class="toolbar">
             <div class="toolbar-group">
-                <label>Meal Type</label>
-                <div class="filter-chips" id="meal-type-filters">
+                <span class="toolbar-label" id="meal-type-label">Meal Type</span>
+                <div class="filter-chips" id="meal-type-filters" role="group" aria-labelledby="meal-type-label">
                     <button type="button" class="filter-chip" data-meal="Breakfast">Breakfast</button>
                     <button type="button" class="filter-chip" data-meal="Lunch">Lunch</button>
                     <button type="button" class="filter-chip" data-meal="Dinner">Dinner</button>
@@ -46,21 +48,23 @@
                 </div>
             </div>
             <div class="toolbar-group">
-                <label>Rating</label>
-                <div class="filter-chips" id="rating-filters">
+                <span class="toolbar-label" id="rating-label">Rating</span>
+                <div class="filter-chips" id="rating-filters" role="group" aria-labelledby="rating-label">
                     <button type="button" class="filter-chip" data-min="5">5 Stars</button>
                     <button type="button" class="filter-chip" data-min="4">4+ Stars</button>
                     <button type="button" class="filter-chip" data-min="3">3+ Stars</button>
                 </div>
-                <button type="button" class="filter-clear" id="filter-clear">Clear Filters</button>
             </div>
             <div class="toolbar-group">
-                <label>Sort</label>
-                <select id="sort-select">
+                <label class="toolbar-label" for="sort-select">Sort</label>
+                <select id="sort-select" class="select toolbar-control">
                     <option value="rating_desc">Highest Rated</option>
                     <option value="date_desc">Most Recent</option>
                     <option value="date_asc">Oldest First</option>
                 </select>
+            </div>
+            <div class="toolbar-reset">
+                <button type="button" class="btn btn--quiet" id="filter-clear">Clear Filters</button>
             </div>
         </div>
 
@@ -73,6 +77,8 @@
     <div class="modal-overlay" id="review-modal-overlay">
         <div class="modal-content">
             <h3 id="review-modal-title">Add Review</h3>
+            <div class="modal-scroll">
+            <div class="modal-body">
             <form id="review-form">
                 <input type="hidden" id="review-plan-id">
                 <div class="form-group">
@@ -90,16 +96,19 @@
                     <textarea id="review-text" placeholder="How was this meal?" rows="4"></textarea>
                 </div>
                 <div class="modal-actions">
-                    <button type="submit" class="btn-primary">Save Review</button>
-                    <button type="button" class="btn-cancel" id="btn-cancel-review">Cancel</button>
+                    <button type="submit" class="btn">Save Review</button>
+                    <button type="button" class="btn btn--secondary" id="btn-cancel-review">Cancel</button>
                 </div>
             </form>
+            </div>
+            </div>
         </div>
     </div>
 
     <!-- Shared meal add/edit modal (see templates/_meal_edit_modal.html) -->
     {% include "_meal_edit_modal.html" %}
 
+    <script src="/static/modal.js?v={{ css_version }}"></script>
     <script src="/static/meal_edit_modal.js?v={{ css_version }}"></script>
     <script>
         // State
@@ -213,15 +222,15 @@
 
                 const ratingRow = `<div class="history-card-rating-row">
                     ${renderStars(plan.rating)}
-                    <button class="btn-edit" onclick="openReviewModal(${plan.id})">${plan.rating ? 'Edit Review' : 'Add Review'}</button>
-                    <button class="btn-edit" onclick="openEditModal(${plan.id})">Edit</button>
+                    <button class="btn btn--sm" onclick="openReviewModal(${plan.id})">${plan.rating ? 'Edit Review' : 'Add Review'}</button>
+                    <button class="btn btn--sm" onclick="openEditModal(${plan.id})">Edit</button>
                 </div>`;
 
                 return `
                     <div class="history-card" data-id="${plan.id}">
                         <div class="history-card-header">
                             <div class="history-card-title"><strong>${escapeHtml(mealType)}:</strong> ${escapeHtml(plan.plan)}</div>
-                            <div class="history-card-date">${escapeHtml(formatDate(plan.date))}</div>
+                            <div class="meta-date">${escapeHtml(formatDate(plan.date))}</div>
                         </div>
                         ${ratingRow}
                         ${reviewHtml}
@@ -351,7 +360,7 @@
             currentMinRating = '';
             currentSort = 'rating_desc';
             document.getElementById('sort-select').value = currentSort;
-            document.querySelectorAll('.filter-toolbar .filter-chip').forEach(c => c.classList.remove('active'));
+            document.querySelectorAll('.toolbar .filter-chip').forEach(c => c.classList.remove('active'));
             fetchHistory();
         });
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -29,11 +29,18 @@
         </div>
     </nav>
 
+    <div class="page stack">
+        <header class="page-header">
+            <div class="page-header-row">
+                <h2>Settings</h2>
+            </div>
+        </header>
+
     <!-- Family Members Section -->
-    <div class="border-container">
-        <div class="header-container">
-            <h2>Family Members</h2>
-            <button class="btn-add" id="btn-add-member">Add Member</button>
+    <div class="border-container stack">
+        <div class="page-header-row">
+            <h3>Family Members</h3>
+            <button class="btn" id="btn-add-member">Add Member</button>
         </div>
 
         <div class="list-container" id="family-list">
@@ -42,10 +49,10 @@
     </div>
 
     <!-- Calendars Section -->
-    <div class="border-container">
-        <div class="header-container">
-            <h2>Calendars</h2>
-            <button class="btn-add" id="btn-add-calendar">Add Calendar</button>
+    <div class="border-container stack">
+        <div class="page-header-row">
+            <h3>Calendars</h3>
+            <button class="btn" id="btn-add-calendar">Add Calendar</button>
         </div>
 
         <div class="list-container" id="calendar-list">
@@ -54,9 +61,9 @@
     </div>
 
     <!-- Weather Section -->
-    <div class="border-container">
-        <div class="header-container">
-            <h2>Weather</h2>
+    <div class="border-container stack">
+        <div class="page-header-row">
+            <h3>Weather</h3>
         </div>
         <form id="weather-form">
             <div class="form-group">
@@ -64,14 +71,14 @@
                 <input type="text" id="weather-nws-url" placeholder="https://forecast.weather.gov/MapClick.php?lat=33.085&lon=-97.0542&FcstType=dwml">
                 <small>Search your location at <a href="https://forecast.weather.gov" target="_blank">forecast.weather.gov</a>, then copy the page URL and append <code>&FcstType=dwml</code>.</small>
             </div>
-            <button type="submit" class="btn-save">Save</button>
+            <button type="submit" class="btn">Save</button>
         </form>
     </div>
 
     <!-- LLM Section -->
-    <div class="border-container">
-        <div class="header-container">
-            <h2>LLM</h2>
+    <div class="border-container stack">
+        <div class="page-header-row">
+            <h3>LLM</h3>
         </div>
         <form id="llm-form">
             <div class="form-group">
@@ -106,41 +113,41 @@
                 </div>
             </div>
             <div class="ai-field-actions">
-                <button type="submit" class="btn-save">Save</button>
-                <button type="button" class="btn-ghost" onclick="openHistoryModal('llm_config')">Version History</button>
+                <button type="submit" class="btn">Save</button>
+                <button type="button" class="btn btn--quiet" onclick="openHistoryModal('llm_config')">Version History</button>
             </div>
         </form>
     </div>
 
     <!-- AI Section -->
-    <div class="border-container">
-        <div class="header-container">
-            <h2>AI</h2>
+    <div class="border-container stack">
+        <div class="page-header-row">
+            <h3>AI</h3>
         </div>
         <div id="ai-form">
             <div class="form-group">
                 <label>Family Context</label>
                 <textarea id="ai-family-context" rows="12" placeholder="Describe your family, routines, values, and scheduling preferences..."></textarea>
                 <div class="ai-field-actions">
-                    <button type="button" class="btn-save" onclick="saveAiField('family_context')">Save</button>
-                    <button type="button" class="btn-ghost" onclick="openHistoryModal('family_context')">Version History</button>
+                    <button type="button" class="btn" onclick="saveAiField('family_context')">Save</button>
+                    <button type="button" class="btn btn--quiet" onclick="openHistoryModal('family_context')">Version History</button>
                 </div>
             </div>
             <div class="form-group">
                 <label>Agent Voice</label>
                 <textarea id="ai-agent-voice" rows="8" placeholder="Describe the tone and personality for Rally's summaries..."></textarea>
                 <div class="ai-field-actions">
-                    <button type="button" class="btn-save" onclick="saveAiField('agent_voice')">Save</button>
-                    <button type="button" class="btn-ghost" onclick="openHistoryModal('agent_voice')">Version History</button>
+                    <button type="button" class="btn" onclick="saveAiField('agent_voice')">Save</button>
+                    <button type="button" class="btn btn--quiet" onclick="openHistoryModal('agent_voice')">Version History</button>
                 </div>
             </div>
         </div>
     </div>
 
     <!-- Meal Planner Section -->
-    <div class="border-container">
-        <div class="header-container">
-            <h2>Meal Planner</h2>
+    <div class="border-container stack">
+        <div class="page-header-row">
+            <h3>Meal Planner</h3>
         </div>
         <form id="meal-planner-form">
             <div class="form-group">
@@ -152,14 +159,14 @@
                     <option value="Snacks">Snacks</option>
                 </select>
             </div>
-            <button type="submit" class="btn-save">Save</button>
+            <button type="submit" class="btn">Save</button>
         </form>
     </div>
 
     <!-- Learning Section -->
-    <div class="border-container">
-        <div class="header-container">
-            <h2>Learning</h2>
+    <div class="border-container stack">
+        <div class="page-header-row">
+            <h3>Learning</h3>
         </div>
         <form id="learning-form">
             <div class="form-group">
@@ -169,14 +176,14 @@
                 </label>
                 <small>Add a family-friendly STEM concept to the daily summary, with super-easy, age-appropriate ways to explore it during your day.</small>
             </div>
-            <button type="submit" class="btn-save">Save</button>
+            <button type="submit" class="btn">Save</button>
         </form>
     </div>
 
     <!-- Shopping List Section -->
-    <div class="border-container">
-        <div class="header-container">
-            <h2>Shopping List</h2>
+    <div class="border-container stack">
+        <div class="page-header-row">
+            <h3>Shopping List</h3>
         </div>
         <form id="shopping-form">
             <div class="form-group">
@@ -186,15 +193,15 @@
                 </label>
                 <small>Adds your open shopping items, grouped by store, to The Briefing. Purchased items are never included.</small>
             </div>
-            <button type="submit" class="btn-save">Save</button>
+            <button type="submit" class="btn">Save</button>
         </form>
     </div>
 
     <!-- Sports Section -->
-    <div class="border-container">
-        <div class="header-container">
-            <h2>Sports</h2>
-            <button class="btn-add" id="btn-add-team">Add Team</button>
+    <div class="border-container stack">
+        <div class="page-header-row">
+            <h3>Sports</h3>
+            <button class="btn" id="btn-add-team">Add Team</button>
         </div>
         <form id="sports-form">
             <div class="form-group">
@@ -204,7 +211,7 @@
                 </label>
                 <small>Adds tonight's games and races with their TV channel and radio station, plus notable events in the next two weeks. Notable events are announced once, not every morning.</small>
             </div>
-            <button type="submit" class="btn-save">Save</button>
+            <button type="submit" class="btn">Save</button>
         </form>
 
         <div class="list-container" id="followed-team-list">
@@ -213,9 +220,9 @@
     </div>
 
     <!-- General Section -->
-    <div class="border-container">
-        <div class="header-container">
-            <h2>General</h2>
+    <div class="border-container stack">
+        <div class="page-header-row">
+            <h3>General</h3>
         </div>
         <form id="general-form">
             <div class="form-group">
@@ -224,14 +231,17 @@
                     <option value="">Select a timezone</option>
                 </select>
             </div>
-            <button type="submit" class="btn-save">Save</button>
+            <button type="submit" class="btn">Save</button>
         </form>
+    </div>
     </div>
 
     <!-- Family Member Modal -->
     <div class="modal-overlay" id="member-modal-overlay">
         <div class="modal-content">
             <h3 id="member-modal-title">Add Family Member</h3>
+            <div class="modal-scroll">
+            <div class="modal-body">
             <form id="member-form">
                 <input type="hidden" id="member-id">
                 <div class="form-group">
@@ -240,9 +250,11 @@
                 </div>
 
                 <div class="modal-actions">
-                    <button type="submit" class="btn-primary">Save</button>
-                    <button type="button" class="btn-cancel" id="btn-cancel-member">Cancel</button>
-                </div>
+                    <button type="submit" class="btn">Save</button>
+                    <button type="button" class="btn btn--secondary" id="btn-cancel-member">Cancel</button>
+            </div>
+            </div>
+        </div>
             </form>
         </div>
     </div>
@@ -251,6 +263,8 @@
     <div class="modal-overlay" id="calendar-modal-overlay">
         <div class="modal-content">
             <h3 id="calendar-modal-title">Add Calendar</h3>
+            <div class="modal-scroll">
+            <div class="modal-body">
             <form id="calendar-form">
                 <input type="hidden" id="calendar-id">
                 <div class="form-group">
@@ -293,9 +307,11 @@
                     </div>
                 </div>
                 <div class="modal-actions">
-                    <button type="submit" class="btn-primary">Save</button>
-                    <button type="button" class="btn-cancel" id="btn-cancel-calendar">Cancel</button>
-                </div>
+                    <button type="submit" class="btn">Save</button>
+                    <button type="button" class="btn btn--secondary" id="btn-cancel-calendar">Cancel</button>
+            </div>
+            </div>
+        </div>
             </form>
         </div>
     </div>
@@ -304,6 +320,8 @@
     <div class="modal-overlay" id="team-modal-overlay">
         <div class="modal-content">
             <h3 id="team-modal-title">Add Team</h3>
+            <div class="modal-scroll">
+            <div class="modal-body">
             <form id="team-form">
                 <input type="hidden" id="team-id">
                 <div class="form-group">
@@ -340,9 +358,11 @@
                     </label>
                 </div>
                 <div class="modal-actions">
-                    <button type="submit" class="btn-primary">Save</button>
-                    <button type="button" class="btn-cancel" id="btn-cancel-team">Cancel</button>
-                </div>
+                    <button type="submit" class="btn">Save</button>
+                    <button type="button" class="btn btn--secondary" id="btn-cancel-team">Cancel</button>
+            </div>
+            </div>
+        </div>
             </form>
         </div>
     </div>
@@ -351,17 +371,24 @@
     <div class="modal-overlay" id="history-modal-overlay">
         <div class="modal-content">
             <h3 id="history-modal-title">Version History</h3>
+            <div class="modal-scroll">
+            <div class="modal-body">
             <div class="history-list" id="history-list"></div>
             <div class="modal-actions">
-                <button type="button" class="btn-primary" id="btn-change-version">Change Version</button>
-                <button type="button" class="btn-cancel" id="btn-cancel-history">Cancel</button>
+                <button type="button" class="btn" id="btn-change-version">Change Version</button>
+                <button type="button" class="btn btn--secondary" id="btn-cancel-history">Cancel</button>
             </div>
+            </div>
+        </div>
         </div>
     </div>
 
     <!-- Verification Modal -->
     <div class="modal-overlay" id="verify-modal-overlay">
-        <div class="modal-content" style="max-width: 360px;">
+        <!-- The one modal with no title and no form: a transient status dialog.
+             It keeps the chassis but not the scroll wrapper, because its whole
+             content is a single centred status block. -->
+        <div class="modal-content modal-content--narrow">
             <div id="verify-modal-body"></div>
         </div>
     </div>
@@ -451,8 +478,8 @@
                         <div class="editable-item-title">${escapeHtml(member.name)}</div>
                     </div>
                     <div class="editable-item-actions">
-                        <button class="btn-edit" onclick="openEditMemberModal(${member.id})">Edit</button>
-                        <button class="btn-delete" onclick="confirmDeleteMember(${member.id})">Delete</button>
+                        <button class="btn btn--sm" onclick="openEditMemberModal(${member.id})">Edit</button>
+                        <button class="btn btn--secondary btn--sm" onclick="confirmDeleteMember(${member.id})">Delete</button>
                     </div>
                 </div>
             `).join('');
@@ -577,8 +604,8 @@
                             ${descHtml}
                         </div>
                         <div class="editable-item-actions">
-                            <button class="btn-edit" onclick="openEditCalendarModal(${cal.id})">Edit</button>
-                            <button class="btn-delete" onclick="confirmDeleteCalendar(${cal.id})">Delete</button>
+                            <button class="btn btn--sm" onclick="openEditCalendarModal(${cal.id})">Edit</button>
+                            <button class="btn btn--secondary btn--sm" onclick="confirmDeleteCalendar(${cal.id})">Delete</button>
                         </div>
                     </div>
                 `;
@@ -899,7 +926,7 @@
                 + '<div class="verify-detail">' + escapeHtml(errorMessage) + '</div>'
                 + '</div>'
                 + '<div class="modal-actions" style="justify-content: center; margin-top: 20px;">'
-                + '<button class="btn-cancel" onclick="closeVerifyModal()">Close</button>'
+                + '<button class="btn btn--secondary" onclick="closeVerifyModal()">Close</button>'
                 + '</div>';
         }
 
@@ -957,9 +984,9 @@
                             ${radio}
                         </div>
                         <div class="editable-item-actions">
-                            <button class="btn-edit" onclick="testFollowedTeam(${team.id})">Test</button>
-                            <button class="btn-edit" onclick="openEditTeamModal(${team.id})">Edit</button>
-                            <button class="btn-delete" onclick="confirmDeleteTeam(${team.id})">Delete</button>
+                            <button class="btn btn--sm" onclick="testFollowedTeam(${team.id})">Test</button>
+                            <button class="btn btn--sm" onclick="openEditTeamModal(${team.id})">Edit</button>
+                            <button class="btn btn--secondary btn--sm" onclick="confirmDeleteTeam(${team.id})">Delete</button>
                         </div>
                     </div>
                 `;
@@ -1327,5 +1354,6 @@
     <footer>
         <a href="/settings">Settings</a>
     </footer>
+    <script src="/static/modal.js?v={{ css_version }}"></script>
 </body>
 </html>

--- a/templates/shopping.html
+++ b/templates/shopping.html
@@ -29,22 +29,29 @@
         </div>
     </nav>
 
-    <div class="section-container">
-        <div class="header-container">
-            <h2>Shopping List</h2>
-            <div class="header-actions">
-                <button class="btn-add" id="btn-add-item">Add Item</button>
+    <div class="page stack">
+        <header class="page-header">
+            <div class="page-header-row">
+                <h2>Shopping List</h2>
+                <div class="page-header-actions">
+                    <button class="btn" id="btn-add-item">Add Item</button>
+                </div>
             </div>
-        </div>
+            <div class="page-header-meta">
+                <a class="link-quiet" href="/shopping/purchased">View purchased items</a>
+                <!-- Store management is navigation, not a filter. It sat in the
+                     filter bar looking identical to Clear Filters, which resets. -->
+                <button type="button" class="btn btn--quiet" id="btn-manage-stores">Manage stores</button>
+            </div>
+        </header>
 
-        <a class="view-switch" href="/shopping/purchased">View purchased items</a>
-
-        <div class="filter-toolbar">
+        <div class="toolbar">
             <div class="toolbar-group">
-                <label>Store</label>
-                <div class="filter-chips" id="filter-store-chips"></div>
-                <button type="button" class="filter-clear" id="filter-clear">Clear Filters</button>
-                <button type="button" class="filter-clear" id="btn-manage-stores">Manage stores</button>
+                <span class="toolbar-label" id="store-label">Store</span>
+                <div class="filter-chips" id="filter-store-chips" role="group" aria-labelledby="store-label"></div>
+            </div>
+            <div class="toolbar-reset">
+                <button type="button" class="btn btn--quiet" id="filter-clear">Clear Filters</button>
             </div>
         </div>
 
@@ -83,9 +90,9 @@
                     </div>
                 </form>
                 <div class="modal-actions">
-                    <button type="submit" form="item-form" class="btn-primary">Save</button>
-                    <button type="button" class="btn-cancel" id="btn-cancel-item">Cancel</button>
-                    <button type="button" class="btn-delete modal-delete" id="btn-delete-item" style="display:none">Delete</button>
+                    <button type="submit" form="item-form" class="btn">Save</button>
+                    <button type="button" class="btn btn--secondary" id="btn-cancel-item">Cancel</button>
+                    <button type="button" class="btn btn--secondary modal-delete" id="btn-delete-item" style="display:none">Delete</button>
                 </div>
             </div>
             </div>
@@ -102,12 +109,12 @@
                     <label>Add a store</label>
                     <div class="store-manage-row">
                         <input type="text" id="store-add-name" placeholder="Store name" required>
-                        <button type="submit" class="btn-edit">Add</button>
+                        <button type="submit" class="btn btn--sm">Add</button>
                     </div>
                 </form>
                 <div id="store-manage-list"></div>
                 <div class="modal-actions">
-                    <button type="button" class="btn-cancel" id="btn-close-stores">Done</button>
+                    <button type="button" class="btn btn--secondary" id="btn-close-stores">Done</button>
                 </div>
             </div>
             </div>
@@ -332,7 +339,7 @@
                         ${completedHtml}
                     </div>
                     <div class="editable-item-actions">
-                        <button class="btn-edit" onclick="openEditModal(${item.id})">Edit</button>
+                        <button class="btn btn--sm" onclick="openEditModal(${item.id})">Edit</button>
                     </div>
                 </div>
             `;
@@ -606,8 +613,8 @@
             list.innerHTML = stores.map(s => `
                 <div class="store-manage-row" data-id="${s.id}">
                     <input type="text" value="${escapeAttr(s.name)}" aria-label="Store name">
-                    <button type="button" class="btn-edit" data-action="rename">Rename</button>
-                    <button type="button" class="btn-delete" data-action="delete">Delete</button>
+                    <button type="button" class="btn btn--sm" data-action="rename">Rename</button>
+                    <button type="button" class="btn btn--secondary btn--sm" data-action="delete">Delete</button>
                 </div>
             `).join('');
         }
@@ -695,25 +702,6 @@
 
         document.getElementById('filter-clear').addEventListener('click', clearFilters);
 
-        // Show a modal and compute its fade state once it's laid out.
-        function showModalOverlay(overlayId) {
-            const overlay = document.getElementById(overlayId);
-            overlay.style.display = 'flex';
-            const scroll = overlay.querySelector('.modal-scroll');
-            if (scroll) requestAnimationFrame(() => updateModalFade(scroll));
-        }
-
-        function updateModalFade(scroll) {
-            const body = scroll.querySelector('.modal-body');
-            const maxScroll = body.scrollHeight - body.clientHeight;
-            scroll.toggleAttribute('data-overflow-top', body.scrollTop > 1);
-            scroll.toggleAttribute('data-overflow-bottom', body.scrollTop < maxScroll - 1);
-        }
-        document.querySelectorAll('.modal-scroll').forEach(scroll => {
-            const body = scroll.querySelector('.modal-body');
-            body.addEventListener('scroll', () => updateModalFade(scroll));
-        });
-
         // ── Initialize ──
         fetchStores().then(fetchItems);
 
@@ -736,5 +724,6 @@
     <footer>
         <a href="/settings">Settings</a>
     </footer>
+    <script src="/static/modal.js?v={{ css_version }}"></script>
 </body>
 </html>

--- a/templates/shopping_purchased.html
+++ b/templates/shopping_purchased.html
@@ -29,31 +29,37 @@
         </div>
     </nav>
 
-    <div class="section-container">
-        <div class="header-container">
-            <h2>Shopping List</h2>
-        </div>
-
-        <a class="view-switch" href="/shopping">Back to shopping list</a>
-
-        <!-- Required, not decorative: without it the page silently loses history
-             and reads as broken next to the tasks archive, which keeps everything. -->
-        <div class="page-note">Purchased items are kept for 30 days.</div>
-
-        <div class="filter-toolbar">
-            <div class="toolbar-group">
-                <label>Store</label>
-                <div class="filter-chips" id="filter-store-chips"></div>
-                <button type="button" class="filter-clear" id="filter-clear">Clear Filters</button>
+    <div class="page stack">
+        <header class="page-header">
+            <div class="page-header-row">
+                <h2>Shopping List</h2>
             </div>
-            <div class="toolbar-group toolbar-search">
-                <label for="search-input">Search</label>
-                <input type="text" id="search-input" class="search-input"
-                       placeholder="Search purchased items" autocomplete="off">
-                <button type="button" class="search-btn" id="search-btn" disabled>Search</button>
-                <button type="button" class="filter-clear" id="search-clear">Clear Search</button>
+            <div class="page-header-meta">
+                <a class="link-quiet" href="/shopping">Back to shopping list</a>
+                <!-- Required, not decorative: without it the page silently loses
+                     history and reads as broken next to the tasks archive. -->
+                <p class="page-note">Purchased items are kept for 30 days.</p>
+            </div>
+        </header>
+
+        <div class="toolbar">
+            <div class="toolbar-group">
+                <span class="toolbar-label" id="store-label">Store</span>
+                <div class="filter-chips" id="filter-store-chips" role="group" aria-labelledby="store-label"></div>
+            </div>
+            <div class="toolbar-search">
+                <label class="toolbar-label" for="search-input">Search</label>
+                <div class="toolbar-search-controls">
+                    <input type="text" id="search-input" class="search-input"
+                           placeholder="Search purchased items" autocomplete="off">
+                    <button type="button" class="btn btn--secondary" id="search-btn" disabled>Search</button>
+                    <button type="button" class="btn btn--quiet" id="search-clear">Clear Search</button>
+                </div>
             </div>
             <div class="search-results-count" id="search-results-count" hidden></div>
+            <div class="toolbar-reset">
+                <button type="button" class="btn btn--quiet" id="filter-clear">Clear Filters</button>
+            </div>
         </div>
 
         <div id="groups-container">

--- a/templates/styleguide.html
+++ b/templates/styleguide.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Rally — Style Guide</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📰</text></svg>">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="/static/styles.css?v={{ css_version }}" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <h1>Rally</h1>
+        <div class="subtitle">Style Guide</div>
+    </header>
+
+    <nav>
+        <a href="/dashboard">Dashboard</a>
+        <a href="/todo">Tasks</a>
+        <a href="/shopping">Shopping</a>
+        <div class="nav-dropdown" id="meal-dropdown">
+            <button class="nav-dropdown-btn" onclick="toggleMealDropdown(event)">Meal Planner</button>
+            <div class="nav-dropdown-content">
+                <a href="/dinner-planner">Current &amp; Upcoming</a>
+                <a href="/meal-history">Previous Meals</a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="page stack">
+        <header class="page-header">
+            <div class="page-header-row">
+                <h2>Style Guide</h2>
+            </div>
+            <div class="page-header-meta">
+                <p class="page-note">
+                    Every component and state, rendered from the real stylesheet. If something
+                    here looks wrong, the app looks wrong too. See
+                    docs/visual-design-system.md for the rules behind it.
+                </p>
+            </div>
+        </header>
+
+        <section>
+            <div class="card-header">Space scale</div>
+            <div id="sg-space"></div>
+        </section>
+
+        <section>
+            <div class="card-header">Type scale</div>
+            <div id="sg-type"></div>
+        </section>
+
+        <section>
+            <div class="card-header">Colour roles</div>
+            <p class="page-note">
+                Text uses ink, ink-muted or ink-subtle only. The rule tokens are hairlines
+                and fail contrast as text.
+            </p>
+            <div id="sg-colour"></div>
+        </section>
+
+        <section>
+            <div class="card-header">Headings</div>
+            <h2>Page title — h2</h2>
+            <h3>Section and modal title — h3</h3>
+            <div class="card-header">Card header</div>
+            <div class="shopping-group-header">
+                <span class="shopping-group-name">Group header</span>
+                <span class="shopping-group-rule"></span>
+                <span class="shopping-group-count">4 items</span>
+            </div>
+        </section>
+
+        <section>
+            <div class="card-header">Buttons</div>
+            <p class="page-note">
+                One family, four roles, one size plus a compact modifier. Save is the same
+                control everywhere it appears.
+            </p>
+            <div class="list-container">
+                <div class="editable-item">
+                    <div class="editable-item-content">
+                        <div class="editable-item-description">Default &middot; primary action</div>
+                        <div class="page-header-actions">
+                            <button class="btn">Add Task</button>
+                            <button class="btn" disabled>Disabled</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="editable-item">
+                    <div class="editable-item-content">
+                        <div class="editable-item-description">Secondary &middot; cancel, delete, dismiss</div>
+                        <div class="page-header-actions">
+                            <button class="btn btn--secondary">Cancel</button>
+                            <button class="btn btn--secondary">Delete</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="editable-item">
+                    <div class="editable-item-content">
+                        <div class="editable-item-description">Quiet &middot; resets and inline actions</div>
+                        <div class="page-header-actions">
+                            <button class="btn btn--quiet">Clear Filters</button>
+                            <a class="link-quiet" href="/styleguide">View purchased items</a>
+                        </div>
+                    </div>
+                </div>
+                <div class="editable-item">
+                    <div class="editable-item-content">
+                        <div class="editable-item-description">Compact &middot; inside a list row</div>
+                        <div class="page-header-actions">
+                            <button class="btn btn--sm">Edit</button>
+                            <button class="btn btn--secondary btn--sm">Delete</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <div class="card-header">Toolbar</div>
+            <p class="page-note">
+                Labels stack above their chips below 768px and sit inline above it. The reset
+                slot is always last, and always in the same place on every page.
+            </p>
+            <div class="toolbar">
+                <div class="toolbar-group">
+                    <span class="toolbar-label" id="sg-filter-label">Assignee</span>
+                    <div class="filter-chips" role="group" aria-labelledby="sg-filter-label">
+                        <button type="button" class="filter-chip active">Unassigned</button>
+                        <button type="button" class="filter-chip">Jon</button>
+                        <button type="button" class="filter-chip">Rodryk</button>
+                        <button type="button" class="filter-chip">Sarah</button>
+                        <button type="button" class="filter-chip">Soren</button>
+                    </div>
+                </div>
+                <div class="toolbar-group">
+                    <label class="toolbar-label" for="sg-sort">Sort</label>
+                    <select id="sg-sort" class="select toolbar-control">
+                        <option>Due Date (Soonest)</option>
+                        <option>Newest First</option>
+                    </select>
+                </div>
+                <div class="toolbar-search">
+                    <label class="toolbar-label" for="sg-search">Search</label>
+                    <input type="text" id="sg-search" class="search-input" placeholder="Search">
+                    <button type="button" class="btn btn--secondary">Search</button>
+                    <button type="button" class="btn btn--quiet">Clear Search</button>
+                </div>
+                <div class="toolbar-reset">
+                    <button type="button" class="btn btn--quiet">Clear Filters</button>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <div class="card-header">List rows</div>
+            <div class="list-container">
+                <div class="editable-item">
+                    <div class="todo-checkbox"><input type="checkbox"></div>
+                    <div class="editable-item-content">
+                        <div class="editable-item-title">Return library books <span class="assignee-label">— Soren</span></div>
+                        <div class="editable-item-description">In the bag by the door</div>
+                        <div class="todo-due-date overdue">Due Saturday, Aug 1</div>
+                    </div>
+                    <div class="editable-item-actions"><button class="btn btn--sm">Edit</button></div>
+                </div>
+                <div class="editable-item completed">
+                    <div class="todo-checkbox"><input type="checkbox" checked></div>
+                    <div class="editable-item-content">
+                        <div class="editable-item-title">Diet cokes</div>
+                        <div class="shopping-completed-at">Purchased Monday, Aug 10</div>
+                    </div>
+                    <div class="editable-item-actions"><button class="btn btn--sm">Edit</button></div>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <div class="card-header">Empty and loading states</div>
+            <div class="list-container">
+                <div class="container-empty-state">No tasks match the current filter.</div>
+                <div class="container-loading-state">Loading tasks…</div>
+            </div>
+        </section>
+
+        <section>
+            <div class="card-header">Form controls</div>
+            <div class="border-container">
+                <div class="form-group">
+                    <label for="sg-text">Text field</label>
+                    <input type="text" id="sg-text" placeholder="Item name">
+                    <small>Help text sits under the field it explains.</small>
+                </div>
+                <div class="form-group">
+                    <label for="sg-select">Select</label>
+                    <select id="sg-select"><option>Dinner</option></select>
+                </div>
+                <div class="form-group">
+                    <label for="sg-area">Textarea</label>
+                    <textarea id="sg-area" rows="3" placeholder="What's on the menu?"></textarea>
+                </div>
+                <div class="form-group">
+                    <label>Checkboxes</label>
+                    <div class="checkbox-group">
+                        <label class="checkbox-label"><input type="checkbox" checked> Jon</label>
+                        <label class="checkbox-label"><input type="checkbox"> Sarah</label>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label>Radios</label>
+                    <div class="radio-options">
+                        <label><input type="radio" name="sg-radio" checked> Due date of the last task</label>
+                        <label><input type="radio" name="sg-radio"> Date the last task was completed</label>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <div class="card-header">Card</div>
+            <div class="card">
+                <div class="card-header">Weather &amp; Preparedness</div>
+                <div class="card-content">
+                    <p>Partly cloudy with highs around 68&deg;F. Light jacket recommended for
+                    morning activities. <strong>No rain expected today.</strong></p>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <div class="card-header">Modal</div>
+            <p class="page-note">
+                Every modal uses one chassis, so each one signals a scrollable body the same way.
+            </p>
+            <div class="page-header-actions">
+                <button class="btn" onclick="showModalOverlay('sg-modal')">Open modal</button>
+            </div>
+        </section>
+    </div>
+
+    <div class="modal-overlay" id="sg-modal">
+        <div class="modal-content">
+            <h3>Add Item</h3>
+            <div class="modal-scroll">
+            <div class="modal-body">
+                <div class="form-group">
+                    <label for="sg-modal-name">Item</label>
+                    <input type="text" id="sg-modal-name" placeholder="Item name">
+                </div>
+                <div class="form-group">
+                    <label for="sg-modal-note">Note (optional)</label>
+                    <textarea id="sg-modal-note" rows="3"></textarea>
+                </div>
+                <div class="modal-actions">
+                    <button type="button" class="btn">Save</button>
+                    <button type="button" class="btn btn--secondary" onclick="hideModalOverlay('sg-modal')">Cancel</button>
+                    <button type="button" class="btn btn--secondary modal-delete">Delete</button>
+                </div>
+            </div>
+            </div>
+        </div>
+    </div>
+
+    <footer>
+        <a href="/settings">Settings</a>
+    </footer>
+
+    <script src="/static/modal.js?v={{ css_version }}"></script>
+    <script>
+        // Read the tokens back out of the cascade rather than hard-coding them,
+        // so this page cannot describe a scale the stylesheet no longer has.
+        const root = getComputedStyle(document.documentElement);
+
+        function swatchRows(target, items, render) {
+            document.getElementById(target).innerHTML =
+                '<div class="list-container">' + items.map(render).join('') + '</div>';
+        }
+
+        swatchRows('sg-space', ['1', '2', '3', '4', '5', '6', '7', '8'], n => {
+            const value = root.getPropertyValue(`--space-${n}`).trim();
+            return `<div class="editable-item">
+                <div class="editable-item-content">
+                    <div class="editable-item-title">--space-${n}</div>
+                    <div class="editable-item-description">${value}</div>
+                </div>
+                <div style="width:${value};align-self:stretch;background:var(--ink);"></div>
+            </div>`;
+        });
+
+        swatchRows('sg-type', ['xs', 'sm', 'base', 'lg', 'xl', 'display'], name => {
+            const value = root.getPropertyValue(`--text-${name}`).trim();
+            return `<div class="editable-item">
+                <div class="editable-item-content">
+                    <div class="editable-item-description">--text-${name} &middot; ${value}</div>
+                    <div style="font-size:${value};line-height:1.3;">Rally</div>
+                </div>
+            </div>`;
+        });
+
+        swatchRows('sg-colour',
+            ['ink', 'ink-strong', 'ink-muted', 'ink-subtle', 'rule', 'rule-subtle', 'surface-sunken'],
+            name => {
+                const value = root.getPropertyValue(`--${name}`).trim();
+                return `<div class="editable-item">
+                    <div style="width:2.75rem;align-self:stretch;background:${value};border:1px solid var(--rule);"></div>
+                    <div class="editable-item-content">
+                        <div class="editable-item-title">--${name}</div>
+                        <div class="editable-item-description">${value}</div>
+                    </div>
+                </div>`;
+            });
+
+        function toggleMealDropdown(e) {
+            e.stopPropagation();
+            document.getElementById('meal-dropdown').classList.toggle('open');
+        }
+        document.addEventListener('click', () => {
+            document.getElementById('meal-dropdown').classList.remove('open');
+        });
+    </script>
+</body>
+</html>

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -29,33 +29,38 @@
         </div>
     </nav>
 
-    <div class="section-container">
-        <div class="header-container">
-            <h2>Tasks</h2>
-            <div class="header-actions">
-                <button class="btn-add" id="btn-add-task">Add Task</button>
+    <div class="page stack">
+        <header class="page-header">
+            <div class="page-header-row">
+                <h2>Tasks</h2>
+                <div class="page-header-actions">
+                    <button class="btn" id="btn-add-task">Add Task</button>
+                </div>
             </div>
-        </div>
+            <div class="page-header-meta">
+                <a class="link-quiet" href="/todo/completed">View completed tasks</a>
+            </div>
+        </header>
 
-        <a class="view-switch" href="/todo/completed">View completed tasks</a>
-
-        <div class="filter-toolbar">
+        <div class="toolbar">
             <div class="toolbar-group">
-                <label>Assignee</label>
-                <div class="filter-chips" id="filter-assignee-chips">
+                <span class="toolbar-label" id="assignee-label">Assignee</span>
+                <div class="filter-chips" id="filter-assignee-chips" role="group" aria-labelledby="assignee-label">
                     <button type="button" class="filter-chip" data-value="unassigned">Unassigned</button>
                 </div>
-                <button type="button" class="filter-clear" id="filter-clear">Clear Filters</button>
             </div>
             <div class="toolbar-group">
-                <label for="sort-by">Sort</label>
-                <select id="sort-by">
+                <label class="toolbar-label" for="sort-by">Sort</label>
+                <select id="sort-by" class="select toolbar-control">
                     <option value="due-soonest">Due Date (Soonest)</option>
                     <option value="due-furthest">Due Date (Furthest Out)</option>
                     <option value="assignee">Assignee</option>
                     <option value="newest">Newest First</option>
                     <option value="oldest">Oldest First</option>
                 </select>
+            </div>
+            <div class="toolbar-reset">
+                <button type="button" class="btn btn--quiet" id="filter-clear">Clear Filters</button>
             </div>
         </div>
 
@@ -64,13 +69,15 @@
         </div>
     </div>
 
-    <div class="section-container">
-        <div class="header-container">
-            <h2>Recurring Tasks</h2>
-            <div class="header-actions">
-                <button class="btn-add" id="btn-add-recurring">Add Recurring</button>
+    <div class="page stack">
+        <header class="page-header">
+            <div class="page-header-row">
+                <h2>Recurring Tasks</h2>
+                <div class="page-header-actions">
+                    <button class="btn" id="btn-add-recurring">Add Recurring</button>
+                </div>
             </div>
-        </div>
+        </header>
 
         <div class="list-container" id="recurring-list-container">
             <div class="container-loading-state">Loading recurring tasks...</div>
@@ -199,9 +206,9 @@
                 </div>
             </form>
                 <div class="modal-actions">
-                    <button type="submit" form="recurring-form" class="btn-primary">Save</button>
-                    <button type="button" class="btn-cancel" id="btn-cancel-recurring">Cancel</button>
-                    <button type="button" class="btn-delete modal-delete" id="btn-delete-recurring" style="display:none" onclick="confirmDeleteRecurringFromModal()">Delete</button>
+                    <button type="submit" form="recurring-form" class="btn">Save</button>
+                    <button type="button" class="btn btn--secondary" id="btn-cancel-recurring">Cancel</button>
+                    <button type="button" class="btn btn--secondary modal-delete" id="btn-delete-recurring" style="display:none" onclick="confirmDeleteRecurringFromModal()">Delete</button>
                 </div>
             </div>
             </div>
@@ -241,9 +248,9 @@
                     </div>
                 </form>
                 <div class="modal-actions">
-                    <button type="submit" form="todo-form" class="btn-primary">Save</button>
-                    <button type="button" class="btn-cancel" id="btn-cancel">Cancel</button>
-                    <button type="button" class="btn-delete modal-delete" id="btn-delete-todo" style="display:none" onclick="confirmDeleteFromModal()">Delete</button>
+                    <button type="submit" form="todo-form" class="btn">Save</button>
+                    <button type="button" class="btn btn--secondary" id="btn-cancel">Cancel</button>
+                    <button type="button" class="btn btn--secondary modal-delete" id="btn-delete-todo" style="display:none" onclick="confirmDeleteFromModal()">Delete</button>
                 </div>
             </div>
             </div>
@@ -435,7 +442,7 @@
                                 ${dueDateHtml}
                             </div>
                             <div class="editable-item-actions">
-                                <button class="btn-edit" onclick="openEditModal(${todo.id})">Edit</button>
+                                <button class="btn btn--sm" onclick="openEditModal(${todo.id})">Edit</button>
                             </div>
                         </div>
                     `;
@@ -462,8 +469,8 @@
                                 <div class="recurring-schedule">Last completed: ${formatLastCompleted(rt.last_completed_at || rt.last_completed_date)}</div>
                             </div>
                             <div class="editable-item-actions">
-                                <button class="btn-edit" onclick="toggleRecurringActive(${rt.id}, ${rt.active})">${rt.active ? 'Pause' : 'Resume'}</button>
-                                <button class="btn-edit" onclick="openEditRecurringModal(${rt.id})">Edit</button>
+                                <button class="btn btn--sm" onclick="toggleRecurringActive(${rt.id}, ${rt.active})">${rt.active ? 'Pause' : 'Resume'}</button>
+                                <button class="btn btn--sm" onclick="openEditRecurringModal(${rt.id})">Edit</button>
                             </div>
                         </div>
                     `;
@@ -968,36 +975,6 @@
             }
         });
 
-        // Fade the top/bottom edges of a scrollable modal only when content is
-        // hidden in that direction, so the scrolled-to actions stay crisp.
-        function updateModalFade(scroll) {
-            const body = scroll.querySelector('.modal-body');
-            const maxScroll = body.scrollHeight - body.clientHeight;
-            scroll.toggleAttribute('data-overflow-top', body.scrollTop > 1);
-            scroll.toggleAttribute('data-overflow-bottom', body.scrollTop < maxScroll - 1);
-        }
-        document.querySelectorAll('.modal-scroll').forEach(scroll => {
-            const body = scroll.querySelector('.modal-body');
-            const refresh = () => updateModalFade(scroll);
-            body.addEventListener('scroll', refresh);
-            // Recompute when fields toggle the body's height (e.g. switching
-            // to custom recurrence). Field handlers run before this bubbles.
-            body.addEventListener('change', refresh);
-            // Backstop for size changes not driven by a change event.
-            if (window.ResizeObserver) {
-                const ro = new ResizeObserver(refresh);
-                Array.from(body.children).forEach(child => ro.observe(child));
-            }
-        });
-
-        // Show a modal and compute its fade state once it's laid out.
-        function showModalOverlay(overlayId) {
-            const overlay = document.getElementById(overlayId);
-            overlay.style.display = 'flex';
-            const scroll = overlay.querySelector('.modal-scroll');
-            if (scroll) requestAnimationFrame(() => updateModalFade(scroll));
-        }
-
         // Initialize
         fetchFamilyMembers().then(() => {
             fetchTodos();
@@ -1017,5 +994,6 @@
     <footer>
         <a href="/settings">Settings</a>
     </footer>
+    <script src="/static/modal.js?v={{ css_version }}"></script>
 </body>
 </html>

--- a/templates/todo_completed.html
+++ b/templates/todo_completed.html
@@ -29,24 +29,26 @@
         </div>
     </nav>
 
-    <div class="section-container">
-        <div class="header-container">
-            <h2>Tasks</h2>
-        </div>
+    <div class="page stack">
+        <header class="page-header">
+            <div class="page-header-row">
+                <h2>Tasks</h2>
+            </div>
+            <div class="page-header-meta">
+                <a class="link-quiet" href="/todo">Back to current tasks</a>
+            </div>
+        </header>
 
-        <a class="view-switch" href="/todo">Back to current tasks</a>
-
-        <div class="filter-toolbar">
+        <div class="toolbar">
             <div class="toolbar-group">
-                <label>Assignee</label>
-                <div class="filter-chips" id="filter-assignee-chips">
+                <span class="toolbar-label" id="assignee-label">Assignee</span>
+                <div class="filter-chips" id="filter-assignee-chips" role="group" aria-labelledby="assignee-label">
                     <button type="button" class="filter-chip" data-value="unassigned">Unassigned</button>
                 </div>
-                <button type="button" class="filter-clear" id="filter-clear">Clear Filters</button>
             </div>
             <div class="toolbar-group">
-                <label for="sort-by">Sort</label>
-                <select id="sort-by">
+                <label class="toolbar-label" for="sort-by">Sort</label>
+                <select id="sort-by" class="select toolbar-control">
                     <option value="completed-newest">Completion Date (Most Recent)</option>
                     <option value="completed-oldest">Completion Date (Oldest)</option>
                     <option value="due-soonest">Due Date (Soonest)</option>
@@ -56,14 +58,19 @@
                     <option value="oldest">Oldest First</option>
                 </select>
             </div>
-            <div class="toolbar-group toolbar-search">
-                <label for="search-input">Search</label>
-                <input type="text" id="search-input" class="search-input"
-                       placeholder="Search completed tasks" autocomplete="off">
-                <button type="button" class="search-btn" id="search-btn" disabled>Search</button>
-                <button type="button" class="filter-clear" id="search-clear">Clear Search</button>
+            <div class="toolbar-search">
+                <label class="toolbar-label" for="search-input">Search</label>
+                <div class="toolbar-search-controls">
+                    <input type="text" id="search-input" class="search-input"
+                           placeholder="Search completed tasks" autocomplete="off">
+                    <button type="button" class="btn btn--secondary" id="search-btn" disabled>Search</button>
+                    <button type="button" class="btn btn--quiet" id="search-clear">Clear Search</button>
+                </div>
             </div>
             <div class="search-results-count" id="search-results-count" hidden></div>
+            <div class="toolbar-reset">
+                <button type="button" class="btn btn--quiet" id="filter-clear">Clear Filters</button>
+            </div>
         </div>
 
         <div class="list-container" id="list-container">
@@ -71,7 +78,7 @@
         </div>
 
         <div class="load-more-container" id="load-more-container" style="display:none;">
-            <button type="button" class="btn-load-more" id="btn-load-more">Load more</button>
+            <button type="button" class="btn btn--secondary" id="btn-load-more">Load more</button>
         </div>
     </div>
 

--- a/tests/test_stylesheet.py
+++ b/tests/test_stylesheet.py
@@ -1,0 +1,118 @@
+"""Static checks on the stylesheet.
+
+These need no browser, so they run in the ordinary test job and catch the
+cheap-to-make mistakes before the visual suite ever starts: a value typed
+instead of a token, a selector declared twice, a focus ring switched off.
+
+The rules they enforce are the ones written down in
+docs/visual-design-system.md.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+CSS_PATH = pathlib.Path(__file__).resolve().parents[1] / "static" / "styles.css"
+
+# Comments carry prose about the rules ("never set outline: none"), so every
+# check runs against the stylesheet with comments removed.
+SOURCE = re.sub(r"/\*.*?\*/", "", CSS_PATH.read_text(), flags=re.S)
+
+# Blocks where raw values are the definition rather than a usage.
+TOKEN_BLOCK = re.compile(r":root\s*\{[^}]*\}", re.S)
+DECLARATIONS_ONLY = TOKEN_BLOCK.sub("", SOURCE)
+
+
+def _rules() -> list[tuple[str, str]]:
+    """Every (context, selector) pair, where context is the enclosing at-rules.
+
+    A brace-depth walk rather than a regex: a selector inside `@media` is a
+    different rule from the same selector at the top level, and conflating the
+    two would let a genuine duplicate through.
+    """
+    rules: list[tuple[str, str]] = []
+    stack: list[tuple[str, str]] = []
+    buffer = ""
+    for char in SOURCE:
+        if char == "{":
+            head = " ".join(buffer.split())
+            buffer = ""
+            context = " > ".join(h for kind, h in stack if kind == "at")
+            if head.startswith("@"):
+                stack.append(("at", head))
+            else:
+                rules.append((context, head))
+                stack.append(("rule", head))
+        elif char == "}":
+            buffer = ""
+            if stack:
+                stack.pop()
+        else:
+            buffer += char
+    return rules
+
+
+def test_no_selector_is_declared_twice_in_the_same_context():
+    """F1 — duplicated blocks are how rules silently override each other.
+
+    `footer`, `footer a` and `footer a:hover` were each declared twice
+    verbatim, and a stale duplicate of `.toolbar-search` later broke the
+    toolbar's shared column grid until it was found by measurement.
+    """
+    seen: dict[tuple[str, str], int] = {}
+    for context, selector in _rules():
+        if selector.startswith("@") or selector.endswith("%"):
+            continue  # at-rules and keyframe stops legitimately repeat
+        seen[(context, selector)] = seen.get((context, selector), 0) + 1
+    duplicates = {key: count for key, count in seen.items() if count > 1}
+    assert not duplicates, f"selectors declared more than once: {duplicates}"
+
+
+def test_no_rule_suppresses_the_focus_ring():
+    """E1 — a control may not switch focus off without replacing it."""
+    offenders = re.findall(r"[^;{}]*outline:\s*(?:none|0)[^;}]*", DECLARATIONS_ONLY)
+    assert not offenders, f"focus suppressed without a replacement: {offenders}"
+
+
+def test_colours_are_defined_only_as_tokens():
+    """C4 — components reference roles; literals live in :root alone."""
+    body = re.sub(r"url\([^)]*\)", "", DECLARATIONS_ONLY)
+    literals = re.findall(r"#[0-9a-fA-F]{3,8}\b", body)
+    assert not literals, f"raw colours outside the token block: {sorted(set(literals))}"
+
+
+def test_type_sizes_are_defined_only_as_tokens():
+    """C1 — 17 declared font sizes became six tokens; keep it that way."""
+    sizes = re.findall(r"font-size:\s*([^;]+);", DECLARATIONS_ONLY)
+    off_scale = [s.strip() for s in sizes if "var(--text-" not in s and s.strip() != "inherit"]
+    assert not off_scale, f"font sizes not taken from the type scale: {off_scale}"
+
+
+@pytest.mark.parametrize("prop", ["margin", "padding", "gap", "row-gap", "column-gap"])
+def test_spacing_comes_from_the_scale(prop):
+    """C2 — 18 ad hoc spacing values became one 4px scale.
+
+    Hairlines (1px) and the -1px border overlaps are exempt: they are optical
+    details, not spacing.
+    """
+    pattern = re.compile(rf"^\s*{prop}(?:-[a-z]+)?:\s*([^;]+);", re.M)
+    offenders = []
+    for value in pattern.findall(DECLARATIONS_ONLY):
+        for token in value.split():
+            if re.fullmatch(r"-?[0-9.]+px", token) and token not in {"1px", "-1px"}:
+                offenders.append(value.strip())
+    assert not offenders, f"{prop} values outside the space scale: {sorted(set(offenders))}"
+
+
+def test_the_stylesheet_declares_the_documented_token_set():
+    """The scales the tests and the styleguide both read back."""
+    root = TOKEN_BLOCK.search(SOURCE).group(0)
+    for n in range(1, 9):
+        assert f"--space-{n}:" in root, f"--space-{n} is missing"
+    for name in ["xs", "sm", "base", "lg", "xl", "display"]:
+        assert f"--text-{name}:" in root, f"--text-{name} is missing"
+    for name in ["ink", "ink-muted", "ink-subtle", "rule", "surface", "inverse"]:
+        assert f"--{name}:" in root, f"--{name} is missing"

--- a/tests/visual/conftest.py
+++ b/tests/visual/conftest.py
@@ -1,0 +1,178 @@
+"""A real browser against a real server, seeded with the sample database.
+
+These tests are skipped unless Playwright and its Chromium build are present,
+so `uv run pytest` stays fast and dependency-free for everyone who is not
+working on the design system. CI installs the browser and runs them.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+# pytest puts src/ on the path via `pythonpath`, but the server and the seed
+# helpers run in subprocesses that inherit no such thing.
+SRC = pathlib.Path(__file__).resolve().parents[2] / "src"
+
+pytest.importorskip("playwright", reason="Playwright is not installed")
+
+from playwright.sync_api import sync_playwright  # noqa: E402
+
+VIEWPORTS = {
+    "mobile": (390, 844),
+    "tablet": (834, 1112),
+    "desktop": (1440, 900),
+}
+
+# Every page a family member can reach, plus the styleguide.
+PAGES = {
+    "dashboard": "/dashboard",
+    "todo": "/todo",
+    "todo-completed": "/todo/completed",
+    "shopping": "/shopping",
+    "shopping-purchased": "/shopping/purchased",
+    "dinner-planner": "/dinner-planner",
+    "meal-history": "/meal-history",
+    "settings": "/settings",
+    "styleguide": "/styleguide",
+}
+
+# Pages built from the page/toolbar primitives. Dashboard, Settings and the
+# styleguide are excluded from toolbar assertions: they have no filter bar.
+TOOLBAR_PAGES = [
+    "todo",
+    "todo-completed",
+    "shopping",
+    "shopping-purchased",
+    "dinner-planner",
+    "meal-history",
+]
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _run(args: list[str], env: dict[str, str]) -> None:
+    result = subprocess.run(args, env=env, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"{args[:3]} failed:\n{result.stdout}\n{result.stderr}")
+
+
+@pytest.fixture(scope="session")
+def live_server(tmp_path_factory) -> str:
+    """Serve Rally from a seeded throwaway database and yield its base URL."""
+    db_path = tmp_path_factory.mktemp("visual") / "rally.db"
+    env = {
+        **os.environ,
+        "RALLY_DB_PATH": str(db_path),
+        "PYTHONPATH": os.pathsep.join([str(SRC), os.environ.get("PYTHONPATH", "")]).rstrip(
+            os.pathsep
+        ),
+    }
+
+    _run([sys.executable, "-c", "from rally.database import init_db; init_db()"], env)
+    _run([sys.executable, "-c", "from rally.cli import seed; seed()"], env)
+
+    port = _free_port()
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "rally.main:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--log-level",
+            "warning",
+        ],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    base = f"http://127.0.0.1:{port}"
+
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError("the test server exited before it became ready")
+        try:
+            urllib.request.urlopen(f"{base}/dashboard", timeout=1)
+            break
+        except urllib.error.URLError, ConnectionError, TimeoutError:
+            time.sleep(0.2)
+    else:
+        proc.terminate()
+        raise RuntimeError("the test server never became ready")
+
+    try:
+        yield base
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+
+@pytest.fixture(scope="session")
+def browser():
+    with sync_playwright() as p:
+        try:
+            instance = p.chromium.launch()
+        except Exception as exc:  # pragma: no cover - environment guard
+            pytest.skip(f"Chromium is not installed for Playwright: {exc}")
+        try:
+            yield instance
+        finally:
+            instance.close()
+
+
+@pytest.fixture(scope="session")
+def measure(browser, live_server):
+    """Return `measure(page_name, viewport) -> dict` for the whole session.
+
+    Results are cached: every assertion below reads the same measurement of the
+    same rendered page, so a full run costs one page load per page/viewport.
+    """
+    from .probes import MEASURE_JS
+
+    cache: dict[tuple[str, str], dict] = {}
+    contexts: dict[str, object] = {}
+
+    def _measure(page_name: str, viewport: str) -> dict:
+        key = (page_name, viewport)
+        if key in cache:
+            return cache[key]
+        if viewport not in contexts:
+            width, height = VIEWPORTS[viewport]
+            contexts[viewport] = browser.new_context(
+                viewport={"width": width, "height": height},
+                # A phone reports a coarse pointer; the stylesheet keys its
+                # touch targets off that as well as off width.
+                is_mobile=(viewport == "mobile"),
+                has_touch=(viewport != "desktop"),
+            )
+        page = contexts[viewport].new_page()
+        try:
+            page.goto(live_server + PAGES[page_name], wait_until="networkidle")
+            page.wait_for_timeout(250)
+            cache[key] = page.evaluate(MEASURE_JS)
+        finally:
+            page.close()
+        return cache[key]
+
+    try:
+        yield _measure
+    finally:
+        for ctx in contexts.values():
+            ctx.close()

--- a/tests/visual/probes.py
+++ b/tests/visual/probes.py
@@ -1,0 +1,208 @@
+"""The single in-page measurement used by every visual assertion.
+
+One script, evaluated once per page and viewport, returning geometry and
+computed styles. Keeping it in one place means the tests all describe the same
+rendering rather than each poking at the DOM their own way.
+"""
+
+MEASURE_JS = r"""
+() => {
+  const px = (v) => Math.round(v * 10) / 10;
+  const box = (el) => {
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return {
+      x: px(r.x), y: px(r.y + window.scrollY), w: px(r.width), h: px(r.height),
+      right: px(r.right), bottom: px(r.bottom + window.scrollY),
+    };
+  };
+  const visible = (el) => {
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0;
+  };
+
+  const root = getComputedStyle(document.documentElement);
+  const token = (name) => root.getPropertyValue(name).trim();
+  const remPx = parseFloat(getComputedStyle(document.documentElement).fontSize);
+  const toPx = (value) => value.endsWith('rem')
+    ? Math.round(parseFloat(value) * remPx * 100) / 100
+    : parseFloat(value);
+
+  const out = {};
+
+  out.tokens = {
+    space: ['1','2','3','4','5','6','7','8'].map(n => token(`--space-${n}`)),
+    text: ['xs','sm','base','lg','xl','display'].map(n => token(`--text-${n}`)),
+    textPx: ['xs','sm','base','lg','xl','display'].map(n => toPx(token(`--text-${n}`))),
+    colours: ['ink','ink-strong','ink-muted','ink-subtle','rule','rule-subtle',
+              'surface','surface-sunken','inverse'].map(n => token(`--${n}`)),
+    targetMin: toPx(token('--target-min')),
+  };
+
+  out.frame = {
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+    viewportHeight: window.innerHeight,
+    horizontalOverflow:
+      document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
+  };
+
+  // ---- page-level blocks that must share a left edge ----
+  // Only blocks that sit directly in the page column. Anything nested inside a
+  // bordered container is inset on purpose.
+  out.leftEdges = {};
+  for (const sel of ['.header', 'nav', '.page', '.page-header-row', '.toolbar', 'footer']) {
+    const el = document.querySelector(sel);
+    if (el && visible(el)) out.leftEdges[sel] = px(el.getBoundingClientRect().x);
+  }
+
+  // ---- the first row of real content, for the mobile fold check ----
+  const firstContent = document.querySelector(
+    '.list-container, #groups-container, .dashboard-grid, .border-container');
+  out.firstContent = box(firstContent);
+
+  // ---- page header ----
+  const headerRow = document.querySelector('.page-header-row');
+  const meta = document.querySelector('.page-header-meta');
+  const toolbar = document.querySelector('.toolbar');
+  out.pageHeader = headerRow ? {
+    row: box(headerRow),
+    meta: box(meta),
+    hasActions: !!document.querySelector('.page-header-actions'),
+  } : null;
+  out.toolbarBox = box(toolbar);
+  // Distance from the whole header block to the next sibling block.
+  const headerBlock = document.querySelector('.page-header');
+  if (headerBlock && headerBlock.nextElementSibling) {
+    out.headerToNext = px(
+      box(headerBlock.nextElementSibling).y - box(headerBlock).bottom);
+  }
+
+  // ---- toolbar anatomy ----
+  out.toolbar = null;
+  if (toolbar) {
+    const groups = [];
+    for (const g of toolbar.querySelectorAll('.toolbar-group')) {
+      const label = g.querySelector('.toolbar-label');
+      const chips = Array.from(g.querySelectorAll('.filter-chip'));
+      if (!label || !chips.length) continue;
+      const lb = box(label), first = box(chips[0]);
+      groups.push({
+        label: label.textContent.trim(),
+        chipCount: chips.length,
+        // Inline iff the label's vertical centre falls inside the first chip.
+        labelInline: lb.y + lb.h / 2 >= first.y && lb.y + lb.h / 2 <= first.bottom,
+      });
+    }
+    const reset = toolbar.querySelector('.toolbar-reset .btn--quiet');
+    out.toolbar = {
+      box: box(toolbar),
+      groups,
+      reset: box(reset),
+      resetText: reset ? reset.textContent.trim() : null,
+      // The reset must be the toolbar's last child, not a member of a filter group.
+      resetIsLastChild:
+        !!reset && reset.closest('.toolbar-reset') === toolbar.lastElementChild,
+      resetInsideGroup: !!reset && !!reset.closest('.toolbar-group'),
+    };
+  }
+
+  // ---- interactive targets, measured at their effective hit area ----
+  // A checkbox inside a <label> is tapped via the label, so the label is the
+  // target; likewise a control wrapped in a purpose-built hit area.
+  out.targets = [];
+  const sel = 'button, a[href], select, input:not([type=hidden]), [role=button]';
+  for (const el of document.querySelectorAll(sel)) {
+    if (!visible(el)) continue;
+    // WCAG 2.5.8 exempts a target rendered inline inside a run of prose — a
+    // help-text link cannot be 44px tall without wrecking the sentence.
+    if (getComputedStyle(el).display === 'inline') continue;
+    let hit = el;
+    const wrapper = el.closest('label, .todo-checkbox');
+    if (wrapper && visible(wrapper)) hit = wrapper;
+    const r = hit.getBoundingClientRect();
+    out.targets.push({
+      tag: el.tagName.toLowerCase(),
+      cls: (el.className || '').toString().slice(0, 60),
+      label: (el.textContent || el.value || '').trim().slice(0, 30),
+      w: px(r.width), h: px(r.height),
+    });
+  }
+
+  // ---- focus rings: focus each kind of control and look for a visible ring ----
+  out.focusable = [];
+  {
+    const seen = new Set();
+    for (const el of document.querySelectorAll('button, a[href], input, select, textarea')) {
+      // A disabled control cannot take focus, so it has no focus state to check.
+      if (!visible(el) || el.disabled) continue;
+      const key = (el.className || '').toString() || el.tagName;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      el.focus();
+      const cs = getComputedStyle(el);
+      const ring = !(cs.outlineStyle === 'none' || parseFloat(cs.outlineWidth) === 0)
+        || cs.boxShadow !== 'none';
+      out.focusable.push({cls: key.slice(0, 60), tag: el.tagName.toLowerCase(), ring});
+      el.blur();
+    }
+  }
+
+  // ---- computed style census, plus the text/contrast sample ----
+  const srgb = (c) => { c /= 255; return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4); };
+  const lum = (rgb) => {
+    const m = rgb.match(/\d+(\.\d+)?/g).map(Number);
+    return 0.2126 * srgb(m[0]) + 0.7152 * srgb(m[1]) + 0.0722 * srgb(m[2]);
+  };
+  const opaqueBackground = (el) => {
+    for (let n = el; n; n = n.parentElement) {
+      const bg = getComputedStyle(n).backgroundColor;
+      const m = bg.match(/\d+(\.\d+)?/g);
+      if (m && (m.length < 4 || Number(m[3]) > 0.5)) return bg;
+    }
+    return 'rgb(255, 255, 255)';
+  };
+
+  out.fontSizes = {};
+  out.colours = {};
+  out.contrast = [];
+  for (const el of document.querySelectorAll('body *')) {
+    if (!visible(el)) continue;
+    const cs = getComputedStyle(el);
+    out.fontSizes[cs.fontSize] = (out.fontSizes[cs.fontSize] || 0) + 1;
+    out.colours[cs.color] = (out.colours[cs.color] || 0) + 1;
+
+    // Only elements holding their own run of real text, so single-glyph
+    // decorations (empty stars, dropdown carets) are not treated as copy.
+    const own = Array.from(el.childNodes)
+      .filter(n => n.nodeType === 3)
+      .map(n => n.textContent.trim())
+      .join('');
+    if (own.length < 3) continue;
+    const l1 = lum(cs.color), l2 = lum(opaqueBackground(el));
+    const ratio = (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+    out.contrast.push({
+      cls: (el.className || '').toString().slice(0, 50),
+      tag: el.tagName.toLowerCase(),
+      colour: cs.color,
+      fontSize: cs.fontSize,
+      ratio: Math.round(ratio * 100) / 100,
+      text: own.slice(0, 40),
+    });
+  }
+
+  // ---- modal chassis ----
+  out.modals = [];
+  for (const overlay of document.querySelectorAll('.modal-overlay')) {
+    const content = overlay.querySelector('.modal-content');
+    out.modals.push({
+      id: overlay.id,
+      hasScroll: !!content.querySelector('.modal-scroll'),
+      hasBody: !!content.querySelector('.modal-body'),
+      hasTitle: !!content.querySelector('h3'),
+    });
+  }
+
+  return out;
+}
+"""

--- a/tests/visual/test_design_system.py
+++ b/tests/visual/test_design_system.py
@@ -1,0 +1,202 @@
+"""Design-system regression tests.
+
+These encode the rules in docs/visual-design-system.md as assertions against a
+real rendering. They are deliberately geometric rather than pixel-based: when
+one fails it says which rule broke and by how much, which a screenshot diff
+cannot.
+
+Each test names the audit finding it protects against.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import PAGES, TOOLBAR_PAGES, VIEWPORTS
+
+ALL_PAGES = sorted(PAGES)
+TARGET_MIN = 44.0
+
+
+@pytest.mark.parametrize("viewport", sorted(VIEWPORTS))
+@pytest.mark.parametrize("page", ALL_PAGES)
+def test_page_blocks_share_a_left_edge(measure, page, viewport):
+    """A1 — the header, nav, page column and footer must line up.
+
+    Two nested max-widths used to put every desktop page 2px out of line with
+    its own header rule.
+    """
+    edges = measure(page, viewport)["leftEdges"]
+    assert len(set(edges.values())) == 1, f"left edges disagree on {page}/{viewport}: {edges}"
+
+
+@pytest.mark.parametrize("viewport", sorted(VIEWPORTS))
+@pytest.mark.parametrize("page", ALL_PAGES)
+def test_no_horizontal_overflow(measure, page, viewport):
+    """The body never scrolls sideways at any supported width."""
+    frame = measure(page, viewport)["frame"]
+    assert not frame["horizontalOverflow"], (
+        f"{page}/{viewport} scrolls horizontally: {frame['scrollWidth']} > {frame['clientWidth']}"
+    )
+
+
+@pytest.mark.parametrize("viewport", sorted(VIEWPORTS))
+@pytest.mark.parametrize("page", TOOLBAR_PAGES)
+def test_filter_labels_are_placed_by_rule_not_by_chip_count(measure, page, viewport):
+    """B1 — label placement is a design decision, not an accident of wrapping.
+
+    Stacked below 768px, inline at and above it. Before the rebuild this was
+    emergent: three chips sat inline and four did not, so Meal History showed
+    both behaviours in one toolbar and adding a family member relaid out a page.
+    """
+    toolbar = measure(page, viewport)["toolbar"]
+    assert toolbar, f"{page} has no toolbar"
+    if not toolbar["groups"]:
+        # Chips are derived from the rows on the page, so a page whose archive
+        # is empty in the sample data renders none. Nothing to compare.
+        pytest.skip(f"{page} renders no filter chips with the seeded data")
+    expected = VIEWPORTS[viewport][0] >= 768
+    for group in toolbar["groups"]:
+        assert group["labelInline"] is expected, (
+            f"{page}/{viewport}: '{group['label']}' ({group['chipCount']} chips) "
+            f"is {'inline' if group['labelInline'] else 'stacked'}, expected "
+            f"{'inline' if expected else 'stacked'}"
+        )
+
+
+@pytest.mark.parametrize("viewport", sorted(VIEWPORTS))
+def test_clear_filters_occupies_one_fixed_slot_on_every_page(measure, viewport):
+    """B2 — the reset control cannot drift between pages.
+
+    It used to be a child of whichever filter group a template picked, so it
+    landed in five positions across five pages, and on Meal History it changed
+    row as well as column.
+    """
+    seen: dict[str, tuple[float, float]] = {}
+    for page in TOOLBAR_PAGES:
+        toolbar = measure(page, viewport)["toolbar"]
+        assert toolbar["reset"], f"{page} has no toolbar reset slot"
+        assert toolbar["resetText"] == "Clear Filters"
+        assert not toolbar["resetInsideGroup"], f"{page}: the reset is inside a filter group again"
+        assert toolbar["resetIsLastChild"], f"{page}: the reset is not the toolbar's last block"
+        reset = toolbar["reset"]
+        seen[page] = (reset["x"], round(reset["bottom"] - toolbar["box"]["bottom"], 1))
+
+    positions = set(seen.values())
+    assert len(positions) == 1, f"Clear Filters sits differently across pages at {viewport}: {seen}"
+
+
+@pytest.mark.parametrize("viewport", sorted(VIEWPORTS))
+def test_page_header_is_the_same_distance_from_the_next_block_everywhere(measure, viewport):
+    """A2/A3 — the band under the title rule comes from the stack, not luck.
+
+    It used to be 32, 61 or 92px depending on whether a page happened to carry
+    an archive link and a retention note as loose siblings.
+    """
+    gaps = {}
+    for page in ALL_PAGES:
+        data = measure(page, viewport)
+        if data.get("headerToNext") is not None:
+            gaps[page] = data["headerToNext"]
+    assert len(gaps) >= 6, f"expected most pages to use .page-header, got {sorted(gaps)}"
+    assert len(set(gaps.values())) == 1, f"header-to-content gap varies at {viewport}: {gaps}"
+
+
+@pytest.mark.parametrize("page", ALL_PAGES)
+def test_content_starts_above_the_fold_on_a_phone(measure, page):
+    """A4 — a phone must show real content without scrolling.
+
+    Four of eight pages used to place the first row below an 844px viewport;
+    Completed Tasks needed 981px before anything actionable appeared.
+    """
+    data = measure(page, "mobile")
+    first, height = data["firstContent"], data["frame"]["viewportHeight"]
+    assert first, f"{page} renders no content container"
+    assert first["y"] < height, (
+        f"{page}: first content row at {first['y']}px, below the {height}px fold"
+    )
+
+
+@pytest.mark.parametrize("page", ALL_PAGES)
+def test_touch_targets_meet_44px_on_a_phone(measure, page):
+    """E2 — every hit area is at least 44×44 where fingers are used.
+
+    Measured at the effective target: a checkbox inside a label is tapped via
+    the label, so the label is what has to be big enough.
+    """
+    too_small = [
+        t for t in measure(page, "mobile")["targets"] if t["w"] < TARGET_MIN or t["h"] < TARGET_MIN
+    ]
+    assert not too_small, f"{page} has undersized touch targets: {too_small[:6]}"
+
+
+@pytest.mark.parametrize("page", ALL_PAGES)
+def test_every_control_shows_a_focus_ring(measure, page):
+    """E1 — no control may suppress focus without replacing it.
+
+    The whole filter toolbar used to set `outline: none` on `:focus`, leaving
+    keyboard users with no indication of where they were.
+    """
+    blind = [f for f in measure(page, "desktop")["focusable"] if not f["ring"]]
+    assert not blind, f"{page} has controls with no visible focus ring: {blind}"
+
+
+@pytest.mark.parametrize("viewport", sorted(VIEWPORTS))
+@pytest.mark.parametrize("page", ALL_PAGES)
+def test_type_sizes_come_from_the_scale(measure, page, viewport):
+    """C1 — every rendered font-size is one of the six type tokens.
+
+    There were 17 declared sizes, nine of them inside a 0.4rem band.
+    """
+    data = measure(page, viewport)
+    allowed = {round(v, 2) for v in data["tokens"]["textPx"]}
+    used = {round(float(size.rstrip("px")), 2) for size in data["fontSizes"]}
+    assert used <= allowed, (
+        f"{page}/{viewport} renders off-scale type: "
+        f"{sorted(used - allowed)} (scale: {sorted(allowed)})"
+    )
+
+
+@pytest.mark.parametrize("page", ALL_PAGES)
+def test_colours_come_from_the_palette(measure, page):
+    """C4 — every rendered text colour is a palette role."""
+    data = measure(page, "desktop")
+
+    def norm(value: str) -> tuple[int, ...]:
+        if value.startswith("#"):
+            v = value.lstrip("#")
+            return tuple(int(v[i : i + 2], 16) for i in (0, 2, 4))
+        return tuple(int(float(n)) for n in __import__("re").findall(r"\d+(?:\.\d+)?", value)[:3])
+
+    allowed = {norm(c) for c in data["tokens"]["colours"]}
+    used = {norm(c) for c in data["colours"]}
+    assert used <= allowed, f"{page} renders off-palette colours: {sorted(used - allowed)}"
+
+
+@pytest.mark.parametrize("page", ALL_PAGES)
+def test_text_meets_wcag_aa_contrast(measure, page):
+    """C5 — no run of text falls below 4.5:1.
+
+    #999999 was used as a text colour in ten rules at 2.85:1, carrying real
+    information: purchase dates, "Not yet rated", the paused state on
+    recurring tasks.
+    """
+    failures = [c for c in measure(page, "desktop")["contrast"] if c["ratio"] < 4.5]
+    assert not failures, f"{page} has text below 4.5:1: {failures[:6]}"
+
+
+@pytest.mark.parametrize("page", ALL_PAGES)
+def test_every_modal_uses_the_shared_chassis(measure, page):
+    """D2 — one modal chassis, so scrollable content signals itself the same way.
+
+    Five modals had the scroll wrapper and six did not; on a phone the ones
+    without filled ~90% of the viewport with no fade to say more lay below.
+    """
+    for modal in measure(page, "desktop")["modals"]:
+        # The verification dialog is the documented exception: no title, no
+        # form, a single centred status block.
+        if not modal["hasTitle"]:
+            continue
+        assert modal["hasScroll"] and modal["hasBody"], (
+            f"{page}: modal #{modal['id']} is missing the .modal-scroll/.modal-body chassis"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -318,6 +318,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/fb/011c7c717213182caf78084a9bea51c8590b0afda98001f69d9f853a495b/greenlet-3.3.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:bd59acd8529b372775cd0fcbc5f420ae20681c5b045ce25bd453ed8455ab99b5", size = 275737, upload-time = "2026-01-23T15:32:16.889Z" },
     { url = "https://files.pythonhosted.org/packages/41/2e/a3a417d620363fdbb08a48b1dd582956a46a61bf8fd27ee8164f9dfe87c2/greenlet-3.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b31c05dd84ef6871dd47120386aed35323c944d86c3d91a17c4b8d23df62f15b", size = 646422, upload-time = "2026-01-23T16:01:00.354Z" },
     { url = "https://files.pythonhosted.org/packages/b4/09/c6c4a0db47defafd2d6bab8ddfe47ad19963b4e30f5bed84d75328059f8c/greenlet-3.3.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:02925a0bfffc41e542c70aa14c7eda3593e4d7e274bfcccca1827e6c0875902e", size = 658219, upload-time = "2026-01-23T16:05:30.956Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/89/b95f2ddcc5f3c2bc09c8ee8d77be312df7f9e7175703ab780f2014a0e781/greenlet-3.3.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3e0f3878ca3a3ff63ab4ea478585942b53df66ddde327b59ecb191b19dbbd62d", size = 671455, upload-time = "2026-01-23T16:15:57.232Z" },
     { url = "https://files.pythonhosted.org/packages/80/38/9d42d60dffb04b45f03dbab9430898352dba277758640751dc5cc316c521/greenlet-3.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34a729e2e4e4ffe9ae2408d5ecaf12f944853f40ad724929b7585bca808a9d6f", size = 660237, upload-time = "2026-01-23T15:32:53.967Z" },
     { url = "https://files.pythonhosted.org/packages/96/61/373c30b7197f9e756e4c81ae90a8d55dc3598c17673f91f4d31c3c689c3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:aec9ab04e82918e623415947921dea15851b152b822661cce3f8e4393c3df683", size = 1615261, upload-time = "2026-01-23T16:04:25.066Z" },
     { url = "https://files.pythonhosted.org/packages/fd/d3/ca534310343f5945316f9451e953dcd89b36fe7a19de652a1dc5a0eeef3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:71c767cf281a80d02b6c1bdc41c9468e1f5a494fb11bc8688c360524e273d7b1", size = 1683719, upload-time = "2026-01-23T15:33:50.61Z" },
@@ -326,6 +327,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/24/cbbec49bacdcc9ec652a81d3efef7b59f326697e7edf6ed775a5e08e54c2/greenlet-3.3.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:3e63252943c921b90abb035ebe9de832c436401d9c45f262d80e2d06cc659242", size = 282706, upload-time = "2026-01-23T15:33:05.525Z" },
     { url = "https://files.pythonhosted.org/packages/86/2e/4f2b9323c144c4fe8842a4e0d92121465485c3c2c5b9e9b30a52e80f523f/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76e39058e68eb125de10c92524573924e827927df5d3891fbc97bd55764a8774", size = 651209, upload-time = "2026-01-23T16:01:01.517Z" },
     { url = "https://files.pythonhosted.org/packages/d9/87/50ca60e515f5bb55a2fbc5f0c9b5b156de7d2fc51a0a69abc9d23914a237/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9f9d5e7a9310b7a2f416dd13d2e3fd8b42d803968ea580b7c0f322ccb389b97", size = 654300, upload-time = "2026-01-23T16:05:32.199Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/25/c51a63f3f463171e09cb586eb64db0861eb06667ab01a7968371a24c4f3b/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b9721549a95db96689458a1e0ae32412ca18776ed004463df3a9299c1b257ab", size = 662574, upload-time = "2026-01-23T16:15:58.364Z" },
     { url = "https://files.pythonhosted.org/packages/1d/94/74310866dfa2b73dd08659a3d18762f83985ad3281901ba0ee9a815194fb/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92497c78adf3ac703b57f1e3813c2d874f27f71a178f9ea5887855da413cd6d2", size = 653842, upload-time = "2026-01-23T15:32:55.671Z" },
     { url = "https://files.pythonhosted.org/packages/97/43/8bf0ffa3d498eeee4c58c212a3905dd6146c01c8dc0b0a046481ca29b18c/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ed6b402bc74d6557a705e197d47f9063733091ed6357b3de33619d8a8d93ac53", size = 1614917, upload-time = "2026-01-23T16:04:26.276Z" },
     { url = "https://files.pythonhosted.org/packages/89/90/a3be7a5f378fc6e84abe4dcfb2ba32b07786861172e502388b4c90000d1b/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:59913f1e5ada20fde795ba906916aea25d442abcc0593fba7e26c92b7ad76249", size = 1676092, upload-time = "2026-01-23T15:33:52.176Z" },
@@ -650,6 +652,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.62.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/5b/ca2abcf3aa69f9fb510215e3064f30b57fe57657c8d04ede45bb966d5606/playwright-1.62.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d8da938f3748841a8754f2e1f0216902c1c8f8ae3720de8b32ccf8e6913a7c4f", size = 43732091, upload-time = "2026-07-31T17:00:44.178Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/0bfbe9904350961f4dbb713f04342e40d548c5fc26c8157bd13617c81492/playwright-1.62.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:db755ab27db21a04186f1fe8169888e42356086e439b1059b923ef417f0b6034", size = 42510842, upload-time = "2026-07-31T17:00:48.596Z" },
+    { url = "https://files.pythonhosted.org/packages/66/dc/c0486b407ad0699a250f6bbe3066fca95344009a99ca66e88ca175c69dc1/playwright-1.62.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:5108bd5b3e87169ddf269feee097da5893af7f8aea4634dfc840518d64c1f1da", size = 43732093, upload-time = "2026-07-31T17:00:52.218Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6b/b24aebc2b04bffcb342bccf96e287c78b363e1615bed5cea97500cc0393a/playwright-1.62.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:ba33bae6a13b3d9d354c751cb618af357d20fe1d57767cbcce52079bbef17ad3", size = 47748926, upload-time = "2026-07-31T17:00:56.438Z" },
+    { url = "https://files.pythonhosted.org/packages/36/43/b4b18bdc87e1949568fffdcde3ff9a0456266b2d0c6d4432cc34d89ea6eb/playwright-1.62.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db2d76613a57ad844362ce42f7d0c2fa26b19a4f7a46d4f76b891c631e6e5aff", size = 47441423, upload-time = "2026-07-31T17:01:00.404Z" },
+    { url = "https://files.pythonhosted.org/packages/81/22/af5d926fc2c32a339eec00a443644bc40ab9db1dd2dd9017873c59773c0c/playwright-1.62.0-py3-none-win32.whl", hash = "sha256:e5614fa89355d7081457680324bb219f79f69c423c5cb6fa250e30b0d8aebf1c", size = 38164450, upload-time = "2026-07-31T17:01:04.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a9/4160c1033c07af98bf841ad079457dd78408a5ee0dd56cbfe50b8b6a1c22/playwright-1.62.0-py3-none-win_amd64.whl", hash = "sha256:92c0d98ed04eb35af557b709875edba415b1f548bdb22ddb5bb3e1e6c835c2f1", size = 38164458, upload-time = "2026-07-31T17:01:08.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ec/06b55d619a7082a766aa04f2c6bb31435c87f02930087d8a0517119408fa/playwright-1.62.0-py3-none-win_arm64.whl", hash = "sha256:ea8d3055aa9d5a9f1832ac82517bd8b42c78fac7ebcbebb0107116735c8cb6a1", size = 34208868, upload-time = "2026-07-31T17:01:11.818Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -742,6 +763,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -901,6 +934,9 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
+visual = [
+    { name = "playwright" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -922,6 +958,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
 ]
+visual = [{ name = "playwright", specifier = ">=1.48" }]
 
 [[package]]
 name = "recurring-ical-events"


### PR DESCRIPTION
## Summary

A full visual-consistency audit of all eight pages and eleven modals — measured
in the DOM at 1440×900, 834×1112 and 390×844 — and the design system built to
close every finding.

Rally's serif, monochrome, editorial identity is unchanged. What changes is that
it is now expressed the same way on every page, and is held there by tests.

`docs/visual-design-system.md` carries the whole thing: the audit, the system,
and the enforcement. `/styleguide` renders every component from the live
stylesheet.

## The problem, measured

Every page was built by hand against one flat 1,723-line stylesheet with no
shared vocabulary, so the same idea was expressed slightly differently each
time. 33 findings; the ones that drove the work:

**The three that were reported**

- **Chips sat beside the "Store" label but below "Assignee".** `.toolbar-group`
  was a wrapping flex row and `.filter-chips` a single flex item, so placement
  was decided by chip count: at 390px, 3 chips stayed inline and 4+ did not.
  Meal History showed both behaviours *in one toolbar*. Adding a family member
  relaid out the page.
- **"Clear Filters" moved between Meal Planner and Meal History.** It was a
  child of whichever `.toolbar-group` each template picked, so it had no slot.
  At 1440px it landed at x=771 (Tasks), 732 (Meal Planner), 654 (Shopping), 384
  (Purchased) and — on Meal History — x=628 on the *second* row, stranded
  between the Rating chips and the Sort label.
- **Empty space around "Meal History" pushed content down.** The band from the
  title rule to the toolbar was 32px, 61px or 92px depending on whether a page
  happened to carry an archive link and a retention note as loose siblings.

**What the measurements added**

- **Mobile chrome ate the whole first screen.** First content row against an
  844px viewport: Completed Tasks 981px (116%), Tasks 864px (102%), Meal History
  861px (102%), Purchased Items 830px (98%).
- **`--light-gray` (#999) failed WCAG AA at 2.85:1** and was used as a text
  colour in 10 rules, including purchase dates and "Not yet rated".
- **The toolbar had no visible keyboard focus at all** — four controls set
  `outline: none` on `:focus` with no replacement.
- **Two primary buttons, both "Save", both on Settings**: 80×43/16px on the nine
  inline forms, 61×37/14.4px in the four modals opened from that same page.
- **A 2px horizontal jog on every desktop page**, because `body` yielded an
  804px content box while `.section-container` capped at 800px.
- **The modal chassis was split**: 5 modals had the scroll-fade affordance, 6
  did not. At 390px, Add Team filled 90% of the viewport with no fade.
- **17 font sizes, 18 spacing values, 7 letter-spacings**, no scale, no tokens.
- **Dead and duplicated CSS**: `footer`, `footer a` and `footer a:hover`
  declared twice verbatim; the whole `.plan-*` family unused.

## The solution

**Tokens** (`:root`) — one 4px space scale, six type steps, and colours named by
role (`--ink`, `--ink-muted`, `--ink-subtle`, `--rule`, `--surface`) rather than
appearance. `--ink-subtle` (#767676, 4.54:1) replaced #999 everywhere it carried
text; #999 no longer exists.

**Layout primitives** — `.page` (one max-width, owned by `body`),
`.page-header` (title, actions and secondary links as one block), `.stack`
(block rhythm in one declaration). Dashboard and Settings now use them too;
Settings gained a page-level `h2` and its sections became `h3`.

**The toolbar** is one grid: `display: contents` promotes each group's label and
control into it, so every label shares a column and every control starts at the
same x. Labels stack below 768px and sit inline above it — explicitly, not
emergently. `Clear Filters` is rendered by the toolbar as its last block.
`Manage stores` moved to the page header, since it is navigation, not a filter.

**Components** — nine button classes became `.btn` plus `--secondary`,
`--quiet`, `--sm`. One `:focus-visible` rule covers everything. Hit areas are
44px under `(pointer: coarse)` *and* below 768px — the wall tablet is a coarse
pointer at desktop width. All eleven modals share one chassis, extracted to
`static/modal.js`.

## Results

| | Before | After |
|---|---|---|
| Distinct rendered font sizes | 11 | 6, all tokens |
| Declared `font-size` values | 17 | 6 tokens |
| Declared spacing values | 18 | 8 tokens |
| Positions of "Clear Filters" across pages | 5 | 1 |
| Label/chip placement | chip-count dependent | 1 rule per breakpoint |
| Pages with content below the mobile fold | 4 of 8 | 0 of 8 |
| Text below WCAG AA | 10 rules | 0 |
| Controls with no focus ring | 4 | 0 |
| Modals missing the scroll chassis | 6 of 11 | 0 |
| Duplicate rule blocks | 4 | 0, enforced |

## Enforcement

**`tests/test_stylesheet.py`** — static, no browser, runs in the normal test
job. No selector declared twice in the same context, no rule suppressing the
focus ring, no colour/type/spacing literal outside the token block. It earned
its place immediately: it caught a stale duplicate `.toolbar-search` rule that
was silently overriding the new grid, and a second `:root` block in the same
media query.

**`tests/visual/`** — the audit's measuring code turned into assertions against
a real browser and a seeded database, in its own CI job. Each test names the
finding it guards: left edges agree; the header sits the same distance from the
next block on every page; content is above the fold at 390×844; labels follow
the breakpoint rule; Clear Filters occupies one slot; type and colour come from
tokens; text clears 4.5:1; every modal has the chassis; every control has a
focus ring; no target under 44px; no horizontal overflow.

Geometric rather than pixel-based on purpose — a failure says which rule broke
and by how much. The suite skips itself when Playwright is absent, so
`uv run pytest` stays browser-free for anyone not working on the design system.

## Notes for reviewers

- **The two deliberate behaviour changes** are both in the toolbar: label
  placement is now explicit, and "Manage stores" left the filter bar. Everything
  else is the same behaviour, rendered consistently.
- **`/styleguide` ships**, unlinked from the nav. A styleguide that exists only
  in development stops matching production. It reads the scales back out of the
  cascade, so it cannot describe a scale the CSS no longer has.
- **No screenshot baselines.** The geometry assertions and the stylesheet lint
  cover the failures worth catching and explain themselves when they break;
  baselines would add churn and a binary diff for every intentional change.
- **`/dashboard` still has no `h2`** — the wordmark and today's date are already
  its title. It uses the same primitives; only the redundant heading is omitted.
- **The verification dialog keeps a documented variant** (`--narrow`, no scroll
  wrapper): no title, no form, one centred status block. The test exempts
  titleless modals rather than pretending the variant does not exist.
- `uv sync --group visual` drops the editable `rally` install. Tests still work
  (pytest puts `src/` on the path); a bare `uvicorn` then needs `PYTHONPATH=src`.

## Testing

- `uv run pytest` — 622 passed, 3 skipped
- `uv run ruff check .` / `ruff format --check .` — pass
- `uv run pytest tests/visual -v` — 156 passed, 3 skipped, against Chromium
- Both CI jobs green, including the new `visual` job
- The 3 skips are the purchased-items filter assertions: the sample seed leaves
  that archive empty, so the page renders no chips to compare

🤖 Generated with [Claude Code](https://claude.com/claude-code)
