### PR TITLE
Add configurable, per-provider LLM max tokens with a model-maximum option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,6 +376,7 @@ Rally uses a simple, file-based migration system. All migrations live in the `mi
 - `016_add_stem_concept_history` - Add `stem_concept_history` table (records used STEM "concept of the day" topics so the generator avoids repeating a specific topic within 60 days)
 - `017_add_shopping_lists` - Add `shopping_stores`, `shopping_items`, and `shopping_item_history` tables, plus the case-insensitive unique index on store names and the unique index on `shopping_item_history.name_key`
 - `018_add_sports_watchlist` - Add `followed_teams` and `sports_event_notices` tables, plus the unique index on `sports_event_notices.event_key` (records which notable upcoming events have already been announced, so one is mentioned once rather than every morning for two weeks)
+- `019_add_llm_max_tokens` - Backfill `max_tokens`/`max_tokens_mode` (`4000`/`"custom"`) into every `llm_settings_history` row's JSON value that lacks them (unparseable rows are skipped, not rewritten), and seed the `llm_anthropic_max_tokens`, `llm_local_max_tokens`, and `llm_anthropic_max_tokens_mode` settings keys when absent. The backfilled value matches prior behavior exactly, so this migration changes nothing observable by itself
 
 ### Running Migrations
 
@@ -563,6 +564,8 @@ rally/
 │   ├── migrate_012_add_ai_settings_history.py # Migration 012: add ai_settings_history table
 │   ├── migrate_015_add_llm_settings_history.py # Migration 015: add llm_settings_history table
 │   ├── migrate_017_add_shopping_lists.py # Migration 017: add shopping list tables
+│   ├── migrate_018_add_sports_watchlist.py # Migration 018: add followed_teams, sports_event_notices tables
+│   ├── migrate_019_add_llm_max_tokens.py # Migration 019: backfill per-provider LLM max tokens settings
 │   └── run_migrations.py              # Migration runner (executes all migrations in order)
 ├── data/                 # Mounted in container (not in git)
 │   ├── config.toml       # API keys, URLs, coordinates (optional if using Settings UI)
@@ -608,6 +611,7 @@ rally/
   - `shopping_list_in_summary_enabled` ("true"/"false", default "false") folds open shopping items into the daily summary (Shopping List section)
   - `shopping_last_purge_date` (local YYYY-MM-DD) is internal bookkeeping written by the shopping retention purge — never surfaced in the UI
   - `sports_watchlist_enabled` ("true"/"false", default "false") folds tonight's games and notable upcoming events for followed teams into the daily summary (Sports section)
+  - `llm_anthropic_max_tokens` / `llm_local_max_tokens` (default `"4000"` each) are the per-provider token budgets `_call_llm` sends — each provider owns its own key, so switching `Provider` never carries one provider's budget onto the other. `llm_anthropic_max_tokens_mode` (`"model_max"` or `"custom"`, default `"custom"`) is Anthropic-only; in `"model_max"` mode the value is resolved from the Anthropic Models API at save time (not on every generation run) and stored, not re-resolved later — rollback restores the stored number verbatim rather than re-resolving it
   - Connection verification on save: LLM, Weather, Calendar, and Followed Team settings show a verification modal with spinner, checkmark on success (auto-closes), or error message with Close button on failure
 - ✅ AI settings snapshotting with version history and rollback
   - `agent_voice` and `family_context` each have their own Save button and Version History link on the settings page
@@ -615,9 +619,10 @@ rally/
   - Version History modal lists snapshots newest first with a `Current` badge and in-place expandable value previews; **Change Version** rolls the field back (bumps `last_used_at`, repoints the setting, no new row) and updates the field without a page reload
   - Fields roll back independently; all snapshots are retained indefinitely
 - ✅ LLM settings snapshotting with version history and rollback
-  - The LLM section's `Provider` and `Model` are versioned as a **single coupled snapshot** (`llm_config`) — saving the LLM form records one `llm_settings_history` row whose JSON `value` captures the provider and its active model together; the active snapshot is referenced by the `current_llm_config_history_id` settings key
-  - The LLM section has one `Save` button and one `Version History` link; the shared Version History modal shows each snapshot's `Provider` / `Model` pair, and **Change Version** restores both together (select flips, provider fields toggle, model input updates — no page reload, no new row)
-  - The plain `llm_provider` / `llm_local_model` / `llm_anthropic_model` settings keys remain the source of truth read by the generator; save and rollback keep them in sync
+  - The LLM section's `Provider`, `Model`, and per-provider `Max Tokens` (plus, for Anthropic, the budget `Mode`) are versioned as a **single coupled snapshot** (`llm_config`) — saving the LLM form records one `llm_settings_history` row whose JSON `value` captures all of them together; the active snapshot is referenced by the `current_llm_config_history_id` settings key
+  - The LLM section has one `Save` button and one `Version History` link; the shared Version History modal shows each snapshot's `Provider` / `Model` / `Max Tokens` (plus `(model maximum)` when that snapshot used auto mode), and **Change Version** restores all of it together (select flips, provider fields toggle, model and max-tokens inputs update, budget radio flips — no page reload, no new row). Rollback restores the snapshot's stored `max_tokens` verbatim; it never re-resolves against the provider
+  - The plain `llm_provider` / `llm_local_model` / `llm_anthropic_model` / `llm_anthropic_max_tokens` / `llm_local_max_tokens` / `llm_anthropic_max_tokens_mode` settings keys remain the source of truth read by the generator; save and rollback keep them in sync
+  - **Budget** (Anthropic only): `Model maximum` resolves the model's real output cap via `client.models.retrieve(model)` at save time and stores the returned integer — the 4 AM job never makes this call itself. An unresolvable model name (typo, missing API key) rejects the save with the error shown in the verify modal, and writes no snapshot. `Custom` accepts any positive integer with no upper bound — model ceilings differ by provider and rise over time, so Rally does not hardcode one. The local provider has no `Budget` control; it is always a plain `Custom` value
 - ✅ Todo management - Full CRUD API and UI
   - Create, read, update, delete todos
   - Optional due dates with native HTML5 date picker
@@ -751,13 +756,13 @@ rally/
   - `PUT /api/settings/ai/{field_name}` - Explicit save: inserts a new `ai_settings_history` snapshot (`created_at` = `last_used_at` = now, UTC) and points the field's `current_<field>_history_id` setting at it
   - `GET /api/settings/ai/{field_name}/history` - List all snapshots for a field, newest first (by `created_at` descending), plus the current history ID
   - `POST /api/settings/ai/{field_name}/rollback` - Make an existing snapshot active: bumps its `last_used_at` and repoints the setting — no new row inserted. Body: `{history_id}`
-- `/api/settings/llm/config` - Versioned LLM configuration endpoints (coupled `provider` + `model` snapshot)
-  - `GET /api/settings/llm/config` - Get the currently active provider + model and history ID
-  - `PUT /api/settings/llm/config` - Explicit save: inserts a new `llm_settings_history` snapshot capturing the provider + model pair, points `current_llm_config_history_id` at it, and syncs the plain `llm_provider` / model settings keys. Body: `{provider, model}`
+- `/api/settings/llm/config` - Versioned LLM configuration endpoints (coupled `provider` + `model` + `max_tokens` + `max_tokens_mode` snapshot)
+  - `GET /api/settings/llm/config` - Get the currently active config and history ID. `max_tokens`/`max_tokens_mode` are `null` when no snapshot exists yet
+  - `PUT /api/settings/llm/config` - Explicit save: inserts a new `llm_settings_history` snapshot, points `current_llm_config_history_id` at it, and syncs the plain `llm_provider` / model / max-tokens settings keys. Body: `{provider, model, max_tokens, max_tokens_mode}` (`max_tokens` defaults to `4000` and must be `> 0`; `max_tokens_mode` defaults to `"custom"`, forced to `"custom"` server-side for any provider other than `"anthropic"`). In `max_tokens_mode: "model_max"`, the submitted `max_tokens` is ignored and re-resolved from the Anthropic Models API — `400` with a `detail` message if the model can't be resolved (unrecognized name, missing/invalid API key), and no snapshot is written on that path
   - `GET /api/settings/llm/config/history` - List all snapshots, newest first, plus the current history ID
-  - `POST /api/settings/llm/config/rollback` - Make an existing snapshot active: restores provider and model together, bumps `last_used_at`, repoints the setting, and syncs the plain settings keys — no new row inserted. Body: `{history_id}`
+  - `POST /api/settings/llm/config/rollback` - Make an existing snapshot active: restores the whole config together (including the stored `max_tokens`, verbatim — never re-resolved), bumps `last_used_at`, repoints the setting, and syncs the plain settings keys — no new row inserted. Body: `{history_id}`
 - `/api/settings/test-llm` - LLM connectivity test
-  - `POST /api/settings/test-llm` - Test LLM provider connection (sends minimal 1-token request). Returns `{success, message}` or `{success, error}`.
+  - `POST /api/settings/test-llm` - Test LLM provider connection (sends minimal 1-token request). Returns `{success, message}` or `{success, error}`. On Anthropic success, `message` appends the configured max-tokens value (e.g. `"Connected to claude-sonnet-4-6 (max tokens: 128000)"`) — the one place a freshly resolved "Model maximum" budget is confirmed to the operator, since the verify modal auto-closes on success and the field's helper text is the durable surface afterward
 - `/api/settings/test-weather` - Weather connectivity test
   - `POST /api/settings/test-weather` - Fetch the configured NWS forecast URL and confirm it returns DWML weather data (10-second timeout). Returns `{success, message}` or `{success, error}`.
 - `/api/calendars` - Calendar feed CRUD endpoints

--- a/migrations/migrate_019_add_llm_max_tokens.py
+++ b/migrations/migrate_019_add_llm_max_tokens.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Migration 019: Add per-provider LLM max tokens settings and snapshot fields.
+
+Backfills 4000 — the value every install has effectively been running under
+the hardcoded LLM_MAX_TOKENS constant — into:
+
+  - llm_settings_history: adds "max_tokens" (4000) and "max_tokens_mode"
+    ("custom") to every llm_config row's JSON value that doesn't already
+    carry them. Rows whose value doesn't parse as JSON are skipped, not
+    rewritten, so a corrupt row can't be silently mangled.
+  - settings: seeds llm_anthropic_max_tokens, llm_local_max_tokens (both
+    "4000"), and llm_anthropic_max_tokens_mode ("custom") when absent —
+    without these the new Max Tokens fields would render empty on first load.
+
+Because the backfilled value matches current behavior exactly, this migration
+changes nothing observable by itself.
+
+Safe to run multiple times (idempotent).
+"""
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+DEFAULT_MAX_TOKENS = "4000"
+
+
+def migrate():
+    """Run the migration. Return True on success, False on failure."""
+    db_path = os.environ.get("RALLY_DB_PATH")
+
+    if not db_path:
+        prod_path = Path("/data/rally.db")
+        dev_path = Path(__file__).parent.parent / "rally.db"
+        db_path = str(prod_path) if prod_path.exists() else str(dev_path)
+
+    db_path = Path(db_path)
+
+    if not db_path.exists():
+        print(f"  Database not found at {db_path}")
+        print("  No migration needed - database will be created with correct schema.")
+        return True
+
+    print(f"Checking database at {db_path}...")
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    try:
+        # Both tables may not exist yet on a fresh database.
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name IN ('llm_settings_history', 'settings')"
+        )
+        existing_tables = {row[0] for row in cursor.fetchall()}
+
+        # BACKFILL: llm_settings_history rows missing the new JSON keys.
+        rewritten = 0
+        skipped = 0
+        if "llm_settings_history" in existing_tables:
+            cursor.execute(
+                "SELECT id, value FROM llm_settings_history WHERE field_name = 'llm_config'"
+            )
+            rows = cursor.fetchall()
+            for row_id, raw_value in rows:
+                try:
+                    config = json.loads(raw_value)
+                except TypeError, ValueError:
+                    skipped += 1
+                    continue
+
+                changed = False
+                if "max_tokens" not in config:
+                    config["max_tokens"] = int(DEFAULT_MAX_TOKENS)
+                    changed = True
+                if "max_tokens_mode" not in config:
+                    config["max_tokens_mode"] = "custom"
+                    changed = True
+
+                if changed:
+                    cursor.execute(
+                        "UPDATE llm_settings_history SET value = ? WHERE id = ?",
+                        (json.dumps(config), row_id),
+                    )
+                    rewritten += 1
+
+        # BACKFILL: settings keys the generator and the Settings UI both read.
+        seeded = []
+        if "settings" in existing_tables:
+            seed_keys = {
+                "llm_anthropic_max_tokens": DEFAULT_MAX_TOKENS,
+                "llm_local_max_tokens": DEFAULT_MAX_TOKENS,
+                "llm_anthropic_max_tokens_mode": "custom",
+            }
+            for key, value in seed_keys.items():
+                cursor.execute("SELECT 1 FROM settings WHERE key = ?", (key,))
+                if cursor.fetchone():
+                    continue
+                cursor.execute(
+                    "INSERT INTO settings (key, value, updated_at) VALUES (?, ?, datetime('now'))",
+                    (key, value),
+                )
+                seeded.append(key)
+
+        conn.commit()
+
+        if rewritten or seeded:
+            print(
+                f"✓ Migration 019: backfilled {rewritten} llm_settings_history row(s) "
+                f"(skipped {skipped} unparseable), seeded settings keys: {seeded or 'none'}"
+            )
+        else:
+            print("✓ Migration 019: nothing to backfill (idempotent)")
+        return True
+
+    except sqlite3.Error as e:
+        print(f"✗ Migration 019 failed: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    success = migrate()
+    sys.exit(0 if success else 1)

--- a/migrations/run_migrations.py
+++ b/migrations/run_migrations.py
@@ -31,6 +31,9 @@ def run_migrations():
         from migrate_018_add_sports_watchlist import (
             migrate as migrate_018_add_sports_watchlist,
         )
+        from migrate_019_add_llm_max_tokens import (
+            migrate as migrate_019_add_llm_max_tokens,
+        )
         from migrate_add_caldav_support import migrate as migrate_008_add_caldav_support
         from migrate_add_completed_at import migrate as migrate_013_add_completed_at
         from migrate_add_custom_recurrence import migrate as migrate_009_add_custom_recurrence
@@ -70,6 +73,7 @@ def run_migrations():
         ("016_add_stem_concept_history", migrate_016_add_stem_concept_history),
         ("017_add_shopping_lists", migrate_017_add_shopping_lists),
         ("018_add_sports_watchlist", migrate_018_add_sports_watchlist),
+        ("019_add_llm_max_tokens", migrate_019_add_llm_max_tokens),
     ]
 
     print("=" * 60)

--- a/src/rally/generator/generate.py
+++ b/src/rally/generator/generate.py
@@ -161,6 +161,10 @@ class SummaryGenerator:
                     api_key=provider_config.get("api_key", "no-key-needed"),
                 )
 
+        # Token budget for this provider. Read after self.provider is set
+        # above, since the resolution depends on which provider is active.
+        self.max_tokens = self._resolve_max_tokens(db_settings)
+
         # Get local timezone: DB setting > config.toml > UTC
         tz_name = db_settings.get("local_timezone", self.config.get("local_timezone", "UTC"))
         self.local_tz_name = tz_name
@@ -188,6 +192,21 @@ class SummaryGenerator:
 
         # Optional: owner emails for accurate declined-event detection (config.toml fallback only)
         self.calendar_owners = self.config.get("calendar_owners", {})
+
+    def _resolve_max_tokens(self, db_settings: dict) -> int:
+        """Resolve this provider's token budget: DB setting > that provider's
+        own config.toml table (e.g. [llm.anthropic]) > the module default.
+
+        Each provider owns its own settings key, so switching providers never
+        carries one provider's budget onto the other.
+        """
+        max_tokens_key = (
+            "llm_anthropic_max_tokens" if self.provider == "anthropic" else "llm_local_max_tokens"
+        )
+        if max_tokens_key in db_settings:
+            return int(db_settings[max_tokens_key])
+        provider_config = self.config.get("llm", {}).get(self.provider, {})
+        return int(provider_config.get("max_tokens", LLM_MAX_TOKENS))
 
     def _is_event_declined(self, component, owner_email: str | None = None) -> bool:
         """Check if a calendar event has been declined.
@@ -899,7 +918,7 @@ class SummaryGenerator:
         if self.provider == "anthropic":
             kwargs: dict = {
                 "model": self.model,
-                "max_tokens": LLM_MAX_TOKENS,
+                "max_tokens": self.max_tokens,
                 "messages": [{"role": "user", "content": user_prompt}],
             }
             if system_prompt:
@@ -910,20 +929,26 @@ class SummaryGenerator:
                         "cache_control": {"type": "ephemeral"},
                     }
                 ]
-            response = self.client.messages.create(**kwargs)
+            # Streaming, rather than a plain create() call: the SDK refuses a
+            # non-streaming request whose max_tokens could exceed its timeout
+            # guard, which a "Model maximum" budget (up to a model's full
+            # output ceiling) can trip. get_final_message() returns the same
+            # Message shape create() did, so nothing below this call changed.
+            with self.client.messages.stream(**kwargs) as stream:
+                response = stream.get_final_message()
 
             usage = getattr(response, "usage", None)
             stop_reason = getattr(response, "stop_reason", None)
             print(
-                f"[{label}] stop_reason={stop_reason} max_tokens={LLM_MAX_TOKENS} "
+                f"[{label}] stop_reason={stop_reason} max_tokens={self.max_tokens} "
                 f"{_describe_usage(usage)}"
             )
             if stop_reason == "max_tokens":
                 raise LLMTruncatedError(
                     f"LLM response truncated: stop_reason=max_tokens, "
                     f"output_tokens={getattr(usage, 'output_tokens', 'unknown')}, "
-                    f"max_tokens={LLM_MAX_TOKENS}. Thinking tokens share this budget — "
-                    f"raise LLM_MAX_TOKENS or shorten the prompt."
+                    f"max_tokens={self.max_tokens}. Thinking tokens share this budget — "
+                    f"raise the configured Max Tokens or shorten the prompt."
                 )
 
             # Newer models may return thinking blocks before the text block,
@@ -936,7 +961,7 @@ class SummaryGenerator:
             messages.append({"role": "user", "content": user_prompt})
             response = self.client.chat.completions.create(
                 model=self.model,
-                max_tokens=LLM_MAX_TOKENS,
+                max_tokens=self.max_tokens,
                 messages=messages,
             )
 
@@ -945,15 +970,15 @@ class SummaryGenerator:
             # OpenAI-compatible servers signal budget exhaustion as "length".
             finish_reason = getattr(choices[0], "finish_reason", None) if choices else None
             print(
-                f"[{label}] finish_reason={finish_reason} max_tokens={LLM_MAX_TOKENS} "
+                f"[{label}] finish_reason={finish_reason} max_tokens={self.max_tokens} "
                 f"{_describe_usage(usage)}"
             )
             if finish_reason == "length":
                 raise LLMTruncatedError(
                     f"LLM response truncated: finish_reason=length, "
                     f"completion_tokens={getattr(usage, 'completion_tokens', 'unknown')}, "
-                    f"max_tokens={LLM_MAX_TOKENS}. Reasoning tokens share this budget — "
-                    f"raise LLM_MAX_TOKENS or shorten the prompt."
+                    f"max_tokens={self.max_tokens}. Reasoning tokens share this budget — "
+                    f"raise the configured Max Tokens or shorten the prompt."
                 )
 
             return choices[0].message.content if choices else ""

--- a/src/rally/routers/settings.py
+++ b/src/rally/routers/settings.py
@@ -9,6 +9,7 @@ from rally.database import get_db
 from rally.models import AISettingsHistory, Calendar, FollowedTeam, LLMSettingsHistory, Setting
 from rally.schemas import (
     AI_SETTINGS_FIELDS,
+    DEFAULT_LLM_MAX_TOKENS,
     LLM_CONFIG_FIELD,
     UNSET,
     AISettingHistoryEntry,
@@ -167,16 +168,66 @@ def _get_current_llm_snapshot(db: Session) -> LLMSettingsHistory | None:
 
 
 def _llm_config_from_row(row: LLMSettingsHistory) -> dict:
-    """Unpack a snapshot row's coupled JSON value into provider/model."""
+    """Unpack a snapshot row's coupled JSON value into its fields.
+
+    The ``.get()`` defaults are a safety net for a row written between deploy
+    and migration (or if the migration is ever skipped) — every row the
+    migration touches already carries both keys.
+    """
     config = json.loads(row.value)
-    return {"provider": config.get("provider", ""), "model": config.get("model", "")}
+    return {
+        "provider": config.get("provider", ""),
+        "model": config.get("model", ""),
+        "max_tokens": config.get("max_tokens", DEFAULT_LLM_MAX_TOKENS),
+        "max_tokens_mode": config.get("max_tokens_mode", "custom"),
+    }
 
 
-def _apply_llm_config(db: Session, provider: str, model: str) -> None:
-    """Write the provider + model into the plain settings keys read by the generator."""
+def _apply_llm_config(
+    db: Session, provider: str, model: str, max_tokens: int, max_tokens_mode: str
+) -> None:
+    """Write the resolved config into the plain settings keys read by the generator.
+
+    Each provider owns its own max-tokens key, so switching providers never
+    lets one provider's budget leak onto the other.
+    """
     _upsert_setting(db, "llm_provider", provider)
     model_key = "llm_anthropic_model" if provider == "anthropic" else "llm_local_model"
     _upsert_setting(db, model_key, model)
+    max_tokens_key = (
+        "llm_anthropic_max_tokens" if provider == "anthropic" else "llm_local_max_tokens"
+    )
+    _upsert_setting(db, max_tokens_key, str(max_tokens))
+    if provider == "anthropic":
+        _upsert_setting(db, "llm_anthropic_max_tokens_mode", max_tokens_mode)
+
+
+def _resolve_model_max_tokens(model: str, api_key: str) -> int:
+    """Resolve a model's maximum output tokens via the Anthropic Models API.
+
+    Raises HTTPException(400) with a message safe to show the operator inline
+    on any failure — an unrecognized model name, a missing key, or any other
+    provider-side error. Only Anthropic publishes this endpoint, so this is
+    never called for the local provider.
+    """
+    if not model:
+        raise HTTPException(status_code=400, detail="Set a model before resolving its maximum.")
+    if not api_key:
+        raise HTTPException(
+            status_code=400,
+            detail="Set an Anthropic API key before resolving the model's maximum.",
+        )
+
+    import anthropic
+
+    client = anthropic.Anthropic(api_key=api_key)
+    try:
+        info = client.models.retrieve(model)
+    except Exception as e:
+        raise HTTPException(
+            status_code=400, detail=f"Couldn't look up {model}'s maximum: {e}"
+        ) from None
+    return info.max_tokens
 
 
 @router.get("/api/settings/llm/config", response_model=LLMConfigState)
@@ -184,26 +235,57 @@ def get_llm_config(db: Session = Depends(get_db)):
     """Get the currently active LLM provider + model configuration."""
     row = _get_current_llm_snapshot(db)
     if not row:
-        return LLMConfigState(provider="", model="", history_id=None)
+        return LLMConfigState(provider="", model="", max_tokens=None, max_tokens_mode=None)
     return LLMConfigState(**_llm_config_from_row(row), history_id=row.id)
 
 
 @router.put("/api/settings/llm/config", response_model=LLMConfigState)
 def save_llm_config(payload: LLMConfigUpdate, db: Session = Depends(get_db)):
-    """Explicitly save the LLM provider + model pair — inserts a new history snapshot."""
+    """Explicitly save the LLM config — inserts a new history snapshot.
+
+    In ``model_max`` mode, ``max_tokens`` is resolved from the Anthropic Models
+    API here, at save time — the generator later reads the stored number rather
+    than re-resolving on every run. The mode only applies to Anthropic; a local
+    save always writes ``custom`` regardless of what the client sends.
+    """
+    mode = payload.max_tokens_mode if payload.provider == "anthropic" else "custom"
+    max_tokens = payload.max_tokens
+    if mode == "model_max":
+        api_key_row = db.query(Setting).filter(Setting.key == "llm_anthropic_api_key").first()
+        api_key = api_key_row.value if api_key_row else ""
+        max_tokens = _resolve_model_max_tokens(payload.model, api_key)
+    elif max_tokens <= 0:
+        # Only validated in custom mode — model_max ignores the submitted
+        # value entirely (the browser sends a blank/0 placeholder while it's
+        # unresolved, and that must not fail the request before it gets here).
+        raise HTTPException(status_code=422, detail="max_tokens must be a positive integer.")
+
     now = now_utc()  # Single timestamp so created_at == last_used_at on insert
     row = LLMSettingsHistory(
         field_name=LLM_CONFIG_FIELD,
-        value=json.dumps({"provider": payload.provider, "model": payload.model}),
+        value=json.dumps(
+            {
+                "provider": payload.provider,
+                "model": payload.model,
+                "max_tokens": max_tokens,
+                "max_tokens_mode": mode,
+            }
+        ),
         created_at=now,
         last_used_at=now,
     )
     db.add(row)
     db.flush()  # Assign row.id before pointing the setting at it
     _upsert_setting(db, LLM_CONFIG_POINTER_KEY, str(row.id))
-    _apply_llm_config(db, payload.provider, payload.model)
+    _apply_llm_config(db, payload.provider, payload.model, max_tokens, mode)
     db.commit()
-    return LLMConfigState(provider=payload.provider, model=payload.model, history_id=row.id)
+    return LLMConfigState(
+        provider=payload.provider,
+        model=payload.model,
+        max_tokens=max_tokens,
+        max_tokens_mode=mode,
+        history_id=row.id,
+    )
 
 
 @router.get("/api/settings/llm/config/history", response_model=LLMConfigHistoryResponse)
@@ -232,7 +314,12 @@ def get_llm_config_history(db: Session = Depends(get_db)):
 
 @router.post("/api/settings/llm/config/rollback", response_model=LLMConfigState)
 def rollback_llm_config(payload: AISettingRollback, db: Session = Depends(get_db)):
-    """Make an existing snapshot the active version — restores provider and model together."""
+    """Make an existing snapshot the active version — restores the whole config together.
+
+    Restores the stored max_tokens verbatim rather than re-resolving it — a
+    snapshot is a historical record of what actually ran, and re-resolving on
+    rollback would silently change an old configuration.
+    """
     row = db.get(LLMSettingsHistory, payload.history_id)
     if not row or row.field_name != LLM_CONFIG_FIELD:
         raise HTTPException(status_code=404, detail="History entry not found")
@@ -240,7 +327,9 @@ def rollback_llm_config(payload: AISettingRollback, db: Session = Depends(get_db
     row.last_used_at = now_utc()
     _upsert_setting(db, LLM_CONFIG_POINTER_KEY, str(row.id))
     config = _llm_config_from_row(row)
-    _apply_llm_config(db, config["provider"], config["model"])
+    _apply_llm_config(
+        db, config["provider"], config["model"], config["max_tokens"], config["max_tokens_mode"]
+    )
     db.commit()
     db.refresh(row)
     return LLMConfigState(**config, history_id=row.id)
@@ -269,7 +358,13 @@ def test_llm_connection(db: Session = Depends(get_db)):
                 max_tokens=1,
                 messages=[{"role": "user", "content": "hi"}],
             )
-            return {"success": True, "message": f"Connected to {model}"}
+            # The verify modal auto-closes on success, so this is the one
+            # place a just-resolved "Model maximum" budget is confirmed back
+            # to the operator — the helper text under the field is the
+            # durable surface for it afterward.
+            max_tokens = settings.get("llm_anthropic_max_tokens")
+            budget_note = f" (max tokens: {max_tokens})" if max_tokens else ""
+            return {"success": True, "message": f"Connected to {model}{budget_note}"}
         else:
             from openai import OpenAI
 

--- a/src/rally/schemas.py
+++ b/src/rally/schemas.py
@@ -1,6 +1,7 @@
 """Rally Pydantic schemas."""
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
@@ -148,11 +149,34 @@ class AISettingHistoryResponse(BaseModel):
 LLM_CONFIG_FIELD = "llm_config"
 
 
+# Default token budget mirroring generate.LLM_MAX_TOKENS. Not imported directly —
+# generate.py is the generator's own module and schemas.py stays free of it to
+# avoid a needless cross-module coupling for one constant.
+DEFAULT_LLM_MAX_TOKENS = 4000
+
+LLMMaxTokensMode = Literal["model_max", "custom"]
+
+
 class LLMConfigUpdate(BaseModel):
-    """Explicit save of the LLM provider + model pair — creates a new history snapshot."""
+    """Explicit save of the LLM provider + model pair — creates a new history snapshot.
+
+    ``max_tokens`` is always sent by the client (whatever is currently shown in
+    the field); in ``model_max`` mode the server ignores it and resolves the
+    real value from the provider instead. ``max_tokens_mode`` is meaningful for
+    Anthropic only — the router forces it to ``custom`` for every other provider.
+
+    The "must be positive" rule is deliberately NOT enforced here as a Field
+    constraint: the browser sends a blank/zero placeholder in ``model_max``
+    mode (the field is read-only and not yet resolved), and that value is
+    correctly ignored downstream — a schema-level gt=0 would reject the
+    request before the handler ever gets to ignore it. The router validates
+    positivity itself, and only when max_tokens_mode == "custom".
+    """
 
     provider: str
     model: str
+    max_tokens: int = DEFAULT_LLM_MAX_TOKENS
+    max_tokens_mode: LLMMaxTokensMode = "custom"
 
 
 class LLMConfigState(BaseModel):
@@ -160,6 +184,8 @@ class LLMConfigState(BaseModel):
 
     provider: str
     model: str
+    max_tokens: int | None = None  # None when no snapshot exists yet
+    max_tokens_mode: LLMMaxTokensMode | None = None
     history_id: int | None = None  # None when no snapshot exists yet
 
 
@@ -169,6 +195,8 @@ class LLMConfigHistoryEntry(BaseModel):
     id: int
     provider: str
     model: str
+    max_tokens: int
+    max_tokens_mode: LLMMaxTokensMode
     created_at: datetime
     last_used_at: datetime
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -94,6 +94,11 @@
                     <label>Model</label>
                     <input type="text" id="llm-local-model" placeholder="e.g. llama3">
                 </div>
+                <div class="form-group">
+                    <label>Max Tokens</label>
+                    <input type="number" id="llm-local-max-tokens" min="1" step="1">
+                    <small>Covers thinking and output together. Must fit within your model's context window.</small>
+                </div>
             </div>
             <div class="llm-fields-anthropic">
                 <div class="form-group">
@@ -103,6 +108,18 @@
                 <div class="form-group">
                     <label>Model</label>
                     <input type="text" id="llm-anthropic-model" placeholder="e.g. claude-sonnet-4-20250514">
+                </div>
+                <div class="form-group">
+                    <label>Budget</label>
+                    <div class="radio-options">
+                        <label><input type="radio" name="llm-max-tokens-mode" value="model_max" id="llm-max-tokens-mode-model-max"> Model maximum</label>
+                        <label><input type="radio" name="llm-max-tokens-mode" value="custom" id="llm-max-tokens-mode-custom" checked> Custom</label>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label>Max Tokens</label>
+                    <input type="number" id="llm-anthropic-max-tokens" min="1" step="1">
+                    <small id="llm-anthropic-max-tokens-help"></small>
                 </div>
             </div>
             <div class="ai-field-actions">
@@ -660,9 +677,19 @@
             document.getElementById('llm-local-base-url').value = s.llm_local_base_url || '';
             document.getElementById('llm-local-api-key').value = s.llm_local_api_key || '';
             document.getElementById('llm-local-model').value = s.llm_local_model || '';
+            document.getElementById('llm-local-max-tokens').value = s.llm_local_max_tokens || '';
             document.getElementById('llm-anthropic-api-key').value = s.llm_anthropic_api_key || '';
             document.getElementById('llm-anthropic-model').value = s.llm_anthropic_model || '';
+            const anthropicMaxTokensInput = document.getElementById('llm-anthropic-max-tokens');
+            anthropicMaxTokensInput.value = s.llm_anthropic_max_tokens || '';
+            const mode = s.llm_anthropic_max_tokens_mode === 'model_max' ? 'model_max' : 'custom';
+            // A value loaded from settings is authoritative for its mode — mark
+            // it resolved so updateLlmMaxTokensHelp() doesn't blank it on load.
+            anthropicMaxTokensInput.dataset.resolvedMode = mode;
+            anthropicMaxTokensInput.dataset.resolvedModel = s.llm_anthropic_model || '';
+            document.getElementById(mode === 'model_max' ? 'llm-max-tokens-mode-model-max' : 'llm-max-tokens-mode-custom').checked = true;
             toggleLlmFields(provider);
+            updateLlmMaxTokensHelp();
 
             // Meal Planner
             document.getElementById('meal-default-type').value = s.meal_default_type || 'Dinner';
@@ -695,6 +722,47 @@
             document.querySelector('.llm-fields-anthropic').classList.toggle('active', provider === 'anthropic');
         }
 
+        // Persistent surface for the effective Anthropic budget — the verify
+        // modal that confirms it after a save auto-closes, so this small text
+        // under the field is what stays visible whenever Settings is open.
+        function llmMaxTokensMode() {
+            const checked = document.querySelector('input[name="llm-max-tokens-mode"]:checked');
+            return checked ? checked.value : 'custom';
+        }
+
+        function updateLlmMaxTokensHelp() {
+            const mode = llmMaxTokensMode();
+            const input = document.getElementById('llm-anthropic-max-tokens');
+            const help = document.getElementById('llm-anthropic-max-tokens-help');
+            const model = document.getElementById('llm-anthropic-model').value.trim();
+
+            input.readOnly = mode === 'model_max';
+
+            // "Resolved" means the number currently in the field was actually
+            // returned by the provider for the model currently typed in — not
+            // just whatever custom value happened to be sitting there before
+            // the radio was switched. Anything else and the field is blanked
+            // rather than showing a stale number labeled as this model's max.
+            const isResolved = mode === 'model_max' && !!input.value
+                && input.dataset.resolvedMode === 'model_max'
+                && input.dataset.resolvedModel === model;
+
+            if (mode === 'model_max' && !isResolved) {
+                input.value = '';
+            }
+
+            const value = input.value ? Number(input.value).toLocaleString() : '';
+
+            if (mode === 'model_max') {
+                help.textContent = isResolved
+                    ? value + ' — maximum for ' + model + '. Covers thinking and output together.'
+                    : 'Resolved from the model when you save. Covers thinking and output together.';
+            } else {
+                help.textContent = (value ? value + '. ' : '')
+                    + 'Covers thinking and output together. Raise this if summaries are cut off mid-sentence.';
+            }
+        }
+
         // ── AI Settings (versioned agent_voice / family_context) ──
 
         const AI_FIELD_META = {
@@ -725,11 +793,31 @@
             llm_config: {
                 label: 'LLM',
                 baseUrl: '/api/settings/llm/config',
-                formatValue: entry => escapeHtml('Provider: ' + entry.provider + '\nModel: ' + entry.model),
+                formatValue: entry => {
+                    let text = 'Provider: ' + entry.provider + '\nModel: ' + entry.model
+                        + '\nMax Tokens: ' + entry.max_tokens;
+                    if (entry.provider === 'anthropic' && entry.max_tokens_mode === 'model_max') {
+                        text += '  (model maximum)';
+                    }
+                    return escapeHtml(text);
+                },
                 applyRollback: data => {
                     document.getElementById('llm-provider').value = data.provider;
                     document.getElementById(llmModelInputId(data.provider)).value = data.model;
+                    const maxTokensInputId = data.provider === 'anthropic' ? 'llm-anthropic-max-tokens' : 'llm-local-max-tokens';
+                    const maxTokensInput = document.getElementById(maxTokensInputId);
+                    maxTokensInput.value = data.max_tokens;
+                    if (data.provider === 'anthropic') {
+                        const mode = data.max_tokens_mode === 'model_max' ? 'model_max' : 'custom';
+                        // The rolled-back snapshot is itself an authoritative
+                        // resolved value for its mode — restored verbatim, not
+                        // re-resolved (see the rollback endpoint's docstring).
+                        maxTokensInput.dataset.resolvedMode = mode;
+                        maxTokensInput.dataset.resolvedModel = data.model;
+                        document.getElementById(mode === 'model_max' ? 'llm-max-tokens-mode-model-max' : 'llm-max-tokens-mode-custom').checked = true;
+                    }
                     toggleLlmFields(data.provider);
+                    updateLlmMaxTokensHelp();
                 }
             }
         };
@@ -1204,6 +1292,12 @@
             toggleLlmFields(e.target.value);
         });
 
+        // Budget mode toggle and helper-text refresh
+        document.getElementById('llm-max-tokens-mode-model-max').addEventListener('change', updateLlmMaxTokensHelp);
+        document.getElementById('llm-max-tokens-mode-custom').addEventListener('change', updateLlmMaxTokensHelp);
+        document.getElementById('llm-anthropic-max-tokens').addEventListener('input', updateLlmMaxTokensHelp);
+        document.getElementById('llm-anthropic-model').addEventListener('input', updateLlmMaxTokensHelp);
+
         // Weather form
         document.getElementById('weather-form').addEventListener('submit', async (e) => {
             e.preventDefault();
@@ -1222,25 +1316,54 @@
         document.getElementById('llm-form').addEventListener('submit', async (e) => {
             e.preventDefault();
             const provider = document.getElementById('llm-provider').value;
+            // The radio group only exists for Anthropic — local is always custom.
+            const mode = provider === 'anthropic' ? llmMaxTokensMode() : 'custom';
+            const maxTokensInputId = provider === 'anthropic' ? 'llm-anthropic-max-tokens' : 'llm-local-max-tokens';
+            const maxTokensInput = document.getElementById(maxTokensInputId);
             try {
                 await saveSettings({
                     llm_provider: provider,
                     llm_local_base_url: document.getElementById('llm-local-base-url').value,
                     llm_local_api_key: document.getElementById('llm-local-api-key').value,
                     llm_local_model: document.getElementById('llm-local-model').value,
+                    llm_local_max_tokens: document.getElementById('llm-local-max-tokens').value,
                     llm_anthropic_api_key: document.getElementById('llm-anthropic-api-key').value,
-                    llm_anthropic_model: document.getElementById('llm-anthropic-model').value
+                    llm_anthropic_model: document.getElementById('llm-anthropic-model').value,
+                    llm_anthropic_max_tokens: document.getElementById('llm-anthropic-max-tokens').value,
+                    llm_anthropic_max_tokens_mode: mode
                 });
-                // Snapshot the coupled provider + model pair for version history
+
+                // This call is authoritative: in "model_max" mode it resolves the
+                // real budget from the provider and is the one place the save can
+                // fail (an unresolvable model name, a missing key). It always runs
+                // before the connectivity test below, so a bad model name fails
+                // once, not twice.
+                openVerifyModal('LLM');
                 const response = await fetch('/api/settings/llm/config', {
                     method: 'PUT',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         provider: provider,
-                        model: document.getElementById(llmModelInputId(provider)).value
+                        model: document.getElementById(llmModelInputId(provider)).value,
+                        max_tokens_mode: mode,
+                        max_tokens: parseInt(maxTokensInput.value, 10) || 0
                     })
                 });
-                if (!response.ok) throw new Error('Failed to save LLM config snapshot');
+                const result = await response.json();
+                if (!response.ok) {
+                    showVerifyError(result.detail || 'Failed to save LLM configuration');
+                    return;
+                }
+
+                // Reflect the resolved value back — the input was read-only in
+                // "model_max" mode, so this is the only place it gets a value.
+                maxTokensInput.value = result.max_tokens;
+                if (provider === 'anthropic') {
+                    maxTokensInput.dataset.resolvedMode = mode;
+                    maxTokensInput.dataset.resolvedModel = document.getElementById('llm-anthropic-model').value;
+                }
+                updateLlmMaxTokensHelp();
+
                 await verifyConnection('/api/settings/test-llm', 'LLM');
             } catch (error) {
                 console.error('Error saving LLM settings:', error);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -386,10 +386,16 @@ def mock_llm(monkeypatch):
             calls.append(("anthropic", kwargs))
             return SimpleNamespace(content=[SimpleNamespace(text="ok")])
 
+    class FakeModels:
+        def retrieve(self, model_id):
+            calls.append(("models.retrieve", model_id))
+            return SimpleNamespace(id=model_id, max_tokens=200000)
+
     class FakeAnthropic:
         def __init__(self, **kwargs):
             self.init_kwargs = kwargs
             self.messages = FakeMessages()
+            self.models = FakeModels()
 
     class FakeCompletions:
         def create(self, **kwargs):

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -35,6 +35,20 @@ def test_llm_anthropic_success(client, make_setting, mock_llm):
     assert mock_llm.calls[0][0] == "anthropic"
 
 
+def test_llm_anthropic_success_includes_configured_budget(client, make_setting, mock_llm):
+    """The verify modal auto-closes, so this is the one place a freshly
+    resolved "Model maximum" budget is confirmed back to the operator."""
+    make_setting("llm_provider", "anthropic")
+    make_setting("llm_anthropic_api_key", "sk-test")
+    make_setting("llm_anthropic_model", "claude-x")
+    make_setting("llm_anthropic_max_tokens", "128000")
+
+    body = client.post("/api/settings/test-llm").json()
+
+    assert body["success"] is True
+    assert "128000" in body["message"]
+
+
 def test_llm_local_success(client, make_setting, mock_llm):
     make_setting("llm_provider", "local")
     make_setting("llm_local_base_url", "http://localhost:1234/v1")

--- a/tests/test_generate_helpers.py
+++ b/tests/test_generate_helpers.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from rally.database import Base
-from rally.generator.generate import SummaryGenerator
+from rally.generator.generate import LLM_MAX_TOKENS, SummaryGenerator
 from rally.models import (
     AISettingsHistory,
     Calendar,
@@ -100,6 +100,7 @@ def test_init_anthropic_provider_from_db(gen_db, mock_llm):
     assert gen.local_tz_name == "America/Chicago"
     assert gen.stem_concept_enabled is True
     assert gen.shopping_list_in_summary_enabled is True
+    assert gen.max_tokens == LLM_MAX_TOKENS  # default when unset
 
 
 def test_init_local_provider_from_db(gen_db, mock_llm):
@@ -119,6 +120,64 @@ def test_init_local_provider_from_db(gen_db, mock_llm):
     assert gen.model == "llama"
     assert gen.stem_concept_enabled is False  # default when unset
     assert gen.shopping_list_in_summary_enabled is False  # default when unset
+    assert gen.max_tokens == LLM_MAX_TOKENS  # default when unset
+
+
+# --- max_tokens resolution -------------------------------------------------------
+
+
+def test_max_tokens_reads_provider_specific_db_setting(gen_db, mock_llm):
+    _seed_settings(
+        gen_db,
+        {
+            "llm_provider": "anthropic",
+            "llm_anthropic_model": "claude-x",
+            "llm_anthropic_api_key": "sk-test",
+            "llm_anthropic_max_tokens": "128000",
+            # A local budget must never leak onto the active Anthropic provider.
+            "llm_local_max_tokens": "4000",
+        },
+    )
+
+    gen = SummaryGenerator()
+
+    assert gen.max_tokens == 128000
+
+
+def test_max_tokens_switches_with_provider(gen_db, mock_llm):
+    """Each provider owns its own key — switching Provider switches budgets."""
+    _seed_settings(
+        gen_db,
+        {
+            "llm_provider": "local",
+            "llm_local_model": "llama",
+            "llm_local_base_url": "http://localhost:1234/v1",
+            "llm_local_max_tokens": "6000",
+            "llm_anthropic_max_tokens": "128000",
+        },
+    )
+
+    gen = SummaryGenerator()
+
+    assert gen.max_tokens == 6000
+
+
+def test_max_tokens_falls_back_to_config_toml_provider_table():
+    """DB setting absent -> falls back to that provider's own config.toml
+    table, exercised directly against the real _resolve_max_tokens method."""
+    gen = SummaryGenerator.__new__(SummaryGenerator)
+    gen.provider = "anthropic"
+    gen.config = {"llm": {"anthropic": {"max_tokens": 32000}}}
+
+    assert gen._resolve_max_tokens({}) == 32000
+
+
+def test_max_tokens_defaults_when_neither_db_nor_config_toml_set():
+    gen = SummaryGenerator.__new__(SummaryGenerator)
+    gen.provider = "local"
+    gen.config = {}
+
+    assert gen._resolve_max_tokens({}) == LLM_MAX_TOKENS
 
 
 # --- load_dinner_plans ---------------------------------------------------------

--- a/tests/test_generate_llm.py
+++ b/tests/test_generate_llm.py
@@ -25,11 +25,34 @@ def make_generator(tz: str = "UTC") -> SummaryGenerator:
     gen.stem_concept_enabled = False
     gen.shopping_list_in_summary_enabled = False
     gen.sports_watchlist_enabled = False
+    gen.max_tokens = LLM_MAX_TOKENS
     return gen
 
 
+class _FakeStream:
+    """Minimal context-manager stand-in for the SDK's `messages.stream(...)`."""
+
+    def __init__(self, message):
+        self._message = message
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def get_final_message(self):
+        return self._message
+
+
 class FakeAnthropic:
-    """Stands in for anthropic.Anthropic — records the create() kwargs."""
+    """Stands in for anthropic.Anthropic — records the stream() kwargs.
+
+    _call_llm's Anthropic branch streams (see the "Model maximum" budget
+    change in generate.py) rather than calling create() directly, so this fake
+    mirrors that: stream() returns a context manager whose get_final_message()
+    yields the same Message shape create() used to return.
+    """
 
     def __init__(self, text, blocks=None, stop_reason="end_turn", usage=None):
         self._text = text
@@ -39,10 +62,11 @@ class FakeAnthropic:
         self.messages = self
         self.last_kwargs = None
 
-    def create(self, **kwargs):
+    def stream(self, **kwargs):
         self.last_kwargs = kwargs
         content = self._blocks or [SimpleNamespace(type="text", text=self._text)]
-        return SimpleNamespace(content=content, stop_reason=self._stop_reason, usage=self._usage)
+        message = SimpleNamespace(content=content, stop_reason=self._stop_reason, usage=self._usage)
+        return _FakeStream(message)
 
 
 class FakeOpenAI:
@@ -238,6 +262,32 @@ def test_call_llm_logs_reasoning_tokens_when_reported(capsys):
     out = capsys.readouterr().out
     assert "[eval]" in out
     assert "reasoning=700" in out
+
+
+def test_call_llm_anthropic_sends_configured_max_tokens():
+    """max_tokens comes from the instance, not the module default — this is
+    what makes the per-provider "Model maximum" budget actually take effect."""
+    gen = make_generator()
+    gen.provider = "anthropic"
+    gen.model = "claude-x"
+    gen.max_tokens = 128000
+    gen.client = FakeAnthropic("hi")
+
+    gen._call_llm("hi")
+
+    assert gen.client.last_kwargs["max_tokens"] == 128000
+
+
+def test_call_llm_local_sends_configured_max_tokens():
+    gen = make_generator()
+    gen.provider = "local"
+    gen.model = "llama"
+    gen.max_tokens = 8000
+    gen.client = FakeOpenAI("hi")
+
+    gen._call_llm("hi")
+
+    assert gen.client.last_kwargs["max_tokens"] == 8000
 
 
 def test_call_llm_logs_when_provider_reports_no_usage(capsys):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -110,32 +110,178 @@ def test_llm_config_get_empty_when_unset(client):
     assert client.get("/api/settings/llm/config").json() == {
         "provider": "",
         "model": "",
+        "max_tokens": None,
+        "max_tokens_mode": None,
         "history_id": None,
     }
 
 
 def test_llm_config_save_writes_derived_keys_anthropic(client):
     body = client.put(
-        "/api/settings/llm/config", json={"provider": "anthropic", "model": "claude-x"}
+        "/api/settings/llm/config",
+        json={"provider": "anthropic", "model": "claude-x", "max_tokens": 16000},
     ).json()
 
     assert (body["provider"], body["model"]) == ("anthropic", "claude-x")
+    assert body["max_tokens"] == 16000
+    assert body["max_tokens_mode"] == "custom"
     assert body["history_id"] is not None
 
     cfg = client.get("/api/settings/llm/config").json()
-    assert (cfg["provider"], cfg["model"]) == ("anthropic", "claude-x")
+    assert (cfg["provider"], cfg["model"], cfg["max_tokens"]) == ("anthropic", "claude-x", 16000)
 
     settings = client.get("/api/settings").json()["settings"]
     assert settings["llm_provider"] == "anthropic"
     assert settings["llm_anthropic_model"] == "claude-x"
+    assert settings["llm_anthropic_max_tokens"] == "16000"
+    assert settings["llm_anthropic_max_tokens_mode"] == "custom"
+    # The other provider's budget key is untouched.
+    assert "llm_local_max_tokens" not in settings
 
 
 def test_llm_config_save_local_uses_local_model_key(client):
-    client.put("/api/settings/llm/config", json={"provider": "local", "model": "llama"})
+    body = client.put(
+        "/api/settings/llm/config",
+        json={"provider": "local", "model": "llama", "max_tokens": 8000},
+    ).json()
+
+    assert body["max_tokens_mode"] == "custom"
 
     settings = client.get("/api/settings").json()["settings"]
     assert settings["llm_provider"] == "local"
     assert settings["llm_local_model"] == "llama"
+    assert settings["llm_local_max_tokens"] == "8000"
+    # Local has no budget-mode setting — the radio only exists for Anthropic.
+    assert "llm_anthropic_max_tokens_mode" not in settings
+
+
+def test_llm_config_save_defaults_max_tokens_when_omitted(client):
+    """Existing callers that don't send max_tokens still work — 4000/custom."""
+    body = client.put("/api/settings/llm/config", json={"provider": "local", "model": "m"}).json()
+
+    assert body["max_tokens"] == 4000
+    assert body["max_tokens_mode"] == "custom"
+
+
+def test_llm_config_save_rejects_non_positive_max_tokens(client):
+    resp = client.put(
+        "/api/settings/llm/config",
+        json={"provider": "local", "model": "m", "max_tokens": 0},
+    )
+    assert resp.status_code == 422
+    # A plain string, not a Pydantic-validation-error array — this is a
+    # deliberate HTTPException from the handler (see the next test for why
+    # positivity can't be a Field-level constraint), and the browser renders
+    # `detail` directly in the verify modal, so an array would show as the
+    # useless literal text "[object Object]".
+    assert isinstance(resp.json()["detail"], str)
+
+
+def test_llm_config_save_model_max_accepts_placeholder_zero_max_tokens(
+    client, make_setting, mock_llm
+):
+    """Regression: the browser blanks the Max Tokens field while "Model
+    maximum" is selected and unresolved, which serializes to 0 — and mode is
+    what the client actually has selected when the field goes blank, so this
+    must succeed exactly like any other model_max save, not 422 on the way in."""
+    make_setting("llm_anthropic_api_key", "sk-test")
+
+    resp = client.put(
+        "/api/settings/llm/config",
+        json={
+            "provider": "anthropic",
+            "model": "claude-x",
+            "max_tokens": 0,
+            "max_tokens_mode": "model_max",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["max_tokens"] == 200000
+
+
+def test_llm_config_save_local_forces_custom_mode_even_if_client_sends_model_max(client):
+    """Defense in depth: local has no Models API, so the server ignores a stray
+    model_max mode from a stale client rather than trusting it."""
+    body = client.put(
+        "/api/settings/llm/config",
+        json={
+            "provider": "local",
+            "model": "llama",
+            "max_tokens": 4000,
+            "max_tokens_mode": "model_max",
+        },
+    ).json()
+
+    assert body["max_tokens_mode"] == "custom"
+    assert body["max_tokens"] == 4000  # not resolved — the submitted value passes through
+
+
+def test_llm_config_save_model_max_resolves_via_models_api(client, make_setting, mock_llm):
+    make_setting("llm_anthropic_api_key", "sk-test")
+
+    body = client.put(
+        "/api/settings/llm/config",
+        json={
+            "provider": "anthropic",
+            "model": "claude-x",
+            "max_tokens": 999,  # ignored — the resolved value wins
+            "max_tokens_mode": "model_max",
+        },
+    ).json()
+
+    assert body["max_tokens"] == 200000  # from FakeModels.retrieve in conftest
+    assert body["max_tokens_mode"] == "model_max"
+    assert ("models.retrieve", "claude-x") in mock_llm.calls
+
+    settings = client.get("/api/settings").json()["settings"]
+    assert settings["llm_anthropic_max_tokens"] == "200000"
+    assert settings["llm_anthropic_max_tokens_mode"] == "model_max"
+
+
+def test_llm_config_save_model_max_rejects_unresolvable_model(client, make_setting, monkeypatch):
+    make_setting("llm_anthropic_api_key", "sk-test")
+
+    import anthropic
+
+    class FailingModels:
+        def retrieve(self, model_id):
+            raise RuntimeError("model not found: bogus-model")
+
+    class FakeAnthropicClient:
+        def __init__(self, **kwargs):
+            self.models = FailingModels()
+
+    monkeypatch.setattr(anthropic, "Anthropic", FakeAnthropicClient)
+
+    resp = client.put(
+        "/api/settings/llm/config",
+        json={
+            "provider": "anthropic",
+            "model": "bogus-model",
+            "max_tokens": 4000,
+            "max_tokens_mode": "model_max",
+        },
+    )
+
+    assert resp.status_code == 400
+    assert "bogus-model" in resp.json()["detail"]
+    # No snapshot was written on the failure path.
+    assert client.get("/api/settings/llm/config").json()["history_id"] is None
+
+
+def test_llm_config_save_model_max_rejects_missing_api_key(client):
+    resp = client.put(
+        "/api/settings/llm/config",
+        json={
+            "provider": "anthropic",
+            "model": "claude-x",
+            "max_tokens": 4000,
+            "max_tokens_mode": "model_max",
+        },
+    )
+    assert resp.status_code == 400
+    assert "API key" in resp.json()["detail"]
 
 
 def test_llm_config_history_is_newest_first(client, frozen_now):
@@ -156,7 +302,8 @@ def test_llm_config_history_is_newest_first(client, frozen_now):
 def test_llm_config_rollback_restores_pair_and_derived_keys(client, db_session, frozen_now):
     frozen_now(T1)
     a = client.put(
-        "/api/settings/llm/config", json={"provider": "anthropic", "model": "claude-1"}
+        "/api/settings/llm/config",
+        json={"provider": "anthropic", "model": "claude-1", "max_tokens": 32000},
     ).json()
     frozen_now(T2)
     client.put("/api/settings/llm/config", json={"provider": "local", "model": "llama"})
@@ -171,17 +318,47 @@ def test_llm_config_rollback_restores_pair_and_derived_keys(client, db_session, 
         "/api/settings/llm/config/rollback", json={"history_id": a["history_id"]}
     ).json()
 
-    assert (rb["provider"], rb["model"]) == ("anthropic", "claude-1")
+    assert (rb["provider"], rb["model"], rb["max_tokens"]) == ("anthropic", "claude-1", 32000)
     cfg = client.get("/api/settings/llm/config").json()
-    assert (cfg["provider"], cfg["model"]) == ("anthropic", "claude-1")
+    assert (cfg["provider"], cfg["model"], cfg["max_tokens"]) == ("anthropic", "claude-1", 32000)
 
     # Derived keys the generator reads are restored too, not just the pointer.
     settings = client.get("/api/settings").json()["settings"]
     assert settings["llm_provider"] == "anthropic"
     assert settings["llm_anthropic_model"] == "claude-1"
+    assert settings["llm_anthropic_max_tokens"] == "32000"
 
     # No new snapshot row.
     assert db_session.query(LLMSettingsHistory).count() == 2
+
+
+def test_llm_config_rollback_restores_max_tokens_verbatim_without_reresolving(
+    client, make_setting, mock_llm
+):
+    """A model_max snapshot's stored number is restored as-is on rollback — the
+    Models API is never called again, even though it's available."""
+    make_setting("llm_anthropic_api_key", "sk-test")
+    a = client.put(
+        "/api/settings/llm/config",
+        json={
+            "provider": "anthropic",
+            "model": "claude-x",
+            "max_tokens": 1,
+            "max_tokens_mode": "model_max",
+        },
+    ).json()
+    assert a["max_tokens"] == 200000  # resolved at save time
+
+    client.put("/api/settings/llm/config", json={"provider": "local", "model": "llama"})
+    calls_before_rollback = len(mock_llm.calls)
+
+    rb = client.post(
+        "/api/settings/llm/config/rollback", json={"history_id": a["history_id"]}
+    ).json()
+
+    assert rb["max_tokens"] == 200000
+    assert rb["max_tokens_mode"] == "model_max"
+    assert len(mock_llm.calls) == calls_before_rollback  # no fresh models.retrieve call
 
 
 def test_llm_config_rollback_missing_history_404(client):


### PR DESCRIPTION
## Summary

`_call_llm` hardcoded a single 4,000-token budget shared by every provider and every model, which is what let #133's truncation happen — raising it required a code change and a redeploy. This adds a per-provider `Max Tokens` setting (each provider owns its own key, so switching `Provider` never carries one provider's budget onto the other), plus an Anthropic-only `Budget` choice between `Custom` (any positive integer, no hardcoded ceiling) and `Model maximum`, which resolves the model's real output cap from the Anthropic Models API at save time and stores the result. The generator reads that stored number rather than re-resolving it on every 4 AM run. Existing behavior is preserved: a migration backfills every install to `4000`/`custom`, matching what `LLM_MAX_TOKENS` already did, so nothing changes until an operator edits the setting.

## Changes

**Backend**
- `src/rally/generator/generate.py` — new `_resolve_max_tokens()` method (DB setting → that provider's `config.toml` table → the `LLM_MAX_TOKENS` default); `_call_llm`'s Anthropic branch switches from `client.messages.create()` to `client.messages.stream()` + `get_final_message()`, required because the SDK refuses a non-streaming request whose `max_tokens` could exceed its timeout guard once the budget can reach a model's full ceiling (e.g. 128K). `get_final_message()` returns the same `Message` shape, so the `stop_reason`/`usage` logging and `LLMTruncatedError` from #133 are unchanged.
- `src/rally/schemas.py` — `LLMConfigUpdate`/`State`/`HistoryEntry` gain `max_tokens`/`max_tokens_mode`. Positivity is deliberately **not** a `Field` constraint (see Notes).
- `src/rally/routers/settings.py` — `save_llm_config` resolves `model_max` via `_resolve_model_max_tokens()` (a new Anthropic Models API call) and rejects the save with a `400` if the model can't be resolved; forces `max_tokens_mode` to `custom` for any provider other than Anthropic; `rollback_llm_config` restores the stored `max_tokens` verbatim, never re-resolving it. `test_llm_connection`'s success message now appends the configured budget.
- `migrations/migrate_019_add_llm_max_tokens.py` (+ registered in `run_migrations.py`) — backfills `max_tokens`/`max_tokens_mode` into every `llm_settings_history` snapshot and seeds the new settings keys, both idempotently. Skips (doesn't rewrite) any snapshot row that isn't valid JSON.

**Frontend**
- `templates/settings.html` — `Max Tokens` field in each provider's group; a `Budget` radio (`Model maximum` / `Custom`) in the Anthropic group only. Persistent helper text under the field states the effective budget, since the verify modal that also confirms it auto-closes on success. The field is read-only and blanked in `Model maximum` mode until a save actually resolves it against the currently-typed model — see Notes.

**Tests**
- `tests/test_settings.py` — save/history/rollback coverage for the new fields, `model_max` resolution success/failure, local forcing `custom`.
- `tests/test_generate_llm.py`, `tests/test_generate_helpers.py` — streaming `FakeAnthropic`, `_resolve_max_tokens` unit tests.
- `tests/test_connectivity.py` — budget appears in the `test-llm` success message.
- `tests/conftest.py` — `mock_llm`'s `FakeAnthropic` gains a `.models.retrieve()` stub.

## Notes for reviewers

- **`max_tokens` is not a `Field(gt=0)` constraint**, even though "any positive integer" is the rule for `Custom` mode. The browser sends a blank/`0` placeholder while `Model maximum` is selected and unresolved, and that's correctly ignored server-side — but a schema-level `gt=0` rejected the request with a `422` *before* the handler ever got a chance to ignore it. This was a real bug I hit clicking through the feature, not a hypothetical: positivity is now validated in the handler, only when `max_tokens_mode == "custom"`.
- **The help text is deliberately conservative about what it claims.** Switching to `Model maximum` before ever saving used to show the *previous custom value* mislabeled as if it were the model's real maximum (e.g. "4,000 — maximum for claude-sonnet-4-6" when 4,000 was just leftover). Fixed by tracking which mode + model the displayed number was actually resolved against (`data-resolved-mode`/`data-resolved-model` on the input), and blanking the field otherwise. I only caught this by clicking through it in a browser — the unit tests didn't exercise the sequence.
- Model-resolution failures surface through the existing verify-modal (`showVerifyError`) rather than inline field errors — the codebase has no inline-field-error convention anywhere else, so this matches every other connectivity check (LLM/Weather/Calendar/Followed Team) instead of introducing a new UI pattern for one field.
- No upper bound on `Custom` mode's value by design — model ceilings differ by provider and rise over time, so a hardcoded maximum would eventually block a legitimate value.

## Testing

- `uv run pytest` — 471 passed.
- `ruff check .` / `ruff format --check .` — clean.
- Verified live in a browser against a real dev `rally.db` and a real Anthropic API key: rendered the new fields correctly, toggled the `Budget` radio (readonly + blanking behavior), saved in `Model maximum` mode (real `models.retrieve("claude-sonnet-4-6")` call resolved `128000`), and restored the original config via the app's own rollback endpoint afterward.
- Ran `_call_llm` directly against the live API with a trivial prompt to confirm the new streaming path (`messages.stream()` + `get_final_message()`) works end-to-end with correct `stop_reason`/`usage` logging — no persisted side effects (no dashboard regeneration, no snapshot overwrite).
- Ran migration 019 against the local dev DB to confirm the backfill and idempotency (also covered by a standalone scratch-DB test during development, not committed).

Closes #140
