### PR TITLE
Style form fields by exclusion, not by listing input types

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -622,9 +622,11 @@ nav a.active,
     letter-spacing: var(--tracking-normal);
 }
 
-.form-group input[type="text"],
-.form-group input[type="password"],
-.form-group input[type="date"],
+/* Every text-like field in a form group, by exclusion rather than by listing
+   the types that exist today. Enumerating them meant a field of a type nobody
+   had used yet — the first `type="number"` — rendered at the browser default,
+   unstyled and 19px tall, until the visual suite caught it. */
+.form-group input:not([type="checkbox"]):not([type="radio"]):not([type="hidden"]),
 .form-group textarea,
 .form-group select,
 .remind-days-input {


### PR DESCRIPTION
## Summary

Unbreaks `main`. The design system's field rule enumerated `text`, `password`
and `date`, so the first `type="number"` field to land in a form group — the LLM
max-tokens inputs from #141 — rendered at the browser default: 19px tall,
13.33px Arial, no border.

#139 and #141 were both green on their own branches and only collided once
merged. The visual suite caught it on the first run against `main`, which is
exactly the job it was added to do.

## Changes

- `static/styles.css` — the form-field selector now matches every text-like
  input by excluding `checkbox`, `radio` and `hidden`, instead of listing the
  types that happened to exist. The next new input type is styled on arrival.

## Notes for reviewers

- This is a one-selector change; no markup moved.
- Verified visually as well as by assertion: the Max Tokens field now matches
  every other field on the page exactly — 47px tall, 16px Crimson Text, `--ink`
  border, spinners suppressed by the shared `appearance: none` like every other
  control.
- The container image already published from the #139 merge carries the
  unstyled fields, so this wants a deploy behind it.

## Testing

- `uv run pytest` — 637 passed, 3 skipped
- `uv run pytest tests/visual tests/test_stylesheet.py` — 166 passed, 3 skipped
  (the four `settings` failures on `main` now pass)
- `uv run ruff check .` / `ruff format --check .` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
